### PR TITLE
fix: workflow permissions to write

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- claude-code-review.yml: `pull-requests: read` → `write` (レビューコメント投稿に必要)
- claude.yml: `pull-requests: read` → `write`, `issues: read` → `write` (@claude 応答に必要)

## Test plan
- [ ] マージ後、次の PR で Claude のレビューコメントが投稿されることを確認