### PR TITLE
fix: connect combat visual feedback to online mode

### DIFF
--- a/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-22

--- a/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/design.md
+++ b/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/design.md
@@ -1,0 +1,51 @@
+## Context
+
+サーバー権威モード移行後、オンラインモードの `update()` ループでは `updateOnlineInput()` → `sendInput()` のパスのみ通る。オフラインモードが `processAttack()` の戻り値（`damageEvents`, `meleeSwings`）からエフェクトをトリガーしていたのに対し、オンラインではサーバー state sync 経由で状態が更新されるだけで、**エフェクトトリガーのフックが未接続**。
+
+既存の仕組み:
+- `HeroRenderer.flash()` / `TowerRenderer.flash()` — 白点滅（既存 API、呼ぶだけ）
+- `MeleeSwingRenderer.play(params)` — 円弧エフェクト（既存 API）
+- `HeroRenderer.sync(state)` — `setVisible(!dead)` で死亡非表示（毎フレーム呼ばれている）
+- `MovementPredictor.setPosition()` / `InputBuffer.clear()` — リセット API（既存）
+
+## Goals / Non-Goals
+
+**Goals:**
+- HP 減少時にダメージフラッシュが両プレイヤーの画面で表示される
+- ローカルプレイヤーの近接攻撃時にメレースイングが表示される
+- 死亡→リスポーン時の MovementPredictor/InputBuffer リセットで予測ズレを防止
+
+**Non-Goals:**
+- Entity Interpolation / ネットワークスムージング（#100）
+- リモートプレイヤーのメレースイング表示（サーバーが攻撃イベントを通知しないため。将来課題）
+- 新エフェクトの追加
+
+## Decisions
+
+### 1. HP 差分検知でダメージフラッシュ
+
+`handleServerHeroUpdate` / `handleServerTowerUpdate` で更新前の HP を取得し、`state.hp < prevHp` なら `flash()` を呼ぶ。
+
+**理由:** サーバーはダメージイベントを個別に送信しない（state sync のみ）。HP 差分が最もシンプルで確実な検知方法。
+
+**代替案:** サーバーからダメージイベントメッセージを送信する → 追加のメッセージ型定義 + サーバー変更が必要。オーバーキル。
+
+### 2. メレースイングは楽観的に再生（ローカルのみ）
+
+`updateOnlineInput` 内で `attackTargetId` がセットされており、かつクールダウンが経過していると推定されるタイミングでメレースイングを再生する。ただし、クライアントには正確なクールダウン情報がないため、**サーバーの `attackCooldown` をスキーマ経由で同期してクライアントで判定する**。
+
+**簡易アプローチ:** サーバーの `attackCooldown` の変化を監視し、`attackCooldown` が 0 にリセット→ 正値にジャンプ（= 攻撃発動）を検知してメレースイングを再生する。これはローカル・リモート両方で動作する。
+
+**理由:** `attackCooldown` は既に `HeroSchema` の `float32` フィールドとして存在し、Colyseus で自動同期される。クライアント側で新しいリスナーを追加するだけで済む。
+
+### 3. 死亡/リスポーン時の予測リセット
+
+`handleServerHeroUpdate` で `dead` が `false → true` に遷移した時、`InputBuffer.clear()` + `MovementPredictor.setPosition(state.x, state.y)` を呼ぶ。リスポーン（`true → false`）時も同様にリセット。
+
+**理由:** 死亡中も入力バッファが溜まるとリスポーン後に予測位置が大きくズレる。
+
+## Risks / Trade-offs
+
+- **[HP 差分が複数ヒットで 1 フラッシュになる]** → 60Hz tick で同一フレーム内の複数ダメージは稀。許容範囲。
+- **[メレースイングのタイミングが若干ずれる]** → `attackCooldown` 変化検知方式なので、サーバーの攻撃タイミングに追従する。楽観的再生よりも正確。
+- **[リモートプレイヤーのメレースイングも表示される]** → `attackCooldown` 変化は全ヒーローで検知できるため、リモートプレイヤーのスイングも表示可能。ただし BOLT（遠距離）にはスイングを出さないよう `projectileSpeed === 0` の判定が必要。

