### PR TITLE
fix: replace gameStart broadcast with state flag (race condition)

### DIFF
--- a/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-19

--- a/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/design.md
+++ b/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/design.md
@@ -1,0 +1,53 @@
+## Context
+
+現在の「ゲーム開始通知」はサーバーが `broadcast('gameStart')` メッセージを `onJoin` 内で即時送信する方式。Colyseus の `joinOrCreate()` が解決した後にクライアントが `room.onMessage('gameStart', ...)` を登録するため、2人目のプレイヤーはメッセージを受け取れない。
+
+以前は `onStateChange` で players 数を監視する方式だったが、lobby PR レビュー時に「明示的なメッセージの方がシンプル」として `onMessage` に変更されたことでデグレした。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 2人目のプレイヤーが確実にゲーム開始を検知できるようにする
+- リスナー登録タイミングに依存しない、構造的にレースコンディションが起きない設計にする
+- 既存のオフラインモードに影響を与えない
+
+**Non-Goals:**
+- マッチメイキングや Room 管理の変更
+- 再接続・リジョイン機能
+- 3人以上の対応
+
+## Decisions
+
+### Decision 1: state フラグ方式を採用（メッセージ方式を廃止）
+
+**選択**: `GameRoomState` スキーマに `gameStarted: boolean` フラグを追加し、state 同期で通知する
+
+**理由**: Colyseus の state 同期は `joinOrCreate()` 解決後に必ずクライアントに届く。schema のバイナリ差分同期はメッセージと異なり、接続確立後の全 state が保証される。これにより、リスナー登録タイミングのレースコンディションが**構造的に不可能**になる。
+
+**却下した代替案**:
+- **サーバー側遅延 (`setTimeout`)**: タイミング依存で脆弱。ネットワーク遅延が大きい場合に再発する
+- **クライアント側で `joinOrCreate` 前にリスナー登録**: Colyseus の API 上不可能（Room オブジェクトが `joinOrCreate` の戻り値）
+- **`onMessage` + 再送リクエスト**: 複雑度が増す上、再送タイミングにも同様のレースがある
+
+### Decision 2: `onStateChange` で `gameStarted` を監視
+
+**選択**: `LobbyScene` で `room.onStateChange` を使い `gameStarted === true` を検知する
+
+**理由**:
+- `onStateChange` は state が変更されるたびに発火し、初回の state sync も含む
+- `joinOrCreate` 解決後に即座に登録すれば、既に `gameStarted === true` の場合も次の state patch で検知可能
+- 既存の `OnlineGameMode.onSceneCreate()` で同様のパターンが使われており、実績がある
+
+### Decision 3: デグレ防止としてサーバーテストを強化
+
+**選択**: サーバーユニットテストで「broadcast は呼ばれない、state.gameStarted が true になる」ことを明示的に検証する
+
+**理由**: 前回のデグレは PR レビューで方式を変更した際に発生した。`broadcast('gameStart')` が呼ばれないことをテストで保証することで、将来のリファクタリングで同じ問題が再発するのを防ぐ。
+
+## Risks / Trade-offs
+
+**[Risk] `onStateChange` が `gameStarted` 変更を含む patch を受信するまでの遅延** → Colyseus の state patch は次のサーバーフレーム（デフォルト ~50ms）で送信されるため、体感上の遅延は無視できる。現行の `broadcast` も同程度の遅延がある。
+
+**[Risk] `gameStarted` フラグのリセット漏れ** → 現行の Room ライフサイクルでは Room が `onCreate` で毎回新規作成されるため、リセット不要。将来 Room 再利用を導入する場合は `onDispose` でのリセットが必要。
+
+**[Trade-off] スキーマサイズの微増** → `boolean` 1フィールド（1バイト）の追加。影響は無視できる。

