### PR TITLE
test: blackbox E2E tests with read-only test API

### DIFF
--- a/e2e/debug-hero-switch.spec.ts
+++ b/e2e/debug-hero-switch.spec.ts
@@ -1,42 +1,16 @@
 import { test, expect } from '@playwright/test'
-
-/** Helper type for accessing Phaser game from window */
-type GameWindow = {
-  game: {
-    scene: {
-      isActive: (key: string) => boolean
-      getScene: (key: string) => {
-        heroState: {
-          type: string
-          position: { x: number; y: number }
-          hp: number
-          maxHp: number
-        }
-      }
-    }
-  }
-}
+import { type TestWindow, waitForTestApi } from './helpers'
 
 test.describe('Debug Hero Switch', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForFunction(
-      () => {
-        const game = (window as unknown as GameWindow).game
-        return game?.scene?.isActive('GameScene')
-      },
-      { timeout: 10000 }
-    )
-    await page.waitForTimeout(500)
+    await waitForTestApi(page)
   })
 
   test('should start as BLADE by default', async ({ page }) => {
-    const heroType = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return scene.heroState.type
-    })
-
+    const heroType = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getHeroType()
+    )
     expect(heroType).toBe('BLADE')
   })
 
@@ -45,12 +19,8 @@ test.describe('Debug Hero Switch', () => {
     await page.waitForTimeout(200)
 
     const state = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return {
-        type: scene.heroState.type,
-        maxHp: scene.heroState.maxHp,
-      }
+      const api = (window as unknown as TestWindow).__test__
+      return { type: api.getHeroType(), maxHp: api.getHeroHp().max }
     })
 
     expect(state.type).toBe('BOLT')
@@ -62,12 +32,8 @@ test.describe('Debug Hero Switch', () => {
     await page.waitForTimeout(200)
 
     const state = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return {
-        type: scene.heroState.type,
-        maxHp: scene.heroState.maxHp,
-      }
+      const api = (window as unknown as TestWindow).__test__
+      return { type: api.getHeroType(), maxHp: api.getHeroHp().max }
     })
 
     expect(state.type).toBe('AURA')
@@ -75,21 +41,15 @@ test.describe('Debug Hero Switch', () => {
   })
 
   test('should switch back to BLADE when pressing key 1', async ({ page }) => {
-    // First switch to BOLT
     await page.keyboard.press('2')
     await page.waitForTimeout(200)
 
-    // Then switch back to BLADE
     await page.keyboard.press('1')
     await page.waitForTimeout(200)
 
     const state = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return {
-        type: scene.heroState.type,
-        maxHp: scene.heroState.maxHp,
-      }
+      const api = (window as unknown as TestWindow).__test__
+      return { type: api.getHeroType(), maxHp: api.getHeroHp().max }
     })
 
     expect(state.type).toBe('BLADE')
@@ -97,37 +57,26 @@ test.describe('Debug Hero Switch', () => {
   })
 
   test('should reset position to spawn on switch', async ({ page }) => {
-    // Get initial spawn position
-    const spawnPos = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return { ...scene.heroState.position }
-    })
+    const spawnPos = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getHeroPosition()
+    )
 
-    // Move hero away from spawn using WASD
     await page.keyboard.down('d')
     await page.waitForTimeout(500)
     await page.keyboard.up('d')
     await page.waitForTimeout(100)
 
-    // Verify hero moved
-    const movedPos = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return { ...scene.heroState.position }
-    })
+    const movedPos = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getHeroPosition()
+    )
     expect(movedPos.x).toBeGreaterThan(spawnPos.x)
 
-    // Switch type — position should reset
     await page.keyboard.press('2')
     await page.waitForTimeout(200)
 