--- a/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/proposal.md
+++ b/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+サーバー権威モード（#98）移行後、オンラインモードの戦闘で**全ての視覚フィードバックが欠落**している。HP減少・死亡判定はサーバーで正しく処理されるが、クライアント側でダメージフラッシュ・メレースイング・死亡非表示が一切表示されない。オフラインモードでは `processAttack()` の戻り値から直接エフェクトをトリガーしているが、オンラインモードではこのパスが存在しない。
+
+Issue #101 参照。
+
+## What Changes
+
+- `handleServerHeroUpdate` で HP 減少を検知し、ダメージフラッシュ（`flash()`）を発火
+- `handleServerTowerUpdate` で HP 減少を検知し、タワーのダメージフラッシュを発火
+- `updateOnlineInput` で攻撃中のメレースイングを楽観的に再生
+- 死亡→リスポーン時に `MovementPredictor` と `InputBuffer` をリセットして予測ズレを防止
+
+## Capabilities
+
+### New Capabilities
+
+_(なし — 既存の仕組みにオンライン対応を追加する実装変更)_
+
+### Modified Capabilities
+
+_(なし — 仕様レベルの要件変更はなく、実装の接続不足を修正するバグフィックス)_
+
+## Non-goals
+
+- ネットワークスムージング / Entity Interpolation（#100 で別途対応）
+- オフラインモードのエフェクト変更（既に動作している）
+- 新しいエフェクト種類の追加
+
+## Impact
+
+- `src/scenes/GameScene.ts` — `handleServerHeroUpdate`, `handleServerTowerUpdate`, `updateOnlineInput` の修正
+- `src/scenes/effects/MeleeSwingRenderer.ts` — 変更なし（既存 API を呼ぶだけ）
+- `src/scenes/HeroRenderer.ts` — 変更なし（`flash()` と `sync()` は既存）
+- `src/network/InputBuffer.ts`, `src/network/MovementPredictor.ts` — リセット API の追加 or 呼び出し
+
+関連スペック: `openspec/specs/attack-system/`, `openspec/specs/death-respawn/`, `openspec/specs/hero-rendering/`

--- a/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/specs/no-spec-changes.md
+++ b/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/specs/no-spec-changes.md
@@ -1,0 +1,1 @@
+No spec-level requirement changes. This is a bug fix connecting existing visual feedback mechanisms to the online mode code path. See proposal.md for details.

--- a/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/tasks.md
+++ b/openspec/changes/archive/2026-02-22-fix-combat-visual-feedback/tasks.md
@@ -1,0 +1,20 @@
+## 1. ダメージフラッシュ（HP 差分検知）
+
+- [x] 1.1 `handleServerHeroUpdate` で更新前の HP を取得し、`state.hp < prevHp` の場合 `flash()` を呼ぶ（ローカル・リモート両方）
+- [x] 1.2 `handleServerTowerUpdate` で同様に HP 差分検知 → `flash()` を呼ぶ
+
+## 2. メレースイング（attackCooldown 変化検知）
+
+- [x] 2.1 `OnlineGameMode.setupListeners` に `attackCooldown` の listen コールバックを追加し、`ServerHeroState` に `attackCooldown` フィールドを追加
+- [x] 2.2 `GameScene.handleServerHeroUpdate` で `attackCooldown` が 0→正値に変化したことを検知し、近接ヒーロー（`projectileSpeed === 0`）の場合のみ `meleeSwing.play()` を呼ぶ
+
+## 3. 死亡/リスポーン時の予測リセット
+
+- [x] 3.1 `handleServerHeroUpdate` でローカルヒーローの `dead` が `false→true` に遷移した時 `InputBuffer.clear()` + `MovementPredictor.setPosition()` を呼ぶ
+- [x] 3.2 リスポーン（`dead: true→false`）時も `MovementPredictor.setPosition(state.x, state.y)` でリセット
+
+## 4. テスト
+
+- [x] 4.1 ユニットテスト：HP 差分検知ロジックのテスト（ヒーロー・タワー）
+- [x] 4.2 全テスト PASS を確認（`npm run test:unit` + サーバーテスト）
+- [x] 4.3 手動テスト：オンラインモードで攻撃時のフラッシュ・メレースイング・死亡/リスポーンを確認