--- a/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/proposal.md
+++ b/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+2人目のプレイヤーがオンライン対戦に参加すると「Waiting for opponent...」のまま固まり、ゲームが開始されない。`broadcast('gameStart')` が `onJoin` 内で即時発火するため、クライアントがリスナーを登録する前にメッセージが配信されてしまうレースコンディションが原因。lobby 実装時の PR レビューで `onStateChange` ポーリングから `onMessage` に変更した際にデグレした。
+
+## What Changes
+
+- サーバー: `GameRoomState` スキーマに `gameStarted: boolean` フラグを追加。`broadcast('gameStart')` を廃止し、state フラグのセットに置換
+- クライアント: `room.onMessage('gameStart')` を廃止し、`room.onStateChange` で `gameStarted` フラグを監視する方式に変更
+- テスト: サーバーユニットテストで `gameStarted` フラグの検証を追加。E2E テスト（オンラインモード）でレースコンディション再発防止を検証
+
+## Non-goals
+
+- マッチメイキングロジックの変更（Room 検索・作成は現行のまま）
+- 3人以上対戦の対応
+- 再接続・リジョイン機能
+
+## Capabilities
+
+### New Capabilities
+（なし）
+
+### Modified Capabilities
+- `online-multiplayer`: 「ゲーム開始通知」の仕組みをメッセージベースからステートベースに変更。クライアントの接続・リスナー登録タイミングに依存しないロバストな通知方式にする
+
+## Impact
+
+- `server/src/schema/GameRoomState.ts` — `gameStarted` フィールド追加
+- `server/src/rooms/GameRoom.ts` — `broadcast('gameStart')` → `this.state.gameStarted = true`
+- `server/src/__tests__/GameRoom.test.ts` — テスト更新
+- `src/scenes/LobbyScene.ts` — `onMessage` → `onStateChange` 監視
+- `openspec/specs/online-multiplayer/spec.md` — ゲーム開始通知 Requirement の更新

--- a/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/specs/online-multiplayer/spec.md
+++ b/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/specs/online-multiplayer/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: ゲーム開始通知
+GameRoom は全プレイヤーが揃った時点で `GameRoomState.gameStarted` フラグを `true` に設定しなければならない（SHALL）。ゲーム開始の通知にはメッセージブロードキャスト（`broadcast('gameStart')`）を使用してはならない（SHALL NOT）。クライアントは `room.onStateChange` で `gameStarted` フラグを監視し、`true` になった時点でゲーム開始処理を行わなければならない（SHALL）。
+
+#### Scenario: 2人揃った時に gameStarted フラグが true になる
+- **WHEN** 2人目のプレイヤーが GameRoom に参加する
+- **THEN** `GameRoomState.gameStarted` が `true` に設定される
+- **THEN** `broadcast('gameStart')` は呼び出されない
+
+#### Scenario: 1人だけの場合は gameStarted が false のまま
+- **WHEN** 1人目のプレイヤーが GameRoom に参加する
+- **THEN** `GameRoomState.gameStarted` は `false` のままである
+
+#### Scenario: 2人目のクライアントが gameStarted を検知する
+- **WHEN** 2人目のプレイヤーの `joinOrCreate` が解決し、`room.onStateChange` を登録する
+- **THEN** 次の state patch で `gameStarted === true` を検知し、ゲーム開始処理が実行される
+
+#### Scenario: 1人目のクライアントも gameStarted を検知する
+- **WHEN** 1人目のプレイヤーが待機中に `gameStarted` が `true` に変わる
+- **THEN** `onStateChange` コールバックが発火し、ゲーム開始処理が実行される
+
+## ADDED Requirements
+
+### Requirement: GameRoomState の gameStarted スキーマフィールド
+`GameRoomState` は `gameStarted: boolean` フィールドを Colyseus の `@type('boolean')` デコレータ付きで持たなければならない（SHALL）。初期値は `false` でなければならない（SHALL）。
+
+#### Scenario: Room 作成時の初期状態
+- **WHEN** GameRoom が `onCreate` で初期化される
+- **THEN** `GameRoomState.gameStarted` は `false` である
+
+#### Scenario: スキーマフィールドがバイナリ同期される
+- **WHEN** サーバーが `gameStarted` を `true` に設定する
+- **THEN** Colyseus のバイナリ差分同期により、全接続中クライアントに変更が伝播される

