### PR TITLE
fix: LobbyScene onStateChange unsubscribe TypeError

### DIFF
--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -158,13 +158,16 @@ export class LobbyScene extends Phaser.Scene {
     // Use state change instead of message to avoid race condition:
     // broadcast('gameStart') can fire before client registers onMessage listener.
     // State sync is guaranteed to arrive after joinOrCreate resolves.
-    const unsubscribe = room.onStateChange((state) => {
+    // Colyseus 0.16: onStateChange is an EventEmitter with .once()/.remove(),
+    // NOT a function that returns an unsubscribe callback.
+    const cb = (state: unknown): void => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if ((state as any).gameStarted === true) {
-        unsubscribe()
+        room.onStateChange.remove(cb)
         this.onGameStart()
       }
-    })
+    }
+    room.onStateChange(cb)
   }
 
   private onGameStart(): void {


### PR DESCRIPTION
## Summary
- Colyseus 0.16 の `room.onStateChange` は `createSignal` ベースの EventEmitter であり、`onStateChange(cb)` の戻り値は関数ではなく EventEmitter
- `unsubscribe()` 呼び出しが `TypeError: unsubscribe is not a function` になっていた
- `room.onStateChange.remove(cb)` で正しく解除するように修正

## Test Plan
- [x] TypeScript 型チェック通過
- [ ] 手動確認: オンラインモードで lobby → gameStart 遷移時にエラーが出ないこと

Closes #93