-    const resetPos = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return { ...scene.heroState.position }
-    })
-
+    const resetPos = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getHeroPosition()
+    )
     expect(resetPos.x).toBeCloseTo(spawnPos.x, 0)
     expect(resetPos.y).toBeCloseTo(spawnPos.y, 0)
   })

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -11,7 +11,9 @@ export type TestApi = {
 
 export type TestWindow = { __test__: TestApi }
 
-// Game constants (must match src/config/gameConfig.ts and src/domain/constants.ts)
+// Game constants — duplicated from src/config/gameConfig.ts and src/domain/constants.ts.
+// E2E tests run in Playwright (Node.js) and cannot import Vite-bundled game modules.
+// If these values change in the source, update here too.
 const GAME_WIDTH = 1280
 const GAME_HEIGHT = 720
 const WORLD_WIDTH = 3200

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,63 @@
+import type { Page, Locator } from '@playwright/test'
+
+export type TestApi = {
+  getHeroType: () => string
+  getHeroPosition: () => { x: number; y: number }
+  getHeroHp: () => { current: number; max: number }
+  getEnemyHp: () => { current: number; max: number }
+  getEnemyPosition: () => { x: number; y: number }
+  getProjectileCount: () => number
+}
+
+export type TestWindow = { __test__: TestApi }
+
+// Game constants (must match src/config/gameConfig.ts and src/domain/constants.ts)
+const GAME_WIDTH = 1280
+const GAME_HEIGHT = 720
+const WORLD_WIDTH = 3200
+const WORLD_HEIGHT = 720
+
+/**
+ * Wait for the E2E test API to become available.
+ */
+export async function waitForTestApi(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => (window as unknown as TestWindow).__test__ !== undefined,
+    { timeout: 10000 }
+  )
+  await page.waitForTimeout(500)
+}
+
+/**
+ * Right-click on the enemy's screen position.
+ *
+ * Computes the enemy's screen coordinates by:
+ * 1. Getting world positions from the test API
+ * 2. Approximating camera scroll (camera follows hero, clamped to world bounds)
+ * 3. Accounting for Phaser Scale.FIT ratio
+ */
+export async function rightClickOnEnemy(page: Page, canvas: Locator): Promise<void> {
+  const positions = await page.evaluate(() => {
+    const t = (window as unknown as TestWindow).__test__
+    return {
+      enemy: t.getEnemyPosition(),
+      hero: t.getHeroPosition(),
+    }
+  })
+
+  const bounds = await canvas.boundingBox()
+  if (!bounds) throw new Error('Canvas not found')
+
+  // Approximate camera scroll (camera follows hero, clamped to world bounds)
+  const cameraScrollX = Math.max(0, Math.min(positions.hero.x - GAME_WIDTH / 2, WORLD_WIDTH - GAME_WIDTH))
+  const cameraScrollY = Math.max(0, Math.min(positions.hero.y - GAME_HEIGHT / 2, WORLD_HEIGHT - GAME_HEIGHT))
+
+  // Scale factor: Phaser Scale.FIT maps logical pixels to actual canvas size
+  const scaleX = bounds.width / GAME_WIDTH
+  const scaleY = bounds.height / GAME_HEIGHT
+
+  const screenX = bounds.x + (positions.enemy.x - cameraScrollX) * scaleX
+  const screenY = bounds.y + (positions.enemy.y - cameraScrollY) * scaleY
+
+  await page.mouse.click(screenX, screenY, { button: 'right' })
+}

--- a/e2e/hp-bar.spec.ts
+++ b/e2e/hp-bar.spec.ts
@@ -1,96 +1,51 @@
 import { test, expect } from '@playwright/test'
-
-/** Helper type for accessing Phaser game from window */
-type GameWindow = {
-  game: {
-    scene: {
-      isActive: (key: string) => boolean
-      getScene: (key: string) => {
-        heroState: {
-          hp: number
-          maxHp: number
-          position: { x: number; y: number }
-          attackTargetId: string | null
-          attackCooldown: number
-        }
-        enemyState: {
-          hp: number
-          maxHp: number
-          position: { x: number; y: number }
-        }
-        heroRenderer: {
-          gameObject: {
-            list: Array<{
-              visible: boolean
-            }>
-          }
-        }
-        enemyRenderer: {
-          gameObject: {
-            list: Array<{
-              visible: boolean
-            }>
-          }
-        }
-      }
-    }
-    canvas: HTMLCanvasElement
-  }
-}
+import { type TestWindow, waitForTestApi, rightClickOnEnemy } from './helpers'
 
 test.describe('HP Bar', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForFunction(
-      () => {
-        const game = (window as unknown as GameWindow).game
-        return game?.scene?.isActive('GameScene')
-      },
-      { timeout: 10000 }
-    )
-    await page.waitForTimeout(500)
+    await waitForTestApi(page)
   })
 
   test('should show HP bar even when hero is at full HP', async ({ page }) => {
-    // Verify hero is at full HP
-    const heroFullHp = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return scene.heroState.hp === scene.heroState.maxHp
-    })
-
-    expect(heroFullHp).toBe(true)
+    const heroHp = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getHeroHp()
+    )
+    expect(heroHp.current).toBe(heroHp.max)
   })
 
   test('should show HP bar after enemy takes damage', async ({ page }) => {
-    // Place hero in range and attack enemy
-    await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
+    // Move hero right until within attack range of the enemy
+    await page.keyboard.down('d')
+    await page.waitForFunction(
+      () => {
+        const t = (window as unknown as TestWindow).__test__
+        const hero = t.getHeroPosition()
+        const enemy = t.getEnemyPosition()
+        const dist = Math.abs(hero.x - enemy.x) + Math.abs(hero.y - enemy.y)
+        return dist < 100
+      },
+      { timeout: 10000 }
+    )
+    await page.keyboard.up('d')
+    await page.waitForTimeout(200)
 
-      const enemyPos = scene.enemyState.position
-      ;(scene as Record<string, unknown>).heroState = {
-        ...scene.heroState,
-        position: { x: enemyPos.x - 80, y: enemyPos.y },
-        attackTargetId: 'enemy-1',
-        attackCooldown: 0,
-      }
-    })
+    // Right-click on enemy using computed screen position
+    const canvas = page.locator('#game-container canvas')
+    await rightClickOnEnemy(page, canvas)
 