--- a/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/tasks.md
+++ b/openspec/changes/archive/2026-02-19-fix-gamestart-race-condition/tasks.md
@@ -1,0 +1,23 @@
+## 1. サーバー側: GameRoomState スキーマ変更
+
+- [x] 1.1 `GameRoomState` に `@type('boolean') gameStarted = false` フィールドを追加 (`server/src/schema/GameRoomState.ts`)
+- [x] 1.2 `GameRoom.onJoin` で `broadcast('gameStart')` を `this.state.gameStarted = true` に置換 (`server/src/rooms/GameRoom.ts`)
+
+## 2. サーバーテスト: デグレ防止
+
+- [x] 2.1 既存テストを更新: 2人参加時に `state.gameStarted === true` を検証 (`server/src/__tests__/GameRoom.test.ts`)
+- [x] 2.2 1人参加時に `state.gameStarted === false` のままであることを検証
+- [x] 2.3 `broadcast('gameStart')` が呼び出されないことを明示的に検証（`room.broadcast` のモックで確認）
+
+## 3. クライアント側: LobbyScene 変更
+
+- [x] 3.1 `watchForGameReady` を `room.onMessage('gameStart')` から `room.onStateChange` + `gameStarted` フラグ監視に変更 (`src/scenes/LobbyScene.ts`)
+- [x] 3.2 `onStateChange` で `gameStarted === true` を検知したら `onGameStart()` を呼び出す
+- [x] 3.3 ゲーム開始後に重複呼び出しを防ぐガード（`lobbyState` チェック）が機能することを確認
+
+## 4. 検証
+
+- [x] 4.1 サーバーユニットテスト全パス (`cd server && npm test`)
+- [x] 4.2 クライアント TypeScript 型チェック (`npx tsc --noEmit`)
+- [x] 4.3 既存ユニットテスト全パス (`npm run test:unit`)
+- [x] 4.4 E2E テスト全パス (`npm run test:e2e`)

--- a/openspec/specs/online-multiplayer/spec.md
+++ b/openspec/specs/online-multiplayer/spec.md
@@ -1,13 +1,33 @@
 ### Requirement: ゲーム開始通知
-GameRoom は全プレイヤーが揃った時点で `gameStart` メッセージを全クライアントにブロードキャストしなければならない（SHALL）。
+GameRoom は全プレイヤーが揃った時点で `GameRoomState.gameStarted` フラグを `true` に設定しなければならない（SHALL）。ゲーム開始の通知にはメッセージブロードキャスト（`broadcast('gameStart')`）を使用してはならない（SHALL NOT）。クライアントは `room.onStateChange` で `gameStarted` フラグを監視し、`true` になった時点でゲーム開始処理を行わなければならない（SHALL）。
 
-#### Scenario: 2人揃った時にゲーム開始を通知する
+#### Scenario: 2人揃った時に gameStarted フラグが true になる
 - **WHEN** 2人目のプレイヤーが GameRoom に参加する
-- **THEN** サーバーが全クライアントに `gameStart` メッセージをブロードキャストする
+- **THEN** `GameRoomState.gameStarted` が `true` に設定される
+- **THEN** `broadcast('gameStart')` は呼び出されない
 
-#### Scenario: 1人だけの場合はゲーム開始しない
+#### Scenario: 1人だけの場合は gameStarted が false のまま
 - **WHEN** 1人目のプレイヤーが GameRoom に参加する
