### PR TITLE
fix: mutual combat and facing sync in online mode

### DIFF
--- a/server/src/__tests__/ServerCombatManager.test.ts
+++ b/server/src/__tests__/ServerCombatManager.test.ts
@@ -241,6 +241,32 @@ describe('ServerCombatManager', () => {
       expect(attacker.attackTargetId).toBe('')
     })
 
+    it('should allow both heroes to deal damage when attacking each other', () => {
+      const heroA = createHero('heroA', {
+        x: 100, y: 100, team: 'blue', radius: 22,
+        attackRange: 60, attackDamage: 60, attackSpeed: 0.8, attackCooldown: 0,
+        heroType: 'BLADE',
+      })
+      const heroB = createHero('heroB', {
+        x: 160, y: 100, team: 'red', radius: 22,
+        attackRange: 60, attackDamage: 60, attackSpeed: 0.8, attackCooldown: 0,
+        heroType: 'BLADE',
+      })
+      heroes.set('heroA', heroA)
+      heroes.set('heroB', heroB)
+
+      const inputA = createInput({ attackTargetId: 'heroB' })
+      const inputB = createInput({ attackTargetId: 'heroA' })
+
+      // Simulate game loop: process both heroes in sequence (same tick)
+      processHeroCombat(heroA, 'heroA', inputA, heroes, towers, projectiles, ProjectileSchema, 0.016)
+      processHeroCombat(heroB, 'heroB', inputB, heroes, towers, projectiles, ProjectileSchema, 0.016)
+
+      // Both heroes should have taken damage
+      expect(heroA.hp).toBe(590) // 650 - 60 from heroB
+      expect(heroB.hp).toBe(590) // 650 - 60 from heroA
+    })
+
     it('should attack tower targets', () => {
       const attacker = createHero('attacker', {
         x: 100, y: 100, team: 'blue', radius: 22,

--- a/server/src/game/ServerMovementSystem.ts
+++ b/server/src/game/ServerMovementSystem.ts
@@ -14,6 +14,9 @@ export function processMovement(
   if (hero.dead) return
   if (!input) return
 
+  // Always apply facing from input (attack facing must sync even when stationary)
+  hero.facing = input.facing
+
   const { moveDir } = input
 
   if (moveDir.x === 0 && moveDir.y === 0) return
@@ -27,9 +30,6 @@ export function processMovement(
 
   hero.x = clamp(hero.x + nx * hero.speed * deltaTime, 0, WORLD_WIDTH)
   hero.y = clamp(hero.y + ny * hero.speed * deltaTime, 0, WORLD_HEIGHT)
-
-  // Apply facing from input
-  hero.facing = input.facing
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -180,12 +180,12 @@ export class LobbyScene extends Phaser.Scene {
       if (!room) return
       const gameMode: GameMode = new OnlineGameMode({ room })
 
-      // Read local player's team and position from server state
+      // Read local player's team and position from server state (heroes map, not players)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const localPlayer = (room.state as any)?.players?.get(room.sessionId)
-      const localTeam: Team | undefined = localPlayer?.team
-      const localPosition: Position | undefined = localPlayer
-        ? { x: localPlayer.x as number, y: localPlayer.y as number }
+      const localHero = (room.state as any)?.heroes?.get(room.sessionId)
+      const localTeam: Team | undefined = localHero?.team
+      const localPosition: Position | undefined = localHero
+        ? { x: localHero.x as number, y: localHero.y as number }
         : undefined
 
       this.scene.start('GameScene', { gameMode, localTeam, localPosition })


### PR DESCRIPTION
## Summary
- Fix `LobbyScene` reading non-existent `players` map instead of `heroes`, causing red team to always get `localTeam=undefined` (defaults to blue). This made `getEnemiesOf()` return allies, so server rejected same-team attacks.
- Move `hero.facing` assignment before `moveDir` early return in `ServerMovementSystem` so stationary attackers' facing syncs to all clients.
- Add mutual combat test confirming both heroes deal damage simultaneously.

Closes #104

## Test plan
- [x] Server unit tests pass (mutual combat test added)
- [x] Manual test: both players deal damage in online mode
- [x] Manual test: attacker facing rotates when target moves (both perspectives)