--- a/src/network/GameMode.ts
+++ b/src/network/GameMode.ts
@@ -29,6 +29,7 @@ export interface RemotePlayerState {
 export interface ServerHeroState extends RemotePlayerState {
   readonly dead: boolean
   readonly attackTargetId: string
+  readonly attackCooldown: number
   readonly respawnTimer: number
   readonly lastProcessedSeq: number
 }

--- a/src/network/OnlineGameMode.ts
+++ b/src/network/OnlineGameMode.ts
@@ -91,6 +91,8 @@ export class OnlineGameMode implements GameMode {
       $(hero).listen('facing', () => this.notifyServerHeroUpdate(sessionId, hero))
       $(hero).listen('hp', () => this.notifyServerHeroUpdate(sessionId, hero))
       $(hero).listen('dead', () => this.notifyServerHeroUpdate(sessionId, hero))
+      // NOTE: attackCooldown decrements every server tick, so this fires continuously.
+      // Acceptable for 2v2 (≤80 extra calls/s). Replace with event-based approach in #111.
       $(hero).listen('attackCooldown', () => this.notifyServerHeroUpdate(sessionId, hero))
       $(hero).listen('respawnTimer', () => this.notifyServerHeroUpdate(sessionId, hero))
       $(hero).listen('lastProcessedSeq', () => this.notifyServerHeroUpdate(sessionId, hero))

--- a/src/network/OnlineGameMode.ts
+++ b/src/network/OnlineGameMode.ts
@@ -91,6 +91,7 @@ export class OnlineGameMode implements GameMode {
       $(hero).listen('facing', () => this.notifyServerHeroUpdate(sessionId, hero))
       $(hero).listen('hp', () => this.notifyServerHeroUpdate(sessionId, hero))
       $(hero).listen('dead', () => this.notifyServerHeroUpdate(sessionId, hero))
+      $(hero).listen('attackCooldown', () => this.notifyServerHeroUpdate(sessionId, hero))
       $(hero).listen('respawnTimer', () => this.notifyServerHeroUpdate(sessionId, hero))
       $(hero).listen('lastProcessedSeq', () => this.notifyServerHeroUpdate(sessionId, hero))
     })
@@ -138,6 +139,7 @@ export class OnlineGameMode implements GameMode {
       team: hero.team as string,
       dead: hero.dead as boolean,
       attackTargetId: hero.attackTargetId as string,
+      attackCooldown: hero.attackCooldown as number,
       respawnTimer: hero.respawnTimer as number,
       lastProcessedSeq: hero.lastProcessedSeq as number,
     }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -425,7 +425,7 @@ export class GameScene extends Phaser.Scene {
     // Snapshot previous state for change detection (before updating entity)
     const existingHero = this.entityManager.getEntity(state.sessionId) as HeroState | null
     const prevHp = existingHero?.hp ?? state.hp
-    const prevAttackCooldown = existingHero?.attackCooldown ?? 0
+    const prevAttackCooldown = existingHero?.attackCooldown ?? state.attackCooldown
     const prevDead = existingHero?.dead ?? state.dead
 
     if (isLocal) {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -422,6 +422,12 @@ export class GameScene extends Phaser.Scene {
     const localSessionId = this.networkBridge.localSessionId
     const isLocal = localSessionId !== null && state.sessionId === localSessionId
 
+    // Snapshot previous state for change detection (before updating entity)
+    const existingHero = this.entityManager.getEntity(state.sessionId) as HeroState | null
+    const prevHp = existingHero?.hp ?? state.hp
+    const prevAttackCooldown = existingHero?.attackCooldown ?? 0
+    const prevDead = existingHero?.dead ?? state.dead
+
     if (isLocal) {
       // Remap local hero ID from placeholder to server sessionId (first time only)
       if (state.sessionId !== this.entityManager.localHeroId) {
@@ -447,6 +453,7 @@ export class GameScene extends Phaser.Scene {
           hp: state.hp,
           maxHp: state.maxHp,
           dead: state.dead,
+          attackCooldown: state.attackCooldown,
           attackTargetId: state.attackTargetId || null,
           respawnTimer: state.respawnTimer,
         }))
@@ -459,6 +466,7 @@ export class GameScene extends Phaser.Scene {
           hp: state.hp,
           maxHp: state.maxHp,
           dead: state.dead,
+          attackCooldown: state.attackCooldown,
           attackTargetId: state.attackTargetId || null,
           respawnTimer: state.respawnTimer,
         }))
@@ -474,6 +482,16 @@ export class GameScene extends Phaser.Scene {
           this.cameras.main.startFollow(renderer.gameObject, true, CAMERA_LERP, CAMERA_LERP)
         }
         this.cameraFollowing = true
+      }
+
+      // Reset prediction on death/respawn transitions
+      if (!prevDead && state.dead) {
+        // Death: clear buffered inputs and snap predictor to server position
+        this.inputBuffer?.clear()
+        this.movementPredictor?.setPosition(state.x, state.y)
+      } else if (prevDead && !state.dead) {
+        // Respawn: snap predictor to respawn position
+        this.movementPredictor?.setPosition(state.x, state.y)
       }
     } else {
       // Remote hero: create entity if new
@@ -502,15 +520,35 @@ export class GameScene extends Phaser.Scene {
         hp: state.hp,
         maxHp: state.maxHp,
         dead: state.dead,
+        attackCooldown: state.attackCooldown,
         attackTargetId: state.attackTargetId || null,
         respawnTimer: state.respawnTimer,
       }))