-- **THEN** `gameStart` メッセージはブロードキャストされない
+- **THEN** `GameRoomState.gameStarted` は `false` のままである
+
+#### Scenario: 2人目のクライアントが gameStarted を検知する
+- **WHEN** 2人目のプレイヤーの `joinOrCreate` が解決し、`room.onStateChange` を登録する
+- **THEN** 次の state patch で `gameStarted === true` を検知し、ゲーム開始処理が実行される
+
+#### Scenario: 1人目のクライアントも gameStarted を検知する
+- **WHEN** 1人目のプレイヤーが待機中に `gameStarted` が `true` に変わる
+- **THEN** `onStateChange` コールバックが発火し、ゲーム開始処理が実行される
+
+### Requirement: GameRoomState の gameStarted スキーマフィールド
+`GameRoomState` は `gameStarted: boolean` フィールドを Colyseus の `@type('boolean')` デコレータ付きで持たなければならない（SHALL）。初期値は `false` でなければならない（SHALL）。
+
+#### Scenario: Room 作成時の初期状態
+- **WHEN** GameRoom が `onCreate` で初期化される
+- **THEN** `GameRoomState.gameStarted` は `false` である
+
+#### Scenario: スキーマフィールドがバイナリ同期される
+- **WHEN** サーバーが `gameStarted` を `true` に設定する
+- **THEN** Colyseus のバイナリ差分同期により、全接続中クライアントに変更が伝播される
 
 ### Requirement: Colyseus サーバーセットアップ
 `server/` ディレクトリに Colyseus ゲームサーバーを配置しなければならない（SHALL）。独立した `package.json` と `tsconfig.json` を持ち、`npm run dev:server` でローカル起動できなければならない（SHALL）。WebSocket エンドポイントをポート 2567（Colyseus デフォルト）で待ち受けなければならない（SHALL）。

--- a/server/src/__tests__/GameRoom.test.ts
+++ b/server/src/__tests__/GameRoom.test.ts
@@ -99,6 +99,9 @@ describe('Team assignment pattern', () => {
 })
 
 describe('gameStart state flag logic', () => {
+  // NOTE: createMockRoom mirrors GameRoom.onJoin logic. If GameRoom.onJoin changes,
+  // this mock must be updated in sync. Ideally use @colyseus/testing for integration
+  // tests that exercise the real class. See Issue #91 for race condition context.
   function createMockRoom() {
     const state = new GameRoomState()
     const broadcasts: { type: string }[] = []

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -86,7 +86,7 @@ export class GameRoom extends Room<GameRoomState> {
     this.state.players.set(client.sessionId, player)
 
     if (this.state.players.size === this.maxClients) {
-      this.broadcast('gameStart')
+      this.state.gameStarted = true
     }
   }
 

--- a/server/src/schema/GameRoomState.ts
+++ b/server/src/schema/GameRoomState.ts
@@ -8,4 +8,7 @@ import { PlayerSchema } from './PlayerSchema.js'
 export class GameRoomState extends Schema {
   @type({ map: PlayerSchema })
   players = new MapSchema<PlayerSchema>()
+
+  @type('boolean')
+  gameStarted = false
 }

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -158,9 +158,10 @@ export class LobbyScene extends Phaser.Scene {
     // Use state change instead of message to avoid race condition:
     // broadcast('gameStart') can fire before client registers onMessage listener.
     // State sync is guaranteed to arrive after joinOrCreate resolves.
-    room.onStateChange((state) => {
+    const unsubscribe = room.onStateChange((state) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if ((state as any).gameStarted === true) {
+        unsubscribe()
         this.onGameStart()
       }
     })

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -155,7 +155,15 @@ export class LobbyScene extends Phaser.Scene {
   }
 
   private watchForGameReady(room: Room): void {
-    room.onMessage('gameStart', () => this.onGameStart())
+    // Use state change instead of message to avoid race condition:
+    // broadcast('gameStart') can fire before client registers onMessage listener.
+    // State sync is guaranteed to arrive after joinOrCreate resolves.
+    room.onStateChange((state) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((state as any).gameStarted === true) {
+        this.onGameStart()
+      }
+    })
   }
 
   private onGameStart(): void {


### PR DESCRIPTION
## Summary
- Replace `broadcast('gameStart')` with `GameRoomState.gameStarted` boolean flag
- Client monitors `room.onStateChange` instead of `room.onMessage('gameStart')`
- State sync is guaranteed after `joinOrCreate` resolves, making the race condition structurally impossible
- Add regression test: `broadcast('gameStart')` must never be called

Closes #91

## Test Plan
- [x] Server unit tests pass (31 tests, including 4 new gameStarted flag tests)
- [x] Client TypeScript type check clean
- [x] Client unit tests pass (265 tests)
- [x] E2E tests pass (22 tests)
- [ ] Manual test: start Colyseus server + 2 browser tabs → both enter game

🤖 Generated with [Claude Code](https://claude.com/claude-code)