-    // Wait for attack to land
-    await page.waitForTimeout(3000)
+    // Wait for enemy HP to decrease
+    await page.waitForFunction(
+      () => {
+        const hp = (window as unknown as TestWindow).__test__.getEnemyHp()
+        return hp.current < hp.max
+      },
+      { timeout: 5000 }
+    )
 
-    // Verify enemy HP decreased
-    const enemyHpResult = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return {
-        hp: scene.enemyState.hp,
-        maxHp: scene.enemyState.maxHp,
-        damaged: scene.enemyState.hp < scene.enemyState.maxHp,
-      }
-    })
-
-    expect(enemyHpResult.damaged).toBe(true)
+    const enemyHp = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getEnemyHp()
+    )
+    expect(enemyHp.current).toBeLessThan(enemyHp.max)
   })
 })

--- a/e2e/projectile-attack.spec.ts
+++ b/e2e/projectile-attack.spec.ts
@@ -1,125 +1,62 @@
 import { test, expect } from '@playwright/test'
-
-/** Helper type for accessing Phaser game from window */
-type GameWindow = {
-  game: {
-    scene: {
-      isActive: (key: string) => boolean
-      getScene: (key: string) => {
-        heroState: {
-          type: string
-          hp: number
-          position: { x: number; y: number }
-          attackTargetId: string | null
-          attackCooldown: number
-          stats: { attackRange: number }
-        }
-        enemyState: {
-          hp: number
-          maxHp: number
-          position: { x: number; y: number }
-        }
-        projectiles: readonly { id: string }[]
-      }
-    }
-  }
-}
+import { type TestWindow, waitForTestApi, rightClickOnEnemy } from './helpers'
 
 test.describe('Projectile Attack', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForFunction(
-      () => {
-        const game = (window as unknown as GameWindow).game
-        return game?.scene?.isActive('GameScene')
-      },
-      { timeout: 10000 }
-    )
-    await page.waitForTimeout(500)
+    await waitForTestApi(page)
   })
 
-  test('should reduce enemy HP when BOLT attacks with projectile', async ({
-    page,
-  }) => {
+  test('should reduce enemy HP when BOLT attacks with projectile', async ({ page }) => {
     // Switch to BOLT (ranged hero)
     await page.keyboard.press('2')
     await page.waitForTimeout(200)
 
-    // Verify switched to BOLT
-    const heroType = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return scene.heroState.type
-    })
-    expect(heroType).toBe('BOLT')
+    expect(
+      await page.evaluate(() => (window as unknown as TestWindow).__test__.getHeroType())
+    ).toBe('BOLT')
 
-    // Get initial enemy HP
-    const initialHp = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return scene.enemyState.hp
-    })
+    const initialHp = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getEnemyHp().current
+    )
 
-    // Place hero within BOLT attack range and set attack target
-    // BOLT: radius=18, attackRange=300
-    await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      const enemyPos = scene.enemyState.position
-      ;(scene as Record<string, unknown>).heroState = {
-        ...scene.heroState,
-        position: { x: enemyPos.x - 150, y: enemyPos.y },
-        attackTargetId: 'enemy-1',
-        attackCooldown: 0,
-      }
-    })
+    // BOLT attackRange=300, initial distance=200 → already in range
+    // Right-click on enemy using computed screen position
+    const canvas = page.locator('#game-container canvas')
+    await rightClickOnEnemy(page, canvas)
 
-    // Wait for projectile to spawn, fly, and hit
-    // BOLT speed=600, distance=150 → travel time ≈ 0.25s
-    // Plus attack cooldown reset (1/1.0 = 1s), allow multiple hits
-    await page.waitForTimeout(4000)
+    // Wait for projectile to fly and hit
+    await page.waitForFunction(
+      (initial) =>
+        (window as unknown as TestWindow).__test__.getEnemyHp().current < initial,
+      initialHp,
+      { timeout: 5000 }
+    )
 
-    // Check enemy HP decreased
-    const finalHp = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return scene.enemyState.hp
-    })
-
+    const finalHp = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getEnemyHp().current
+    )
     expect(finalHp).toBeLessThan(initialHp)
   })
 
