### PR TITLE
fix: resolve server tsconfig rootDir error for shared types

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=builder /app/server/dist/ ./dist/
 ENV PORT=2567
 EXPOSE 2567
 
-CMD ["node", "dist/src/index.js"]
+CMD ["node", "dist/server/src/index.js"]

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev:server": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/server/src/index.js",
     "test": "vitest run"
   },
   "engines": {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -15,7 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "outDir": "./dist",
-    "rootDir": ".",
+    "rootDir": "..",
     "declaration": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": false,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -19,7 +19,6 @@
     "declaration": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": false,
-    "baseUrl": ".",
     "paths": {
       "@shared/*": ["../shared/*"]
     }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,5 +1,3 @@
-import type { StatBlock } from '@/domain/entities/StatBlock'
-
 export interface Position {
   readonly x: number
   readonly y: number
@@ -24,6 +22,16 @@ export interface CombatEntityState extends EntityState {
   readonly maxHp: number
   readonly dead: boolean
   readonly radius: number
+}
+
+/** Combat stats shared by base values, growth rates, and effective values */
+export interface StatBlock {
+  readonly maxHp: number
+  readonly speed: number
+  readonly attackDamage: number
+  readonly attackRange: number
+  /** Attacks per second */
+  readonly attackSpeed: number
 }
 
 /** Common state for entities that can perform attacks (hero, tower, minion, boss) */

--- a/src/domain/entities/StatBlock.ts
+++ b/src/domain/entities/StatBlock.ts
@@ -1,9 +1,1 @@
-/** Combat stats shared by base values, growth rates, and effective values */
-export interface StatBlock {
-  readonly maxHp: number
-  readonly speed: number
-  readonly attackDamage: number
-  readonly attackRange: number
-  /** Attacks per second */
-  readonly attackSpeed: number
-}
+export type { StatBlock } from '@shared/types'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "types": ["vitest/globals"],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@shared/*": ["./shared/*"]


### PR DESCRIPTION
## Summary
- `server/tsconfig.json` の `rootDir` を `"."` → `".."` に変更し、`shared/` ディレクトリが範囲内に入るようにした
- `StatBlock` を `shared/types.ts` に直接定義し、`shared/` → `src/` の循環的パス依存を解消
- `src/domain/entities/StatBlock.ts` は `@shared/types` から re-export（後方互換）

## Test Plan
- [x] `npx tsc --noEmit` (server) — エラーなし
- [x] `npx tsc --noEmit` (frontend) — 新規エラーなし
- [ ] CI テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)