### PR TITLE
docs: fix spec contradictions and add missing details

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,14 +18,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           prompt: |
             Review this pull request. Focus on:
             - Security issues (hardcoded secrets, injection, XSS)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,11 +24,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
+        id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,15 +12,17 @@ All game/tech specs live in `openspec/specs/`:
 |------|----------|
 | `game-mechanics.md` | Map, minions, match tempo, controls, growth system |
 | `heroes.md` | Hero definitions, skills, talent choices |
-| `tech-architecture.md` | Phaser.js, Colyseus, AWS infra, cost |
+| `tech-architecture.md` | Phaser.js, Vite, Colyseus, Terraform, AWS infra, CI/CD |
 | `dev-phases.md` | Phase 1-4 deliverables and goals |
 
 ## Tech Stack
 
-- **Frontend:** Phaser.js (Canvas/WebGL, 2D top-down)
+- **Frontend:** Phaser.js 3.x (Canvas/WebGL, 2D top-down)
+- **Build:** Vite 6.x (dev server + bundler)
 - **Backend (Phase 2+):** Colyseus on Node.js (WebSocket)
-- **Infra:** S3 + CloudFront (static), ECS on EC2 (game server)
-- **Language:** TypeScript
+- **Infra:** Terraform + AWS (S3 + CloudFront static, ECS on EC2 game server)
+- **CI/CD:** GitHub Actions (Claude Code auto-review)
+- **Language:** TypeScript (strict mode)
 
 ## Current Phase
 

--- a/openspec/specs/dev-phases.md
+++ b/openspec/specs/dev-phases.md
@@ -9,7 +9,7 @@
 **Deliverables:**
 - [ ] Map rendering (single lane, bases, tower, bushes)
 - [ ] Character movement (WASD + mouse aim)
-- [ ] Basic attack and skill system (Q, E, R)
+- [ ] Basic attack and skill system (Q, E, R, Space dodge)
 - [ ] 3 heroes playable (BLADE, BOLT, AURA)
 - [ ] Minion auto-spawn and lane walking
 - [ ] XP gain by proximity, level-up talent choices
@@ -17,7 +17,7 @@
 - [ ] Match tempo events (3min buff, 4min boss, 5min sudden death)
 - [ ] Win/lose condition and match reset
 
-**Tech:** Phaser.js only. Deploy to S3 + CloudFront or any static host.
+**Tech:** Phaser.js + Vite + TypeScript. Deploy to S3 + CloudFront or any static host.
 
 ---
 

--- a/openspec/specs/game-mechanics.md
+++ b/openspec/specs/game-mechanics.md
@@ -3,8 +3,9 @@
 ## Map
 
 - **Layout:** Horizontal single-lane. Blue base (left) ↔ Red base (right).
-- **Towers:** 1 per team.
-- **Boss:** 1 at center (spawns at 4:00).
+- **World size:** 3200x720 (px). Camera follows player within this world.
+- **Towers:** 1 per team (positioned between base and lane center).
+- **Boss:** 1 at center of the lane (spawns at 4:00).
 - **Bushes:** 2-3 along lane edges (top/bottom). Break line of sight for ambush plays.
 - **No jungle.** Minimal map cognition load.
 
@@ -49,6 +50,12 @@
 | E | Skill 2 |
 | R | Ultimate (unlocked at Lv3) |
 | Space | Dodge dash (long cooldown) |
+
+## Universal Mechanics
+
+These mechanics are shared by all heroes and are not counted as hero abilities:
+
+- **Dodge Dash (Space):** Short invincibility-frame dash in movement direction. Long cooldown (~10s). Universal escape/engage tool.
 
 ## Visual Style
 

--- a/openspec/specs/heroes.md
+++ b/openspec/specs/heroes.md
@@ -8,6 +8,8 @@ Each hero has exactly 4 abilities:
 3. **Skill 2 (E)** — Utility ability
 4. **Ultimate (R)** — Unlocked at Lv3, enhanced at Lv5
 
+Additionally, all heroes share the universal **Dodge Dash (Space)** mechanic (see game-mechanics.md). This is not counted as a hero ability.
+
 No passives. Simplicity over depth.
 
 ---

--- a/openspec/specs/tech-architecture.md
+++ b/openspec/specs/tech-architecture.md
@@ -2,10 +2,13 @@
 
 ## Frontend
 
-- **Engine:** Phaser.js
+- **Engine:** Phaser.js 3.x
+- **Build Tool:** Vite 6.x (dev server + bundler)
 - **Rendering:** 2D top-down (Canvas / WebGL)
+- **Resolution:** 1280x720 (Scale.FIT + CENTER_BOTH)
+- **Physics:** Arcade Physics (gravity: 0, top-down)
 - **Hosting:** S3 + CloudFront (static files)
-- **Language:** TypeScript
+- **Language:** TypeScript (strict mode)
 
 ## Backend (Phase 2+)
 
@@ -59,3 +62,19 @@ Phase 1 has no backend. Bot-only, runs entirely client-side.
 | S3 + CloudFront | ~$1-3 | Nearly free at low traffic |
 
 Initial monthly cost: **~$20**.
+
+## Infrastructure as Code
+
+- **Tool:** Terraform (>= 1.0)
+- **Local dev:** LocalStack (Docker Compose) for AWS service emulation
+- **Structure:**
+  - `infrastructure/terraform/modules/` — reusable modules (static-hosting)
+  - `infrastructure/terraform/environments/local/` — LocalStack config
+  - `infrastructure/terraform/environments/prod/` — Production AWS config
+- **State:** S3 backend with DynamoDB locking (prod)
+
+## CI/CD
+
+- **Platform:** GitHub Actions
+- **Claude Code Review:** Auto-reviews all non-draft PRs targeting `develop`
+- **Claude Code (@claude):** On-demand via `@claude` mention in PR/issue comments


### PR DESCRIPTION
## Summary
- **tech-architecture.md**: Vite, game resolution (1280x720), Arcade Physics, Terraform/IaC構成、CI/CDセクションを追加
- **game-mechanics.md**: ワールドサイズ (3200x720) を定義、Dodge Dashを「Universal Mechanics」として明確化 (heroes.mdの「4 abilities only」との矛盾解消)
- **heroes.md**: Dodge Dashがヒーロー固有能力に含まれないことを明記、game-mechanics.mdへの相互参照追加
- **dev-phases.md**: Phase 1 Tech欄を実装済みツールチェーン (Phaser + Vite + TS) に更新、Space dodgeをdeliverableに追加
- **CLAUDE.md**: Tech Stackを実際の実装状態に同期

## Test plan
- [ ] 仕様間の相互参照が正しいことを確認
- [ ] 実装 (gameConfig.ts等) と仕様の数値が一致していることを確認