+    }
+
+    // Trigger damage flash when HP decreased
+    if (state.hp < prevHp) {
+      this.entityRenderers.get(state.sessionId)?.flash()
+    }
+
+    // Trigger melee swing when attackCooldown increases (= new attack fired).
+    // Cooldown normally only decreases (counting down), so an increase always means a new attack.
+    const heroType = (state.heroType as HeroType) ?? 'BLADE'
+    if (state.attackCooldown > prevAttackCooldown && HERO_DEFINITIONS[heroType].projectileSpeed === 0) {
+      const heroEntity = this.entityManager.getEntity(state.sessionId) as HeroState | null
+      if (heroEntity) {
+        this.meleeSwing.play({ position: heroEntity.position, facing: heroEntity.facing })
+      }
     }
   }
 
   /** Handle server tower state sync (server-authoritative mode). */
   private handleServerTowerUpdate(state: ServerTowerState): void {
     const existing = this.entityManager.getEntity(state.id)
+
+    // Detect HP decrease for damage flash (before updating entity)
+    const prevHp = (existing as TowerState | null)?.hp ?? state.hp
+
     if (!existing) {
       const towerState = createTowerState({
         id: state.id,
@@ -533,6 +571,11 @@ export class GameScene extends Phaser.Scene {
       maxHp: state.maxHp,
       dead: state.dead,
     }))
+
+    // Trigger damage flash when HP decreased
+    if (state.hp < prevHp) {
+      this.entityRenderers.get(state.id)?.flash()
+    }
   }
 
   /**

--- a/src/scenes/__tests__/GameScene.test.ts
+++ b/src/scenes/__tests__/GameScene.test.ts
@@ -326,6 +326,17 @@ describe('GameScene', () => {
       expect(mockMeleeSwing.play).not.toHaveBeenCalled()
     })
 
+    it('does not trigger meleeSwing on first sync with active cooldown (no previous entity)', () => {
+      const { scene, mockMeleeSwing } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      // First sync for a NEW hero (not yet in EntityManager) with attackCooldown already > 0
+      // (e.g., server processed an attack before client subscribed)
+      call(makeServerHeroState({ sessionId: 'new-hero', team: 'red', attackCooldown: 0.8 }))
+      expect(mockMeleeSwing.play).not.toHaveBeenCalled()
+    })
+
     it('does not trigger meleeSwing when attackCooldown decreases', () => {
       const { scene, mockMeleeSwing } = setupSceneForServerUpdate()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/scenes/__tests__/GameScene.test.ts
+++ b/src/scenes/__tests__/GameScene.test.ts
@@ -57,13 +57,20 @@ vi.mock('@/test/e2eTestApi', () => ({
 }))
 
 import { GameScene } from '@/scenes/GameScene'
+import { EntityManager } from '@/scenes/EntityManager'
+import { CombatManager } from '@/scenes/CombatManager'
+import { NetworkBridge } from '@/scenes/NetworkBridge'
+import { InputBuffer } from '@/network/InputBuffer'
+import { MovementPredictor } from '@/network/MovementPredictor'
 import { OfflineGameMode } from '@/network/OfflineGameMode'
-import type { GameMode } from '@/network/GameMode'
+import type { GameMode, ServerHeroState, ServerTowerState } from '@/network/GameMode'
+import { createTowerState } from '@/domain/entities/Tower'
+import { DEFAULT_TOWER } from '@/domain/entities/towerDefinitions'
 
-function createMockGameMode(): GameMode {
+function createMockGameMode(overrides?: Partial<GameMode>): GameMode {
   return {
-    isServerAuthoritative: false,
-    localSessionId: null,
+    isServerAuthoritative: true,
+    localSessionId: 'local-session',
     onSceneCreate: vi.fn().mockResolvedValue(undefined),
     sendInput: vi.fn(),
     sendLocalState: vi.fn(),
@@ -79,6 +86,107 @@ function createMockGameMode(): GameMode {
     onServerTowerUpdate: vi.fn(),
     onServerProjectileUpdate: vi.fn(),
     dispose: vi.fn(),
+    ...overrides,
+  }
+}
+
+function createMockRenderer() {
+  return {
+    gameObject: {},
+    sync: vi.fn(),
+    update: vi.fn(),
+    flash: vi.fn(),
+    destroy: vi.fn(),
+  }
+}
+
+/**
+ * Set up a GameScene with enough internals to test handleServerHeroUpdate / handleServerTowerUpdate.
+ * Bypasses Phaser's create() by directly assigning private fields.
+ */
+function setupSceneForServerUpdate(options?: { localSessionId?: string }) {
+  const localSessionId = options?.localSessionId ?? 'local-session'
+
+  const scene = new GameScene()
+
+  const em = new EntityManager(
+    { id: localSessionId, type: 'BLADE', team: 'blue', position: { x: 100, y: 200 } },
+    { id: 'enemy-1', type: 'BLADE', team: 'red', position: { x: 300, y: 200 } }
+  )
+  const cm = new CombatManager(em)
+  const gm = createMockGameMode({ localSessionId })
+  const bridge = new NetworkBridge(gm, em, cm)
+
+  const mockMeleeSwing = { play: vi.fn(), update: vi.fn() }
+  const inputBuffer = new InputBuffer()
+  const movementPredictor = new MovementPredictor()
+  movementPredictor.setPosition(100, 200)
+
+  // Assign private fields
+  const s = scene as Record<string, unknown>
+  s.entityManager = em
+  s.combatManager = cm
+  s.networkBridge = bridge
+  s.entityRenderers = new Map()
+  s.meleeSwing = mockMeleeSwing
+  s.inputBuffer = inputBuffer
+  s.movementPredictor = movementPredictor
+  s.cameraFollowing = true
+  s.cameras = { main: { stopFollow: vi.fn(), startFollow: vi.fn() } }
+  s.localTeam = 'blue'
+
+  // Create renderers for existing entities
+  const localRenderer = createMockRenderer()
+  const enemyRenderer = createMockRenderer()
+  ;(s.entityRenderers as Map<string, unknown>).set(localSessionId, localRenderer)
+  ;(s.entityRenderers as Map<string, unknown>).set('enemy-1', enemyRenderer)
+
+  return {
+    scene,
+    em,
+    gm,
+    bridge,
+    mockMeleeSwing,
+    inputBuffer,
+    movementPredictor,
+    localRenderer,
+    enemyRenderer,
+    getRenderer: (id: string) => (s.entityRenderers as Map<string, ReturnType<typeof createMockRenderer>>).get(id),
+    setRenderer: (id: string, r: ReturnType<typeof createMockRenderer>) =>
+      (s.entityRenderers as Map<string, unknown>).set(id, r),
+  }
+}
+
+function makeServerHeroState(overrides?: Partial<ServerHeroState>): ServerHeroState {
+  return {
+    sessionId: 'local-session',
+    x: 100,
+    y: 200,
+    facing: 0,
+    hp: 650,
+    maxHp: 650,
+    heroType: 'BLADE',
+    team: 'blue',
+    dead: false,
+    attackTargetId: '',
+    attackCooldown: 0,
+    respawnTimer: 0,
+    lastProcessedSeq: 0,
+    ...overrides,
+  }
+}
+
+function makeServerTowerState(overrides?: Partial<ServerTowerState>): ServerTowerState {
+  return {
+    id: 'tower-blue',
+    x: 200,
+    y: 300,
+    hp: 2000,
+    maxHp: 2000,
+    dead: false,
+    team: 'blue',
+    radius: 30,
+    ...overrides,
   }
 }
 
@@ -110,6 +218,227 @@ describe('GameScene', () => {
       const scene = new GameScene()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((scene as any).gameMode).toBeInstanceOf(OfflineGameMode)
+    })
+  })
+
+  describe('handleServerHeroUpdate — damage flash', () => {
+    it('triggers flash when hero HP decreases', () => {
+      const { scene, localRenderer } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      // First update: set initial HP
+      call(makeServerHeroState({ hp: 650 }))
+      localRenderer.flash.mockClear()
+
+      // Second update: HP decreased
+      call(makeServerHeroState({ hp: 600 }))
+      expect(localRenderer.flash).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not trigger flash when HP stays the same', () => {
+      const { scene, localRenderer } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      call(makeServerHeroState({ hp: 650 }))
+      localRenderer.flash.mockClear()
+
+      call(makeServerHeroState({ hp: 650 }))
+      expect(localRenderer.flash).not.toHaveBeenCalled()
+    })
+
+    it('does not trigger flash when HP increases', () => {
+      const { scene, localRenderer } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      call(makeServerHeroState({ hp: 500 }))
+      localRenderer.flash.mockClear()
+
+      call(makeServerHeroState({ hp: 600 }))
+      expect(localRenderer.flash).not.toHaveBeenCalled()
+    })
+
+    it('triggers flash for remote hero HP decrease', () => {
+      const { scene, setRenderer } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+      const remoteRenderer = createMockRenderer()
+
+      // First update creates remote entity internally
+      call(makeServerHeroState({ sessionId: 'remote-1', team: 'red', hp: 650 }))
+      setRenderer('remote-1', remoteRenderer)
+
+      // Second update: HP decreased
+      call(makeServerHeroState({ sessionId: 'remote-1', team: 'red', hp: 600 }))
+      expect(remoteRenderer.flash).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('handleServerHeroUpdate — melee swing', () => {
+    it('triggers meleeSwing.play when attackCooldown increases (new attack) for melee hero', () => {
+      const { scene, mockMeleeSwing } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      // Initial state: attackCooldown = 0
+      call(makeServerHeroState({ attackCooldown: 0 }))
+      mockMeleeSwing.play.mockClear()
+
+      // Attack fired: attackCooldown jumps to positive
+      call(makeServerHeroState({ attackCooldown: 0.8 }))
+      expect(mockMeleeSwing.play).toHaveBeenCalledTimes(1)
+      expect(mockMeleeSwing.play).toHaveBeenCalledWith(
+        expect.objectContaining({ position: expect.any(Object), facing: expect.any(Number) })
+      )
+    })
+
+    it('triggers meleeSwing on consecutive attacks (cooldown jumps without reaching 0)', () => {
+      const { scene, mockMeleeSwing } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      // First attack: 0 → 0.8
+      call(makeServerHeroState({ attackCooldown: 0 }))
+      call(makeServerHeroState({ attackCooldown: 0.8 }))
+      mockMeleeSwing.play.mockClear()
+
+      // Cooldown counting down
+      call(makeServerHeroState({ attackCooldown: 0.003 }))
+      expect(mockMeleeSwing.play).not.toHaveBeenCalled()
+
+      // Second attack: cooldown expired + new attack in same tick (0.003 → 0.8)
+      call(makeServerHeroState({ attackCooldown: 0.8 }))
+      expect(mockMeleeSwing.play).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not trigger meleeSwing for ranged hero (BOLT)', () => {
+      const { scene, mockMeleeSwing } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      // First call creates the entity as BOLT
+      call(makeServerHeroState({ heroType: 'BOLT', attackCooldown: 0 }))
+      mockMeleeSwing.play.mockClear()
+
+      call(makeServerHeroState({ heroType: 'BOLT', attackCooldown: 1.0 }))
+      expect(mockMeleeSwing.play).not.toHaveBeenCalled()
+    })
+
+    it('does not trigger meleeSwing when attackCooldown decreases', () => {
+      const { scene, mockMeleeSwing } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      call(makeServerHeroState({ attackCooldown: 0.5 }))
+      mockMeleeSwing.play.mockClear()
+
+      call(makeServerHeroState({ attackCooldown: 0.3 }))
+      expect(mockMeleeSwing.play).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleServerHeroUpdate — death/respawn prediction reset', () => {
+    it('clears input buffer and resets predictor on death (false→true)', () => {
+      const { scene, inputBuffer, movementPredictor } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+      const clearSpy = vi.spyOn(inputBuffer, 'clear')
+      const setPosSpy = vi.spyOn(movementPredictor, 'setPosition')
+
+      // Alive state
+      call(makeServerHeroState({ dead: false }))
+      clearSpy.mockClear()
+      setPosSpy.mockClear()
+
+      // Death
+      call(makeServerHeroState({ dead: true, x: 150, y: 250 }))
+      expect(clearSpy).toHaveBeenCalledTimes(1)
+      expect(setPosSpy).toHaveBeenCalledWith(150, 250)
+    })
+
+    it('resets predictor position on respawn (true→false)', () => {
+      const { scene, inputBuffer, movementPredictor } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+      const clearSpy = vi.spyOn(inputBuffer, 'clear')
+      const setPosSpy = vi.spyOn(movementPredictor, 'setPosition')
+
+      // Set dead state
+      call(makeServerHeroState({ dead: true, x: 150, y: 250 }))
+      clearSpy.mockClear()
+      setPosSpy.mockClear()
+
+      // Respawn
+      call(makeServerHeroState({ dead: false, x: 100, y: 200 }))
+      expect(clearSpy).not.toHaveBeenCalled()
+      expect(setPosSpy).toHaveBeenCalledWith(100, 200)
+    })
+
+    it('does not reset prediction when dead state unchanged', () => {
+      const { scene, inputBuffer, movementPredictor } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+      const clearSpy = vi.spyOn(inputBuffer, 'clear')
+      const setPosSpy = vi.spyOn(movementPredictor, 'setPosition')
+
+      call(makeServerHeroState({ dead: false }))
+      clearSpy.mockClear()
+      setPosSpy.mockClear()
+
+      // Still alive — no reset
+      call(makeServerHeroState({ dead: false }))
+      expect(clearSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleServerTowerUpdate — damage flash', () => {
+    it('triggers flash when tower HP decreases', () => {
+      const { scene, em, setRenderer } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerTowerUpdate.bind(scene)
+
+      // Register tower entity
+      const tower = createTowerState({
+        id: 'tower-blue',
+        team: 'blue',
+        position: { x: 200, y: 300 },
+        definition: DEFAULT_TOWER,
+      })
+      em.registerEntity(tower)
+      const towerRenderer = createMockRenderer()
+      setRenderer('tower-blue', towerRenderer)
+
+      // First update: HP unchanged
+      call(makeServerTowerState({ hp: 2000 }))
+      towerRenderer.flash.mockClear()
+
+      // Second update: HP decreased
+      call(makeServerTowerState({ hp: 1800 }))
+      expect(towerRenderer.flash).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not trigger flash when tower HP stays the same', () => {
+      const { scene, em, setRenderer } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerTowerUpdate.bind(scene)
+
+      const tower = createTowerState({
+        id: 'tower-blue',
+        team: 'blue',
+        position: { x: 200, y: 300 },
+        definition: DEFAULT_TOWER,
+      })
+      em.registerEntity(tower)
+      const towerRenderer = createMockRenderer()
+      setRenderer('tower-blue', towerRenderer)
+
+      call(makeServerTowerState({ hp: 2000 }))
+      towerRenderer.flash.mockClear()
+
+      call(makeServerTowerState({ hp: 2000 }))
+      expect(towerRenderer.flash).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary
- HP 差分検知によるダメージフラッシュ（ヒーロー・タワー、ローカル/リモート両方）
- `attackCooldown` 増加検知によるメレースイングエフェクト（近接ヒーローのみ）
- 死亡/リスポーン時の `InputBuffer` + `MovementPredictor` リセットで予測ズレ防止
- `attackCooldown` をエンティティ state に同期して正確な変化検知を実現

## Test plan
- [x] ユニットテスト 13 件追加（HP 差分フラッシュ、メレースイング連続検知、死亡/リスポーンリセット）
- [x] `npm run test:unit` 全 324 テスト PASS
- [x] サーバーテスト 全 77 テスト PASS
- [x] 手動テスト: オンラインモードでダメージフラッシュ・メレースイング・死亡/リスポーン確認

Closes #101