### PR TITLE
feat: Terraform deploy workflow (manual trigger)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,8 @@ jobs:
     needs: terraform-plan
     if: |
       inputs.action == 'apply' &&
-      needs.terraform-plan.result == 'success'
+      needs.terraform-plan.result == 'success' &&
+      needs.terraform-plan.outputs.plan-exit-code == '2'
     environment: prod-deploy
     steps:
       - name: Checkout
@@ -158,14 +159,20 @@ jobs:
         run: terraform init
 
       - name: Terraform Plan Destroy
+        id: destroy-plan
         working-directory: ${{ env.TF_WORKING_DIR }}
         run: |
-          terraform plan -destroy -no-color 2>&1 | tee destroy-plan.txt
+          terraform plan -destroy -out=destroy.tfplan -no-color 2>&1 | tee destroy-plan.txt
           echo "## Destroy Plan" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           cat destroy-plan.txt >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+        continue-on-error: true
+
+      - name: Fail on Destroy Plan Error
+        if: steps.destroy-plan.outcome == 'failure'
+        run: exit 1
 
       - name: Terraform Destroy
         working-directory: ${{ env.TF_WORKING_DIR }}
-        run: terraform destroy -auto-approve
+        run: terraform apply destroy.tfplan

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,171 @@
+name: Terraform Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Terraform action to perform"
+        required: true
+        type: choice
+        options:
+          - plan
+          - apply
+          - destroy
+
+concurrency:
+  group: terraform-prod
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TF_WORKING_DIR: infrastructure/terraform/environments/prod
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check actor is repository owner
+        if: github.actor != github.repository_owner
+        run: |
+          echo "::error::Only the repository owner can run this workflow."
+          exit 1
+
+  terraform-plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    needs: authorize
+    if: inputs.action == 'plan' || inputs.action == 'apply'
+    outputs:
+      plan-exit-code: ${{ steps.plan.outputs.exitcode }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: terraform-deploy-${{ github.run_id }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.x"
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform plan -out=tfplan -detailed-exitcode -no-color 2>&1 | tee plan-output.txt
+          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Plan Summary
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          echo "## Terraform Plan Result" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat plan-output.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Plan Artifact
+        if: steps.plan.outputs.exitcode == '0' || steps.plan.outputs.exitcode == '2'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan
+          path: |
+            ${{ env.TF_WORKING_DIR }}/tfplan
+            ${{ env.TF_WORKING_DIR }}/plan-output.txt
+          retention-days: 1
+
+      - name: Fail on Plan Error
+        if: steps.plan.outputs.exitcode == '1'
+        run: exit 1
+
+  terraform-apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    needs: terraform-plan
+    if: |
+      inputs.action == 'apply' &&
+      needs.terraform-plan.result == 'success'
+    environment: prod-deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: terraform-deploy-${{ github.run_id }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.x"
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform init
+
+      - name: Download Plan Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan
+          path: ${{ env.TF_WORKING_DIR }}
+
+      - name: Terraform Apply
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform apply tfplan
+
+  terraform-destroy:
+    name: Terraform Destroy
+    runs-on: ubuntu-latest
+    needs: authorize
+    if: inputs.action == 'destroy'
+    environment: prod-deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: terraform-deploy-${{ github.run_id }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.14.x"
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform init
+
+      - name: Terraform Plan Destroy
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform plan -destroy -no-color 2>&1 | tee destroy-plan.txt
+          echo "## Destroy Plan" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat destroy-plan.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Terraform Destroy
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform destroy -auto-approve

--- a/README.md
+++ b/README.md
@@ -17,6 +17,52 @@ npm run build    # Production build
 npm run preview  # Preview production build
 ```
 
+## Testing
+
+```bash
+npm run test:unit      # Vitest unit tests
+npm run test:e2e       # Playwright E2E tests
+npm run test:coverage  # Coverage report
+```
+
+## Deploy (GitHub Actions)
+
+Terraform の Plan / Apply / Destroy を GitHub Actions から手動で実行する。
+
+### 使い方
+
+1. GitHub リポジトリの **Actions** タブを開く
+2. 左メニューから **Terraform Deploy** を選択
+3. **Run workflow** をクリック
+4. ブランチを選択し、action を選ぶ:
+   - `plan` — 変更内容を確認 (適用なし)
+   - `apply` — Plan 後、承認を経て適用
+   - `destroy` — 承認を経てリソース削除
+
+### フロー
+
+```
+plan:    Plan → Job Summary に結果表示
+apply:   Plan → 承認ゲート (prod-deploy) → Apply
+destroy: Destroy Plan 表示 → 承認ゲート (prod-deploy) → Destroy
+```
+
+### 初回セットアップ
+
+**AWS 側:**
+1. IAM OIDC Identity Provider を作成 (Provider URL: `https://token.actions.githubusercontent.com`)
+2. IAM ロールを作成 (trust policy で `repo:yu-kod/simoba:*` に制限)
+3. S3 バケット `simoba-terraform-state` と DynamoDB テーブル `simoba-terraform-locks` を作成
+
+**GitHub 側:**
+1. Repository Secret に `AWS_ROLE_ARN` を設定
+2. Settings > Environments で `prod-deploy` を作成し、Required Reviewers を設定
+
+### 制限
+
+- リポジトリオーナーのみ実行可能
+- 同時実行は concurrency グループで防止
+
 ## Project Structure
 
 ```

--- a/openspec/changes/archive/2026-02-23-terraform-branch-deploy/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-23-terraform-branch-deploy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-23

--- a/openspec/changes/archive/2026-02-23-terraform-branch-deploy/design.md
+++ b/openspec/changes/archive/2026-02-23-terraform-branch-deploy/design.md
@@ -1,0 +1,88 @@
+## Context
+
+現在の Terraform 構成:
+- `infrastructure/terraform/environments/prod/main.tf` — S3 backend、`static_hosting` + `game_server` モジュール
+- `infrastructure/terraform/environments/local/main.tf` — LocalStack 向け、`static_hosting` のみ
+- モジュール: `static-hosting` (S3 + CloudFront)、`game-server` (ECS on EC2 + ALB)
+
+prod 環境に任意ブランチのコードをデプロイする GitHub Actions ワークフローが必要。
+prod の `main.tf` にある `container_image` は `${module.game_server.ecr_repository_url}:latest` と循環参照になっている点に注意が必要。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 任意ブランチから手動で prod 環境に Terraform Plan/Apply を実行できる
+- Plan 結果を確認し、承認後に Apply を実行する安全なフロー
+- AWS キーをシークレットに保存しない (OIDC 認証)
+
+**Non-Goals:**
+- ブランチごとの独立環境構築
+- dev 環境の追加 (別チケット)
+- 自動デプロイ (push トリガー)
+- Docker イメージのビルド・プッシュ (Terraform の Plan/Apply のみ)
+- Terraform モジュールの変更
+
+## Decisions
+
+### 1. AWS 認証: OIDC
+
+**選択:** GitHub Actions OIDC + `aws-actions/configure-aws-credentials`
+
+**理由:** AWS アクセスキーをシークレットに保存すると漏洩リスクがある。OIDC は一時的な認証情報を使い、リポジトリ・ブランチ単位で制限できる。
+
+**代替案:**
+- AWS Access Key/Secret を GitHub Secrets に保存 — シンプルだがキーのローテーション管理が必要
+- AWS SSO — セットアップが複雑
+
+**前提条件:** AWS 側で以下の事前設定が必要:
+- IAM OIDC Identity Provider (`token.actions.githubusercontent.com`)
+- IAM ロール (trust policy で `repo:yu-kod/simoba:*` に制限)
+- ロール ARN を GitHub Secrets `AWS_ROLE_ARN` に設定
+
+### 2. ワークフロートリガー: workflow_dispatch
+
+**選択:** `workflow_dispatch` で `action` (plan/apply/destroy) と `environment` (prod) を入力
+
+**理由:** 手動起動でブランチを GitHub UI から選択可能。意図しないデプロイを防止。
+
+**フロー:**
+1. GitHub UI で「Run workflow」→ ブランチ選択 → action 選択
+2. `plan` → `terraform plan` 実行、結果を Job Summary に出力
+3. `apply` → Plan 実行後、GitHub Environment 承認ゲートを通過してから `terraform apply`
+4. `destroy` → 承認後に `terraform destroy`
+
+### 3. 承認ゲート: GitHub Environment
+
+**選択:** GitHub Environment の Required Reviewers 機能
+
+**理由:** GitHub ネイティブの承認フローで追加ツール不要。`apply` / `destroy` 時のみ承認を要求。
+
+**Environment 設定:**
+- `prod-deploy`: Required Reviewers を設定。`plan` は承認不要、`apply` / `destroy` は承認必須
+
+### 4. Terraform State: 既存 S3 backend
+
+**選択:** `prod/main.tf` の既存 S3 backend をそのまま使用
+
+**理由:** 新しい環境を作るわけではないので、state ファイルは既存の `prod/terraform.tfstate` をそのまま参照。
+
+### 5. ジョブ構成: plan + apply の 2 ジョブ
+
+**選択:**
+- `terraform-plan` ジョブ: init → plan → Artifact に tfplan 保存 → Job Summary に出力
+- `terraform-apply` ジョブ: Artifact から tfplan 取得 → `environment: prod-deploy` (承認ゲート) → apply
+- `terraform-destroy` ジョブ: `environment: prod-deploy` (承認ゲート) → destroy
+
+**理由:** plan の結果を人間が確認してから apply する安全なフロー。plan ファイルを Artifact で受け渡すことで、plan 時と apply 時の差分を防ぐ。
+
+## Risks / Trade-offs
+
+- **[State lock 競合]** 複数人が同時に plan/apply すると DynamoDB lock で片方が失敗する → ワークフローの concurrency group で同時実行を防止
+- **[OIDC 設定漏れ]** IAM ロールの trust policy が正しくないと認証失敗 → README にセットアップ手順を記載
+- **[prod 直接操作]** 承認ゲートがあるが、plan なしで apply を選択できてしまう → apply 時にも内部で plan を実行し、差分があれば適用
+- **[container_image 循環参照]** `prod/main.tf` の `container_image` が `module.game_server.ecr_repository_url` を参照 → 初回は ECR が存在しないため plan 失敗の可能性。別途対応が必要
+
+## Open Questions
+
+- ECR への Docker イメージプッシュは別ワークフローで行うか？(今回のスコープ外だが、apply 前にイメージが必要)
+- `prod/main.tf` の `container_image` 循環参照をどう解決するか？ (既存の問題)

--- a/openspec/changes/archive/2026-02-23-terraform-branch-deploy/proposal.md
+++ b/openspec/changes/archive/2026-02-23-terraform-branch-deploy/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+現在 Terraform の環境設定は `local` (LocalStack) と `prod` があるが、任意のブランチのコードを AWS にデプロイする手段がない。手動で Plan → 承認 → Apply できる GitHub Actions ワークフローを追加し、prod 環境へのデプロイを安全に行えるようにする。
+
+## What Changes
+
+- `.github/workflows/deploy.yml` に `workflow_dispatch` 手動トリガーの GitHub Actions ワークフローを追加。任意のブランチを選択して実行可能
+- Plan → GitHub Environment 承認ゲート → Apply の 3 段階フロー
+- OIDC (OpenID Connect) による AWS 認証。シークレットに AWS キーを保存しない
+- 既存の `infrastructure/terraform/environments/prod/` 構成をそのまま使用
+
+## Capabilities
+
+### New Capabilities
+- `github-actions-deploy`: workflow_dispatch 手動トリガーによる Terraform Plan/Apply ワークフロー (OIDC 認証、GitHub Environment 承認ゲート、prod 環境へのデプロイ)
+
+### Modified Capabilities
+
+(なし — 既存の prod Terraform 構成をそのまま使用)
+
+## Non-goals
+
+- 自動デプロイ (push トリガー) は対象外。手動起動のみ
+- ブランチごとの独立環境 (dev 環境等は別チケットで対応)
+- DNS / カスタムドメインの設定
+- LocalStack 環境の変更
+- Terraform モジュール自体の変更
+
+## Impact
+
+- **CI/CD**: `.github/workflows/deploy.yml` 新規ファイル。既存の `test.yml` には影響なし
+- **AWS**: OIDC Identity Provider + IAM ロールの事前設定が必要
+- **GitHub**: Environment (`prod-deploy`) の設定と承認者の登録が必要
+- **既存ファイル**: 変更なし。`infrastructure/terraform/environments/prod/` をそのまま利用
+- 参照スペック: `openspec/specs/game-server-infra/spec.md`, `openspec/specs/tech-architecture.md`

--- a/openspec/changes/archive/2026-02-23-terraform-branch-deploy/specs/github-actions-deploy/spec.md
+++ b/openspec/changes/archive/2026-02-23-terraform-branch-deploy/specs/github-actions-deploy/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: workflow_dispatch 手動トリガー
+`.github/workflows/deploy.yml` は `workflow_dispatch` イベントで起動しなければならない（SHALL）。入力パラメータとして `action` (`plan` / `apply` / `destroy`) を受け付けなければならない（SHALL）。ブランチ選択は GitHub UI のデフォルト機能を使用しなければならない（SHALL）。
+
+#### Scenario: plan アクションを手動実行する
+- **WHEN** GitHub UI で「Run workflow」からブランチを選択し、`action: plan` で実行する
+- **THEN** ワークフローが起動し、`terraform-plan` ジョブが実行される
+
+#### Scenario: apply アクションを手動実行する
+- **WHEN** GitHub UI で `action: apply` を選択して実行する
+- **THEN** `terraform-plan` ジョブ実行後、承認ゲートを経て `terraform-apply` ジョブが実行される
+
+#### Scenario: destroy アクションを手動実行する
+- **WHEN** GitHub UI で `action: destroy` を選択して実行する
+- **THEN** 承認ゲートを経て `terraform-destroy` ジョブが実行される
+
+### Requirement: OIDC による AWS 認証
+ワークフローは GitHub Actions OIDC を使用して AWS に認証しなければならない（SHALL）。`aws-actions/configure-aws-credentials` アクションと `role-to-assume` パラメータを使用しなければならない（SHALL）。AWS アクセスキーを GitHub Secrets に保存してはならない（SHALL NOT）。
+
+#### Scenario: OIDC で一時認証情報を取得する
+- **WHEN** ワークフローが AWS 認証ステップを実行する
+- **THEN** OIDC トークンで一時的な AWS 認証情報が取得され、Terraform コマンドが実行可能になる
+
+#### Scenario: IAM ロール ARN がシークレットから読まれる
+- **WHEN** ワークフローが実行される
+- **THEN** `AWS_ROLE_ARN` シークレットから IAM ロール ARN を取得して使用する
+
+### Requirement: terraform-plan ジョブ
+`terraform-plan` ジョブは `infrastructure/terraform/environments/prod/` に対して `terraform init` と `terraform plan` を実行しなければならない（SHALL）。Plan 結果を GitHub Actions Artifact として保存しなければならない（SHALL）。Plan のサマリーを Job Summary に出力しなければならない（SHALL）。
+
+#### Scenario: plan が成功する
+- **WHEN** `action: plan` または `action: apply` でワークフローが実行される
+- **THEN** `terraform init` → `terraform plan -out=tfplan` が実行され、`tfplan` ファイルが Artifact にアップロードされる
+
+#### Scenario: plan サマリーが Job Summary に表示される
+- **WHEN** `terraform plan` が完了する
+- **THEN** plan の出力が `$GITHUB_STEP_SUMMARY` に書き込まれ、GitHub UI で確認できる
+
+#### Scenario: plan が失敗する
+- **WHEN** Terraform の設定にエラーがある
+- **THEN** ジョブが失敗ステータスで終了し、エラー内容が表示される
+
+### Requirement: terraform-apply ジョブ
+`terraform-apply` ジョブは `action: apply` の場合のみ実行しなければならない（SHALL）。GitHub Environment `prod-deploy` の承認ゲートを通過した後に実行しなければならない（SHALL）。`terraform-plan` ジョブが保存した `tfplan` Artifact を使って `terraform apply` を実行しなければならない（SHALL）。
+
+#### Scenario: 承認後に apply が実行される
+- **WHEN** `terraform-plan` ジョブが成功し、`prod-deploy` Environment の承認者が承認する
+- **THEN** `terraform apply tfplan` が実行される
+
+#### Scenario: 承認が拒否される
+- **WHEN** 承認者が拒否する
+- **THEN** `terraform-apply` ジョブは実行されず、ワークフローが終了する
+
+#### Scenario: plan ジョブが失敗した場合
+- **WHEN** `terraform-plan` ジョブが失敗した状態で apply ジョブに進む
+- **THEN** `terraform-apply` ジョブは実行されない（`needs: terraform-plan` による依存）
+
+### Requirement: terraform-destroy ジョブ
+`terraform-destroy` ジョブは `action: destroy` の場合のみ実行しなければならない（SHALL）。GitHub Environment `prod-deploy` の承認ゲートを通過した後に実行しなければならない（SHALL）。
+
+#### Scenario: 承認後に destroy が実行される
+- **WHEN** `action: destroy` で実行し、承認者が承認する
+- **THEN** `terraform destroy -auto-approve` が実行される
+
+### Requirement: 同時実行の防止
+ワークフローは concurrency グループを設定し、同じ環境への同時実行を防止しなければならない（SHALL）。後から起動したワークフローはキューに入り、先行ワークフローの完了を待たなければならない（SHALL）。
+
+#### Scenario: 同時に 2 つの apply が実行される
+- **WHEN** ユーザー A が apply を実行中に、ユーザー B が apply を実行する
+- **THEN** ユーザー B のワークフローはユーザー A の完了を待ってから実行される
+
+### Requirement: Terraform バージョン固定
+ワークフローは `hashicorp/setup-terraform` アクションで Terraform バージョンを固定しなければならない（SHALL）。バージョンは既存の `required_version` 制約 (`>= 1.0`) に準拠しなければならない（SHALL）。
+
+#### Scenario: 指定バージョンの Terraform が使われる
+- **WHEN** ワークフローが Terraform セットアップステップを実行する
+- **THEN** 指定されたバージョン（例: `1.14.x`）の Terraform がインストールされて使用される

--- a/openspec/changes/archive/2026-02-23-terraform-branch-deploy/tasks.md
+++ b/openspec/changes/archive/2026-02-23-terraform-branch-deploy/tasks.md
@@ -1,0 +1,32 @@
+## 1. ワークフロー基盤
+
+- [x] 1.1 `.github/workflows/deploy.yml` を作成し、`workflow_dispatch` トリガーに `action` 入力 (plan/apply/destroy) を定義する (specs: workflow_dispatch 手動トリガー)
+- [x] 1.2 concurrency グループを設定し、同一環境への同時実行を防止する (specs: 同時実行の防止)
+- [x] 1.3 `permissions: id-token: write` を設定し、OIDC トークン取得を許可する (specs: OIDC による AWS 認証)
+
+## 2. AWS 認証
+
+- [x] 2.1 `aws-actions/configure-aws-credentials` ステップを追加し、OIDC で `AWS_ROLE_ARN` シークレットを使って認証する (specs: OIDC による AWS 認証)
+
+## 3. terraform-plan ジョブ
+
+- [x] 3.1 `hashicorp/setup-terraform` で Terraform バージョンを固定する (specs: Terraform バージョン固定)
+- [x] 3.2 `infrastructure/terraform/environments/prod/` で `terraform init` → `terraform plan -out=tfplan` を実行する (specs: terraform-plan ジョブ)
+- [x] 3.3 plan 結果を `$GITHUB_STEP_SUMMARY` に出力する (specs: terraform-plan ジョブ)
+- [x] 3.4 `tfplan` ファイルを GitHub Actions Artifact としてアップロードする (specs: terraform-plan ジョブ)
+
+## 4. terraform-apply ジョブ
+
+- [x] 4.1 `action == 'apply'` 条件で実行し、`needs: terraform-plan` で依存を設定する (specs: terraform-apply ジョブ)
+- [x] 4.2 `environment: prod-deploy` を設定し、承認ゲートを有効にする (specs: terraform-apply ジョブ)
+- [x] 4.3 Artifact から `tfplan` をダウンロードし、`terraform apply tfplan` を実行する (specs: terraform-apply ジョブ)
+
+## 5. terraform-destroy ジョブ
+
+- [x] 5.1 `action == 'destroy'` 条件で実行し、`environment: prod-deploy` の承認ゲートを設定する (specs: terraform-destroy ジョブ)
+- [x] 5.2 `terraform init` → `terraform destroy -auto-approve` を実行する (specs: terraform-destroy ジョブ)
+
+## 6. 検証
+
+- [x] 6.1 ワークフローの YAML 構文を検証する (`actionlint` またはドライラン)
+- [x] 6.2 GitHub Environment (`prod-deploy`) のセットアップ手順を PR 本文に記載する


### PR DESCRIPTION
## Summary

- GitHub Actions の `workflow_dispatch` による Terraform 手動デプロイワークフローを追加
- 任意のブランチを選択して prod 環境に Plan / Apply / Destroy を実行可能
- OIDC 認証でキーレス、GitHub Environment 承認ゲートで安全なフロー

Closes #125
Closes #123

## Changes

- `.github/workflows/deploy.yml` — 新規ワークフロー
  - `authorize` ジョブ: リポジトリオーナーのみ実行可能
  - `terraform-plan` ジョブ: plan → Job Summary → Artifact
  - `terraform-apply` ジョブ: 承認ゲート → apply
  - `terraform-destroy` ジョブ: destroy plan プレビュー → 承認ゲート → destroy
- `README.md` — デプロイ手順・セットアップガイドを追加

## 初回セットアップ (AWS / GitHub)

### AWS 側
1. IAM OIDC Identity Provider を作成 (Provider URL: `https://token.actions.githubusercontent.com`)
2. IAM ロールを作成 (trust policy で `repo:yu-kod/simoba:*` に制限)
3. S3 バケット `simoba-terraform-state` と DynamoDB テーブル `simoba-terraform-locks` を作成

### GitHub 側
1. Repository Secret に `AWS_ROLE_ARN` を設定
2. Settings > Environments で `prod-deploy` を作成し、Required Reviewers を設定

## Test plan

- [ ] YAML 構文が正しいこと (js-yaml でパース確認済み)
- [ ] `workflow_dispatch` でブランチ選択 + action 選択ができること
- [ ] オーナー以外が実行した場合に `authorize` ジョブで拒否されること
- [ ] `plan` アクションで Job Summary に plan 結果が表示されること
- [ ] `apply` アクションで承認ゲート後に apply が実行されること
- [ ] `destroy` アクションで destroy plan 表示後、承認を経て destroy が実行されること