-  test('should spawn projectiles when BOLT attacks (not instant damage)', async ({
-    page,
-  }) => {
+  test('should spawn projectiles when BOLT attacks (not instant damage)', async ({ page }) => {
     // Switch to BOLT
     await page.keyboard.press('2')
     await page.waitForTimeout(200)
 
-    // Place hero in range and set attack target with cooldown = 0
-    await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      const enemyPos = scene.enemyState.position
-      ;(scene as Record<string, unknown>).heroState = {
-        ...scene.heroState,
-        position: { x: enemyPos.x - 250, y: enemyPos.y },
-        attackTargetId: 'enemy-1',
-        attackCooldown: 0,
-      }
-    })
+    // Right-click on enemy using computed screen position
+    const canvas = page.locator('#game-container canvas')
+    await rightClickOnEnemy(page, canvas)
 
-    // Wait briefly for attack to fire — projectile should exist in flight
-    // before reaching target (distance 250, speed 600 → ~0.42s flight time)
-    await page.waitForTimeout(200)
+    // Wait briefly — projectile should be in flight before reaching target
+    await page.waitForFunction(
+      () => (window as unknown as TestWindow).__test__.getProjectileCount() >= 1,
+      { timeout: 3000 }
+    )
 
-    const projectileCount = await page.evaluate(() => {
-      const game = (window as unknown as GameWindow).game
-      const scene = game.scene.getScene('GameScene')
-      return scene.projectiles.length
-    })
-
-    // At least one projectile should be in flight
-    expect(projectileCount).toBeGreaterThanOrEqual(1)
+    const count = await page.evaluate(
+      () => (window as unknown as TestWindow).__test__.getProjectileCount()
+    )
+    expect(count).toBeGreaterThanOrEqual(1)
   })
 })

--- a/openspec/changes/archive/2026-02-18-e2e-blackbox/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-18-e2e-blackbox/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-18

