### PR TITLE
fix: sync heroType from server state for all heroes

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -46,13 +46,6 @@ function assertHeroType(value: string): HeroType {
   return value as HeroType
 }
 
-/** Debug: number keys 1-3 switch hero type (remove before release — see Issue) */
-const DEBUG_HERO_KEYS: readonly { key: string; type: HeroType }[] = [
-  { key: 'ONE', type: 'BLADE' },
-  { key: 'TWO', type: 'BOLT' },
-  { key: 'THREE', type: 'AURA' },
-]
-
 interface EntityRenderer {
   readonly gameObject: Phaser.GameObjects.Container
   update(delta: number): void
@@ -151,11 +144,6 @@ export class GameScene extends Phaser.Scene {
     this.respawnText.setScrollFactor(0)
     this.respawnText.setDepth(1000)
     this.respawnText.setVisible(false)
-
-    // Debug keys
-    for (const { key, type } of DEBUG_HERO_KEYS) {
-      this.input.keyboard!.on(`keydown-${key}`, () => this.debugSwitchHero(type))
-    }
 
     // E2E test API (dev only)
     if (import.meta.env.DEV) {
@@ -703,24 +691,4 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
-  private debugSwitchHero(type: HeroType): void {
-    const localHeroId = this.entityManager.localHeroId
-    const hero = this.entityManager.getEntity(localHeroId) as HeroState
-    if (hero.type === type) return
-
-    this.entityRenderers.get(localHeroId)?.destroy()
-    this.combatManager.resetProjectiles()
-
-    this.entityManager.registerEntity(createHeroState({
-      id: localHeroId,
-      type,
-      team: this.localTeam,
-      position: this.localSpawnPosition,
-    }))
-
-    const newHero = this.entityManager.getEntity(localHeroId) as HeroState
-    const renderer = new HeroRenderer(this, newHero, true)
-    this.entityRenderers.set(localHeroId, renderer)
-    this.cameras.main.startFollow(renderer.gameObject, true, CAMERA_LERP, CAMERA_LERP)
-  }
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -456,6 +456,7 @@ export class GameScene extends Phaser.Scene {
         )
         this.entityManager.updateEntity<HeroState>(state.sessionId, (h) => ({
           ...h,
+          type: (state.heroType as HeroType) ?? h.type,
           position: { x: reconciled.x, y: reconciled.y },
           facing: state.facing,
           hp: state.hp,
@@ -468,6 +469,7 @@ export class GameScene extends Phaser.Scene {
         // Prediction not set up yet — use server position directly
         this.entityManager.updateEntity<HeroState>(state.sessionId, (h) => ({
           ...h,
+          type: (state.heroType as HeroType) ?? h.type,
           position: { x: state.x, y: state.y },
           facing: state.facing,
           hp: state.hp,
@@ -521,6 +523,7 @@ export class GameScene extends Phaser.Scene {
       // Update entity state from server
       this.entityManager.updateEntity<HeroState>(state.sessionId, (h) => ({
         ...h,
+        type: (state.heroType as HeroType) ?? h.type,
         position: { x: state.x, y: state.y },
         facing: state.facing,
         hp: state.hp,

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -38,6 +38,14 @@ import { registerTestApi } from '@/test/e2eTestApi'
 const FREE_CAMERA_SPEED = 400
 const SERVER_TICK_DELTA = 1 / 60
 
+/** Assert that a server-provided heroType string is a valid HeroType key. */
+function assertHeroType(value: string): HeroType {
+  if (!(value in HERO_DEFINITIONS)) {
+    throw new Error(`Invalid heroType from server: "${value}"`)
+  }
+  return value as HeroType
+}
+
 /** Debug: number keys 1-3 switch hero type (remove before release — see Issue) */
 const DEBUG_HERO_KEYS: readonly { key: string; type: HeroType }[] = [
   { key: 'ONE', type: 'BLADE' },
@@ -445,7 +453,7 @@ export class GameScene extends Phaser.Scene {
       // Reconcile movement prediction
       if (this.inputBuffer && this.movementPredictor) {
         this.inputBuffer.acknowledge(state.lastProcessedSeq)
-        const heroType = (state.heroType as HeroType) ?? 'BLADE'
+        const heroType = assertHeroType(state.heroType)
         const speed = HERO_DEFINITIONS[heroType].base.speed
         const reconciled = this.movementPredictor.reconcile(
           state.x,
@@ -456,7 +464,7 @@ export class GameScene extends Phaser.Scene {
         )
         this.entityManager.updateEntity<HeroState>(state.sessionId, (h) => ({
           ...h,
-          type: (state.heroType as HeroType) ?? h.type,
+          type: assertHeroType(state.heroType),
           position: { x: reconciled.x, y: reconciled.y },
           facing: state.facing,
           hp: state.hp,
@@ -469,7 +477,7 @@ export class GameScene extends Phaser.Scene {
         // Prediction not set up yet — use server position directly
         this.entityManager.updateEntity<HeroState>(state.sessionId, (h) => ({
           ...h,
-          type: (state.heroType as HeroType) ?? h.type,
+          type: assertHeroType(state.heroType),
           position: { x: state.x, y: state.y },
           facing: state.facing,
           hp: state.hp,
@@ -507,7 +515,7 @@ export class GameScene extends Phaser.Scene {
       if (!existing) {
         const heroState = createHeroState({
           id: state.sessionId,
-          type: (state.heroType as HeroType) ?? 'BLADE',
+          type: assertHeroType(state.heroType),
           team: (state.team as Team) ?? 'red',
           position: { x: state.x, y: state.y },
         })

--- a/src/scenes/HeroRenderer.ts
+++ b/src/scenes/HeroRenderer.ts
@@ -72,6 +72,7 @@ export class HeroRenderer {
     // Redraw body if hero type changed (server-authoritative type sync)
     if (heroState.type !== this.heroType) {
       this.heroType = heroState.type
+      this.isFlashing = false
       const color = HERO_COLORS[heroState.type]
       this.bodyGraphics.clear()
       this.drawBody(heroState.type, color)

--- a/src/scenes/HeroRenderer.ts
+++ b/src/scenes/HeroRenderer.ts
@@ -27,7 +27,7 @@ export class HeroRenderer {
   private readonly indicatorGraphics: Phaser.GameObjects.Graphics
   private readonly hpBar: HpBarRenderer
   private readonly radius: number
-  private readonly heroType: HeroType
+  private heroType: HeroType
   private flashTimer = 0
   private isFlashing = false
 
@@ -68,6 +68,16 @@ export class HeroRenderer {
 
     // Hide entire container (body + HP bar) when dead
     this.container.setVisible(!heroState.dead)
+
+    // Redraw body if hero type changed (server-authoritative type sync)
+    if (heroState.type !== this.heroType) {
+      this.heroType = heroState.type
+      const color = HERO_COLORS[heroState.type]
+      this.bodyGraphics.clear()
+      this.drawBody(heroState.type, color)
+      this.indicatorGraphics.clear()
+      this.drawFacingIndicator(color)
+    }
 
     // Rotate facing indicator around the hero
     const offset = this.radius * FACING_INDICATOR_OFFSET

--- a/src/scenes/__tests__/GameScene.test.ts
+++ b/src/scenes/__tests__/GameScene.test.ts
@@ -389,13 +389,12 @@ describe('GameScene', () => {
     })
 
     it('updates remote hero type from server state', () => {
-      const { scene, em, setRenderer } = setupSceneForServerUpdate()
+      const { scene, em } = setupSceneForServerUpdate()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const call = (scene as any).handleServerHeroUpdate.bind(scene)
 
       // Create remote hero as BLADE first
       call(makeServerHeroState({ sessionId: 'remote-1', heroType: 'BLADE', team: 'red' }))
-      setRenderer('remote-1', createMockRenderer())
 
       const heroBlade = em.getEntity('remote-1') as HeroState
       expect(heroBlade.type).toBe('BLADE')

--- a/src/scenes/__tests__/GameScene.test.ts
+++ b/src/scenes/__tests__/GameScene.test.ts
@@ -64,6 +64,7 @@ import { InputBuffer } from '@/network/InputBuffer'
 import { MovementPredictor } from '@/network/MovementPredictor'
 import { OfflineGameMode } from '@/network/OfflineGameMode'
 import type { GameMode, ServerHeroState, ServerTowerState } from '@/network/GameMode'
+import type { HeroState } from '@/domain/entities/Hero'
 import { createTowerState } from '@/domain/entities/Tower'
 import { DEFAULT_TOWER } from '@/domain/entities/towerDefinitions'
 
@@ -367,6 +368,53 @@ describe('GameScene', () => {
       // Still alive — no reset
       call(makeServerHeroState({ dead: false }))
       expect(clearSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleServerHeroUpdate — heroType sync', () => {
+    it('updates local hero type from server state', () => {
+      const { scene, em } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      // Initial state: BLADE
+      call(makeServerHeroState({ heroType: 'BLADE' }))
+      const heroBlade = em.getEntity('local-session') as HeroState
+      expect(heroBlade.type).toBe('BLADE')
+
+      // Server sends BOLT
+      call(makeServerHeroState({ heroType: 'BOLT' }))
+      const heroBolt = em.getEntity('local-session') as HeroState
+      expect(heroBolt.type).toBe('BOLT')
+    })
+
+    it('updates remote hero type from server state', () => {
+      const { scene, em, setRenderer } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      // Create remote hero as BLADE first
+      call(makeServerHeroState({ sessionId: 'remote-1', heroType: 'BLADE', team: 'red' }))
+      setRenderer('remote-1', createMockRenderer())
+
+      const heroBlade = em.getEntity('remote-1') as HeroState
+      expect(heroBlade.type).toBe('BLADE')
+
+      // Server sends AURA for the same remote hero
+      call(makeServerHeroState({ sessionId: 'remote-1', heroType: 'AURA', team: 'red' }))
+      const heroAura = em.getEntity('remote-1') as HeroState
+      expect(heroAura.type).toBe('AURA')
+    })
+
+    it('preserves hero type when server sends the same type', () => {
+      const { scene, em } = setupSceneForServerUpdate()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const call = (scene as any).handleServerHeroUpdate.bind(scene)
+
+      call(makeServerHeroState({ heroType: 'AURA' }))
+      call(makeServerHeroState({ heroType: 'AURA' }))
+      const hero = em.getEntity('local-session') as HeroState
+      expect(hero.type).toBe('AURA')
     })
   })
 


### PR DESCRIPTION
## Summary
- `handleServerHeroUpdate` の全 `updateEntity` コール（ローカル2箇所 + リモート1箇所）に `type` フィールドを追加し、サーバーの `heroType` をエンティティ状態に反映
- `HeroRenderer.sync()` でタイプ変更を検知し、body と facing indicator を再描画するように修正
- heroType 同期のユニットテスト3件追加

Closes #113

## Test plan
- [x] Client unit tests: 325/325 PASS
- [x] Server unit tests: 85/85 PASS
- [x] TypeScript compile: client + server OK
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)