--- a/openspec/changes/archive/2026-02-18-e2e-blackbox/design.md
+++ b/openspec/changes/archive/2026-02-18-e2e-blackbox/design.md
@@ -1,0 +1,80 @@
+## Context
+
+現在の E2E テスト (4 ファイル) は `window.game.scene.getScene('GameScene')` 経由で内部 state を直接読み書きしている。
+
+- **書き込み**: `scene.heroState = { ...scene.heroState, position: ..., attackTargetId: ... }` でヒーローの位置・攻撃対象を設定
+- **読み取り**: `scene.enemyState.hp`, `scene.heroState.type`, `scene.projectiles.length` 等
+
+これにより GameScene のリファクタリング (#76) で 12/18 テストが壊れた。現在はゲッター/セッターで互換を保っている。
+
+## Goals / Non-Goals
+
+**Goals:**
+- テスト入力をキーボード/マウスのみに統一（内部 state 書き換え廃止）
+- GameScene のテスト用ゲッター/セッター (heroState, enemyState, projectiles) を削除
+- 検証用の読み取り専用テスト API を dev ビルド限定で提供
+- CI (headless Chromium) で安定動作を維持
+
+**Non-Goals:**
+- `game-launch.spec.ts`, `map-rendering.spec.ts` の変更（既にブラックボックス的）
+- スクリーンショット比較テストの拡充
+- テストケース追加によるカバレッジ拡大
+
+## Decisions
+
+### Decision 1: テスト入力は Playwright のキーボード/マウス API のみ
+
+**選択**: `page.keyboard`, `page.mouse` を使用。内部 state の直接書き換えを廃止。
+
+**理由**: ユーザーが実際に操作する方法でテストすることで、入力ハンドラ → ドメインロジック → レンダリングの統合パスを検証できる。
+
+**代替案**:
+- `page.evaluate()` で state セット → 今と同じ問題を繰り返す
+- Phaser の input event をプログラム的に発火 → Phaser 内部 API への結合度が高い
+
+### Decision 2: 読み取り専用テスト API (`window.__test__`) を提供
+
+**選択**: GameScene の `create()` 時に `window.__test__` オブジェクトを登録。読み取り専用のクエリメソッドを公開。
+
+```typescript
+// dev ビルドのみ
+window.__test__ = {
+  getHeroType: () => string,
+  getHeroPosition: () => { x, y },
+  getHeroHp: () => { current, max },
+  getEnemyHp: () => { current, max },
+  getEnemyPosition: () => { x, y },
+  getProjectileCount: () => number,
+}
+```
+
+**理由**: Canvas ゲームでは DOM がないため、ピクセルから HP 値やヒーロータイプを判定するのは非現実的。最小限の読み取り API は「テスト可観測性」を提供する現実的なアプローチ。
+
+**代替案**:
+- スクリーンショット比較のみ → 数値の正確な検証不可、環境差で flaky になりやすい
+- DOM overlay で HP 表示 → ゲーム仕様を変えてしまう
+- GameScene ゲッターを残す → 内部構造への結合が残り、リファクタリング耐性がない
+
+**ゲッターとの違い**: ゲッターは `HeroState` オブジェクト全体を返すため内部構造に結合する。`__test__` API はプリミティブ値のみ返すため、内部構造が変わっても API の契約は安定する。
+
+### Decision 3: テスト API は独立モジュール `src/test/e2eTestApi.ts` に配置
+
+**選択**: GameScene 本体にテストコードを書かず、別モジュールで `registerTestApi(entityManager, combatManager)` 関数を提供。
+
+**理由**: テスト支援コードをプロダクションコードから分離。GameScene は `import.meta.env.DEV` ガードで呼び出すだけ。
+
+### Decision 4: 攻撃テストのアプローチ変更
+
+**選択**: WASD でヒーローを敵の近くに移動 → 右クリックで攻撃。`waitForFunction` で HP 変化を待つ。
+
+**現状の問題**: 敵は固定位置だが初期位置からの距離があり、移動に時間がかかる。
+
+**対策**: EntityManager の初期配置で敵を近めに配置しているため (200px 離れ)、WASD 移動 + 右クリックで十分到達可能。`waitForFunction` でポーリング的に HP 変化を検知すれば `waitForTimeout` の固定待ちも削減できる。
+
+## Risks / Trade-offs
+
+**[Risk] 攻撃テストの不安定化** → `waitForFunction` で条件ベースの待機を使い、固定 `waitForTimeout` を最小化。Playwright の retry (CI: 2 回) でカバー。
+
+**[Risk] `__test__` API の prod 混入** → `import.meta.env.DEV` ガード + Vite の tree-shaking で prod ビルドから除外される。
+
+**[Trade-off] 完全なブラックボックスではない** → `window.__test__` による読み取りは「グレーボックス」テスト。Canvas ゲームではこれが現実的な最善策。

--- a/openspec/changes/archive/2026-02-18-e2e-blackbox/proposal.md
+++ b/openspec/changes/archive/2026-02-18-e2e-blackbox/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+現在の E2E テストは `window.game.scene.getScene('GameScene')` 経由で内部 state (`heroState`, `enemyState`, `projectiles`) を直接読み書きしている。テスト入力として内部 state を書き換え、検証にも内部 state を読み取るため、リファクタリングのたびに E2E テストが壊れる。#76 で互換ゲッターを追加して対処したが、根本的な改善が必要。
+
+## What Changes
+
+- **入力のブラックボックス化**: テストの操作はキーボード/マウスのみ。内部 state の直接書き換え (`scene.heroState = {...}`) を廃止
+- **読み取り専用テスト API の導入**: `window.__test__` に読み取り専用のゲーム状態クエリを公開。Canvas ゲームではピクセルから数値（HP 等）を判定するのが困難なため、最小限の読み取り API を提供する現実的アプローチを採る
+- **GameScene ゲッターの廃止**: `heroState` setter、`enemyState` getter、`projectiles` getter を GameScene から削除。代わりに `window.__test__` API を使用
+- **4 テストファイルの書き換え**: `melee-attack`, `hp-bar`, `projectile-attack`, `debug-hero-switch`
+
+### Non-goals
+
+- `game-launch.spec.ts` と `map-rendering.spec.ts` は変更しない（既にブラックボックス的）
+- ビジュアルリグレッションテスト（スクリーンショット比較）の拡充は本スコープ外
+- テストカバレッジの拡大は含まない（既存テストの質の向上のみ）
+
+## Capabilities
+
+### New Capabilities
+
+- `e2e-test-api`: dev ビルド限定で `window.__test__` に公開する読み取り専用クエリ API
+
+### Modified Capabilities
+
+（既存の spec レベルの要件変更なし）
+
+## Impact
+
+- `e2e/melee-attack.spec.ts` — 全面書き換え
+- `e2e/hp-bar.spec.ts` — 全面書き換え
+- `e2e/projectile-attack.spec.ts` — 全面書き換え
+- `e2e/debug-hero-switch.spec.ts` — 全面書き換え
+- `src/scenes/GameScene.ts` — ゲッター削除 + テスト API 登録
+- 新規: テスト API モジュール（`src/test/` または `src/scenes/` 配下）

--- a/openspec/changes/archive/2026-02-18-e2e-blackbox/specs/e2e-test-api/spec.md
+++ b/openspec/changes/archive/2026-02-18-e2e-blackbox/specs/e2e-test-api/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: 読み取り専用テスト API の提供
+
+dev ビルド (`import.meta.env.DEV === true`) において、`window.__test__` にゲーム状態を読み取るクエリオブジェクトを公開する。
+API はプリミティブ値のみ返し、内部オブジェクト (`HeroState` 等) を直接公開してはならない (SHALL NOT)。
+prod ビルドでは `window.__test__` が存在してはならない (SHALL NOT)。
+
+#### Scenario: dev ビルドで API が利用可能
+- **WHEN** dev モードでゲームを起動し GameScene がアクティブになる
+- **THEN** `window.__test__` オブジェクトが存在する
+
+#### Scenario: prod ビルドで API が存在しない
+- **WHEN** prod ビルド (`import.meta.env.DEV === false`) でゲームを起動する
+- **THEN** `window.__test__` は `undefined` である
+
+### Requirement: ヒーロー状態の読み取り
+
+`window.__test__` は以下のヒーロー状態クエリを提供する (SHALL):
+- `getHeroType()` → `string` (例: `'BLADE'`, `'BOLT'`, `'AURA'`)
+- `getHeroPosition()` → `{ x: number, y: number }`
+- `getHeroHp()` → `{ current: number, max: number }`
+
+#### Scenario: ヒーロータイプの取得
+- **WHEN** `window.__test__.getHeroType()` を呼び出す
+- **THEN** 現在のヒーロータイプ文字列が返る (例: `'BLADE'`)
+
+#### Scenario: ヒーロー切り替え後のタイプ取得
+- **WHEN** キー `2` を押して BOLT に切り替えた後に `getHeroType()` を呼び出す
+- **THEN** `'BOLT'` が返る
+
+#### Scenario: ヒーロー位置の取得
+- **WHEN** `window.__test__.getHeroPosition()` を呼び出す
+- **THEN** 現在のヒーロー座標 `{ x, y }` が返る
+
+#### Scenario: ヒーロー HP の取得
+- **WHEN** `window.__test__.getHeroHp()` を呼び出す
+- **THEN** `{ current, max }` が返り、`current <= max` かつ `max > 0` である
+
+### Requirement: 敵状態の読み取り
+
+`window.__test__` は以下の敵状態クエリを提供する (SHALL):
+- `getEnemyHp()` → `{ current: number, max: number }`
+- `getEnemyPosition()` → `{ x: number, y: number }`
+
+#### Scenario: 敵 HP の取得
+- **WHEN** `window.__test__.getEnemyHp()` を呼び出す
+- **THEN** `{ current, max }` が返り、初期状態では `current === max` である
+
+#### Scenario: 敵がダメージを受けた後の HP
+- **WHEN** ヒーローが敵を攻撃して HP が減少した後に `getEnemyHp()` を呼び出す
+- **THEN** `current < max` である
+
+### Requirement: 投射物状態の読み取り
+
+`window.__test__` は以下の投射物クエリを提供する (SHALL):
+- `getProjectileCount()` → `number`
+
+#### Scenario: 投射物が存在しない場合
+- **WHEN** 攻撃していない状態で `getProjectileCount()` を呼び出す
+- **THEN** `0` が返る
+
+#### Scenario: BOLT 攻撃中の投射物カウント
+- **WHEN** BOLT が攻撃して投射物が飛行中に `getProjectileCount()` を呼び出す
+- **THEN** `1` 以上の値が返る
+
+### Requirement: E2E テストは内部 state を書き換えない
+
+全ての E2E テストはユーザー入力 (キーボード/マウス) のみでゲーム操作を行う (SHALL)。
+`page.evaluate()` でゲーム内部 state を変更するコードを含んではならない (SHALL NOT)。
+唯一の例外は `window.__test__` API 経由の読み取りである。
+
+#### Scenario: 近接攻撃テスト
+- **WHEN** WASD で敵に接近し、敵を右クリックする
+- **THEN** 敵 HP が減少する（`window.__test__.getEnemyHp()` で検証）
+
+#### Scenario: 投射物攻撃テスト
+- **WHEN** キー `2` で BOLT に切り替え、WASD で敵に接近し、敵を右クリックする
+- **THEN** 投射物が生成され、敵 HP が減少する
+
+### Requirement: GameScene テスト用ゲッターの廃止
+
+GameScene から以下のテスト用プロパティを削除する (SHALL):
+- `get heroState()` / `set heroState()`
+- `get enemyState()`
+- `get projectiles()`
+
+#### Scenario: ゲッター削除後もテスト全 PASS
+- **WHEN** GameScene からゲッター/セッターを削除する
+- **THEN** `window.__test__` API を使用する新しい E2E テストが全て PASS する

--- a/openspec/changes/archive/2026-02-18-e2e-blackbox/tasks.md
+++ b/openspec/changes/archive/2026-02-18-e2e-blackbox/tasks.md
@@ -1,0 +1,22 @@
+## 1. テスト API の実装
+
+- [x] 1.1 `src/test/e2eTestApi.ts` を作成。`registerTestApi(entityManager, combatManager)` 関数で `window.__test__` に読み取り専用クエリ (`getHeroType`, `getHeroPosition`, `getHeroHp`, `getEnemyHp`, `getEnemyPosition`, `getProjectileCount`) を登録
+- [x] 1.2 GameScene.create() で `import.meta.env.DEV` ガード付きで `registerTestApi()` を呼び出す
+- [x] 1.3 テスト API のユニットテストを作成 (各クエリが正しい値を返すことを検証)
+
+## 2. E2E テストの書き換え
+
+- [x] 2.1 `e2e/debug-hero-switch.spec.ts` を書き換え。`scene.heroState.*` → `window.__test__.getHeroType()` / `getHeroPosition()` / `getHeroHp()` に置換
+- [x] 2.2 `e2e/melee-attack.spec.ts` を書き換え。state 直接書き換えを廃止し、WASD 移動 + 右クリック攻撃 + `waitForFunction` で HP 変化を検知
+- [x] 2.3 `e2e/hp-bar.spec.ts` を書き換え。`scene.heroState.hp` / `scene.enemyState.hp` → `window.__test__` API に置換
+- [x] 2.4 `e2e/projectile-attack.spec.ts` を書き換え。BOLT 切り替え + WASD 移動 + 右クリック攻撃。`getProjectileCount()` と `getEnemyHp()` で検証
+
+## 3. GameScene クリーンアップ
+
+- [x] 3.1 GameScene から `heroState` getter/setter、`enemyState` getter、`projectiles` getter を削除
+
+## 4. 検証
+
+- [x] 4.1 `npm run test:unit` — 全 PASS 確認
+- [x] 4.2 `npm run test:e2e` — 全 PASS 確認
+- [x] 4.3 E2E テストで `scene.heroState` / `scene.enemyState` / `scene.projectiles` への直接アクセスがゼロであることを grep で確認

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -19,6 +19,7 @@ import { NetworkBridge } from '@/scenes/NetworkBridge'
 import type { HeroType } from '@/domain/types'
 import { OfflineGameMode } from '@/network/OfflineGameMode'
 import { OnlineGameMode } from '@/network/OnlineGameMode'
+import { registerTestApi } from '@/test/e2eTestApi'
 
 /** Debug: number keys 1-3 switch hero type (remove before release — see Issue) */
 const DEBUG_HERO_KEYS: readonly { key: string; type: HeroType }[] = [
@@ -38,16 +39,6 @@ export class GameScene extends Phaser.Scene {
   private meleeSwing!: MeleeSwingRenderer
   private projectileRenderer!: ProjectileRenderer
   private remoteRenderers = new Map<string, HeroRenderer>()
-
-  /** Expose hero state for E2E test inspection */
-  get heroState() { return this.entityManager.localHero }
-  set heroState(value) { this.entityManager.updateLocalHero(() => value) }
-
-  /** Expose enemy state for E2E test inspection */
-  get enemyState() { return this.entityManager.enemy }
-
-  /** Expose projectiles for E2E test inspection */
-  get projectiles() { return this.combatManager.projectiles }
 
   constructor() {
     super({ key: 'GameScene' })
@@ -78,6 +69,11 @@ export class GameScene extends Phaser.Scene {
     // Debug keys
     for (const { key, type } of DEBUG_HERO_KEYS) {
       this.input.keyboard!.on(`keydown-${key}`, () => this.debugSwitchHero(type))
+    }
+
+    // E2E test API (dev only)
+    if (import.meta.env.DEV) {
+      registerTestApi(this.entityManager, this.combatManager)
     }
 
     // Network

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -72,6 +72,8 @@ export class GameScene extends Phaser.Scene {
     }
 
     // E2E test API (dev only)
+    // Static import is tree-shaken by Vite in production builds
+    // because the only call site is inside this dead-code branch.
     if (import.meta.env.DEV) {
       registerTestApi(this.entityManager, this.combatManager)
     }

--- a/src/test/__tests__/e2eTestApi.test.ts
+++ b/src/test/__tests__/e2eTestApi.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { registerTestApi, unregisterTestApi } from '@/test/e2eTestApi'
+import { EntityManager } from '@/scenes/EntityManager'
+import { CombatManager } from '@/scenes/CombatManager'
+
+describe('e2eTestApi', () => {
+  let em: EntityManager
+  let cm: CombatManager
+
+  beforeEach(() => {
+    em = new EntityManager(
+      { id: 'player-1', type: 'BLADE', team: 'blue', position: { x: 100, y: 200 } },
+      { id: 'enemy-1', type: 'BOLT', team: 'red', position: { x: 500, y: 300 } }
+    )
+    cm = new CombatManager(em)
+    registerTestApi(em, cm)
+  })
+
+  afterEach(() => {
+    unregisterTestApi()
+  })
+
+  it('should register window.__test__', () => {
+    expect(window.__test__).toBeDefined()
+  })
+
+  it('should unregister window.__test__', () => {
+    unregisterTestApi()
+    expect(window.__test__).toBeUndefined()
+  })
+
+  describe('getHeroType', () => {
+    it('should return current hero type', () => {
+      expect(window.__test__!.getHeroType()).toBe('BLADE')
+    })
+
+    it('should reflect hero type changes', () => {
+      em.resetLocalHero({ id: 'player-1', type: 'BOLT', team: 'blue', position: { x: 0, y: 0 } })
+      expect(window.__test__!.getHeroType()).toBe('BOLT')
+    })
+  })
+
+  describe('getHeroPosition', () => {
+    it('should return current hero position', () => {
+      const pos = window.__test__!.getHeroPosition()
+      expect(pos.x).toBe(100)
+      expect(pos.y).toBe(200)
+    })
+
+    it('should reflect position changes', () => {
+      em.updateLocalHero((h) => ({ ...h, position: { x: 300, y: 400 } }))
+      const pos = window.__test__!.getHeroPosition()
+      expect(pos.x).toBe(300)
+      expect(pos.y).toBe(400)
+    })
+  })
+
+  describe('getHeroHp', () => {
+    it('should return current and max HP', () => {
+      const hp = window.__test__!.getHeroHp()
+      expect(hp.current).toBe(hp.max)
+      expect(hp.max).toBeGreaterThan(0)
+    })
+  })
+
+  describe('getEnemyHp', () => {
+    it('should return current and max HP', () => {
+      const hp = window.__test__!.getEnemyHp()
+      expect(hp.current).toBe(hp.max)
+      expect(hp.max).toBeGreaterThan(0)
+    })
+
+    it('should reflect damage', () => {
+      em.updateEnemy((e) => ({ ...e, hp: e.hp - 50 }))
+      const hp = window.__test__!.getEnemyHp()
+      expect(hp.current).toBe(hp.max - 50)
+    })
+  })
+
+  describe('getEnemyPosition', () => {
+    it('should return enemy position', () => {
+      const pos = window.__test__!.getEnemyPosition()
+      expect(pos.x).toBe(500)
+      expect(pos.y).toBe(300)
+    })
+  })
+
+  describe('getProjectileCount', () => {
+    it('should return 0 when no projectiles', () => {
+      expect(window.__test__!.getProjectileCount()).toBe(0)
+    })
+  })
+})

--- a/src/test/e2eTestApi.ts
+++ b/src/test/e2eTestApi.ts
@@ -1,0 +1,47 @@
+import type { EntityManager } from '@/scenes/EntityManager'
+import type { CombatManager } from '@/scenes/CombatManager'
+
+export interface E2ETestApi {
+  getHeroType: () => string
+  getHeroPosition: () => { x: number; y: number }
+  getHeroHp: () => { current: number; max: number }
+  getEnemyHp: () => { current: number; max: number }
+  getEnemyPosition: () => { x: number; y: number }
+  getProjectileCount: () => number
+}
+
+declare global {
+  interface Window {
+    __test__?: E2ETestApi
+  }
+}
+
+export function registerTestApi(
+  entityManager: EntityManager,
+  combatManager: CombatManager
+): void {
+  window.__test__ = {
+    getHeroType: () => entityManager.localHero.type,
+    getHeroPosition: () => {
+      const { x, y } = entityManager.localHero.position
+      return { x, y }
+    },
+    getHeroHp: () => ({
+      current: entityManager.localHero.hp,
+      max: entityManager.localHero.maxHp,
+    }),
+    getEnemyHp: () => ({
+      current: entityManager.enemy.hp,
+      max: entityManager.enemy.maxHp,
+    }),
+    getEnemyPosition: () => {
+      const { x, y } = entityManager.enemy.position
+      return { x, y }
+    },
+    getProjectileCount: () => combatManager.projectiles.length,
+  }
+}
+
+export function unregisterTestApi(): void {
+  delete window.__test__
+}


### PR DESCRIPTION
## Summary

- E2E テストの内部 state 直接アクセスを廃止し、ブラックボックステストに移行
- `window.__test__` 読み取り専用 API を導入 (DEV ビルド限定)
- キーボード/マウス操作のみでテスト入力を行うよう全面書き換え
- GameScene から `heroState`, `enemyState`, `projectiles` ゲッターを削除

### Changes
- **NEW** `src/test/e2eTestApi.ts` — 読み取り専用テスト API (`getHeroType`, `getHeroPosition`, `getHeroHp`, `getEnemyHp`, `getEnemyPosition`, `getProjectileCount`)
- **NEW** `e2e/helpers.ts` — 共有ヘルパー (`waitForTestApi`, `rightClickOnEnemy` — カメラ scroll + Scale.FIT 対応)
- **NEW** `src/test/__tests__/e2eTestApi.test.ts` — ユニットテスト 11件
- **REWRITE** 4 E2E テストファイル (debug-hero-switch, melee-attack, hp-bar, projectile-attack)
- **CLEANUP** GameScene から互換ゲッター削除

### Key decisions
- 条件ベース待機 (`waitForFunction`) を採用 — headless Chromium の FPS 変動に対応
- 敵クリック座標をカメラ位置 + Scale.FIT 比率から動的計算

## Test plan
- [x] `npm run test:unit` — 228/228 PASS
- [x] `npm run test:e2e` — 18/18 PASS
- [x] `grep scene.(heroState|enemyState|projectiles) e2e/` — 0 matches

Closes #78