### PR TITLE
feat: VPC module + game-server Fargate rewrite

### DIFF
--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -29,6 +29,12 @@ provider "aws" {
   }
 }
 
+module "vpc" {
+  source = "../../modules/vpc"
+
+  environment = "prod"
+}
+
 module "static_hosting" {
   source = "../../modules/static-hosting"
 
@@ -40,9 +46,7 @@ module "static_hosting" {
 module "game_server" {
   source = "../../modules/game-server"
 
-  environment        = "prod"
-  vpc_id             = var.vpc_id
-  public_subnet_ids  = var.public_subnet_ids
-  private_subnet_ids = var.private_subnet_ids
-  container_image    = "${module.game_server.ecr_repository_url}:latest"
+  environment       = "prod"
+  vpc_id            = module.vpc.vpc_id
+  public_subnet_ids = module.vpc.public_subnet_ids
 }

--- a/infrastructure/terraform/environments/prod/variables.tf
+++ b/infrastructure/terraform/environments/prod/variables.tf
@@ -8,18 +8,3 @@ variable "bucket_name" {
   description = "S3 bucket name for game client"
   type        = string
 }
-
-variable "vpc_id" {
-  description = "VPC ID for game server infrastructure"
-  type        = string
-}
-
-variable "public_subnet_ids" {
-  description = "Public subnet IDs for ALB"
-  type        = list(string)
-}
-
-variable "private_subnet_ids" {
-  description = "Private subnet IDs for ECS instances"
-  type        = list(string)
-}

--- a/infrastructure/terraform/modules/game-server/main.tf
+++ b/infrastructure/terraform/modules/game-server/main.tf
@@ -1,8 +1,8 @@
 # --- ECR Repository ---
 resource "aws_ecr_repository" "game_server" {
   name                 = "simoba-server-${var.environment}"
-  image_tag_mutability = "MUTABLE"
-  force_delete         = true
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = var.force_delete_ecr
 
   image_scanning_configuration {
     scan_on_push = true
@@ -57,6 +57,14 @@ resource "aws_security_group" "fargate" {
   }
 }
 
+# --- CloudWatch Log Group ---
+resource "aws_cloudwatch_log_group" "game" {
+  count = var.container_image != "" ? 1 : 0
+
+  name              = "/ecs/simoba-game-${var.environment}"
+  retention_in_days = 30
+}
+
 # --- ECS Task Definition (Fargate) ---
 resource "aws_ecs_task_definition" "game" {
   count = var.container_image != "" ? 1 : 0
@@ -86,10 +94,9 @@ resource "aws_ecs_task_definition" "game" {
     logConfiguration = {
       logDriver = "awslogs"
       options = {
-        "awslogs-group"         = "/ecs/simoba-game-${var.environment}"
+        "awslogs-group"         = aws_cloudwatch_log_group.game[0].name
         "awslogs-region"        = data.aws_region.current.name
         "awslogs-stream-prefix" = "colyseus"
-        "awslogs-create-group"  = "true"
       }
     }
   }])

--- a/infrastructure/terraform/modules/game-server/main.tf
+++ b/infrastructure/terraform/modules/game-server/main.tf
@@ -35,50 +35,16 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-# --- IAM Role for EC2 Instances (ECS Container Instances) ---
-resource "aws_iam_role" "ecs_instance" {
-  name = "simoba-ecs-instance-${var.environment}"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
-      Principal = {
-        Service = "ec2.amazonaws.com"
-      }
-    }]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_instance" {
-  role       = aws_iam_role.ecs_instance.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
-}
-
-resource "aws_iam_instance_profile" "ecs_instance" {
-  name = "simoba-ecs-instance-${var.environment}"
-  role = aws_iam_role.ecs_instance.name
-}
-
-# --- Security Group: ALB ---
-resource "aws_security_group" "alb" {
-  name_prefix = "simoba-alb-${var.environment}-"
-  description = "Allow HTTP/HTTPS inbound for ALB"
+# --- Security Group: Fargate Tasks ---
+resource "aws_security_group" "fargate" {
+  name_prefix = "simoba-fargate-${var.environment}-"
+  description = "Allow Colyseus port inbound for Fargate tasks"
   vpc_id      = var.vpc_id
 
   ingress {
-    description = "HTTP"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    description = "HTTPS"
-    from_port   = 443
-    to_port     = 443
+    description = "Colyseus WebSocket"
+    from_port   = var.container_port
+    to_port     = var.container_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -91,142 +57,13 @@ resource "aws_security_group" "alb" {
   }
 }
 
-# --- Security Group: ECS Instances ---
-resource "aws_security_group" "ecs" {
-  name_prefix = "simoba-ecs-${var.environment}-"
-  description = "Allow traffic from ALB only"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    description     = "Colyseus from ALB"
-    from_port       = var.container_port
-    to_port         = var.container_port
-    protocol        = "tcp"
-    security_groups = [aws_security_group.alb.id]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-# --- ALB ---
-resource "aws_lb" "game" {
-  name               = "simoba-game-${var.environment}"
-  internal           = false
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.alb.id]
-  subnets            = var.public_subnet_ids
-}
-
-resource "aws_lb_target_group" "game" {
-  name        = "simoba-game-${var.environment}"
-  port        = var.container_port
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
-  target_type = "instance"
-
-  health_check {
-    path                = "/health"
-    healthy_threshold   = 2
-    unhealthy_threshold = 3
-    timeout             = 5
-    interval            = 10
-    matcher             = "200"
-  }
-
-  stickiness {
-    type            = "lb_cookie"
-    cookie_duration = 86400
-    enabled         = true
-  }
-}
-
-resource "aws_lb_listener" "game_http" {
-  load_balancer_arn = aws_lb.game.arn
-  port              = 80
-  protocol          = "HTTP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.game.arn
-  }
-}
-
-# --- Launch Template for EC2 ---
-data "aws_ssm_parameter" "ecs_ami" {
-  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
-}
-
-resource "aws_launch_template" "ecs" {
-  name_prefix   = "simoba-ecs-${var.environment}-"
-  image_id      = data.aws_ssm_parameter.ecs_ami.value
-  instance_type = var.instance_type
-
-  iam_instance_profile {
-    arn = aws_iam_instance_profile.ecs_instance.arn
-  }
-
-  vpc_security_group_ids = [aws_security_group.ecs.id]
-
-  user_data = base64encode(<<-EOF
-    #!/bin/bash
-    echo "ECS_CLUSTER=${aws_ecs_cluster.game.name}" >> /etc/ecs/ecs.config
-    EOF
-  )
-}
-
-# --- ECS Capacity Provider (EC2 Auto Scaling) ---
-resource "aws_autoscaling_group" "ecs" {
-  name_prefix         = "simoba-ecs-${var.environment}-"
-  vpc_zone_identifier = var.private_subnet_ids
-  min_size            = 0
-  max_size            = 2
-  desired_capacity    = var.desired_count
-
-  launch_template {
-    id      = aws_launch_template.ecs.id
-    version = "$Latest"
-  }
-
-  tag {
-    key                 = "AmazonECSManaged"
-    value               = "true"
-    propagate_at_launch = true
-  }
-}
-
-resource "aws_ecs_capacity_provider" "ec2" {
-  name = "simoba-ec2-${var.environment}"
-
-  auto_scaling_group_provider {
-    auto_scaling_group_arn = aws_autoscaling_group.ecs.arn
-
-    managed_scaling {
-      status          = "ENABLED"
-      target_capacity = 100
-    }
-  }
-}
-
-resource "aws_ecs_cluster_capacity_providers" "game" {
-  cluster_name       = aws_ecs_cluster.game.name
-  capacity_providers = [aws_ecs_capacity_provider.ec2.name]
-
-  default_capacity_provider_strategy {
-    capacity_provider = aws_ecs_capacity_provider.ec2.name
-    weight            = 1
-  }
-}
-
-# --- ECS Task Definition ---
+# --- ECS Task Definition (Fargate) ---
 resource "aws_ecs_task_definition" "game" {
+  count = var.container_image != "" ? 1 : 0
+
   family                   = "simoba-game-${var.environment}"
-  requires_compatibilities = ["EC2"]
-  network_mode             = "bridge"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
   execution_role_arn       = aws_iam_role.ecs_task_execution.arn
   cpu                      = var.cpu
   memory                   = var.memory
@@ -235,12 +72,9 @@ resource "aws_ecs_task_definition" "game" {
     name      = "colyseus"
     image     = var.container_image
     essential = true
-    cpu       = var.cpu
-    memory    = var.memory
 
     portMappings = [{
       containerPort = var.container_port
-      hostPort      = var.container_port
       protocol      = "tcp"
     }]
 
@@ -263,23 +97,19 @@ resource "aws_ecs_task_definition" "game" {
 
 data "aws_region" "current" {}
 
-# --- ECS Service ---
+# --- ECS Service (Fargate + Public IP) ---
 resource "aws_ecs_service" "game" {
+  count = var.container_image != "" ? 1 : 0
+
   name            = "simoba-game-${var.environment}"
   cluster         = aws_ecs_cluster.game.id
-  task_definition = aws_ecs_task_definition.game.arn
+  task_definition = aws_ecs_task_definition.game[0].arn
   desired_count   = var.desired_count
+  launch_type     = "FARGATE"
 
-  capacity_provider_strategy {
-    capacity_provider = aws_ecs_capacity_provider.ec2.name
-    weight            = 1
+  network_configuration {
+    subnets          = var.public_subnet_ids
+    security_groups  = [aws_security_group.fargate.id]
+    assign_public_ip = true
   }
-
-  load_balancer {
-    target_group_arn = aws_lb_target_group.game.arn
-    container_name   = "colyseus"
-    container_port   = var.container_port
-  }
-
-  depends_on = [aws_lb_listener.game_http]
 }

--- a/infrastructure/terraform/modules/game-server/outputs.tf
+++ b/infrastructure/terraform/modules/game-server/outputs.tf
@@ -1,8 +1,3 @@
-output "alb_dns_name" {
-  description = "DNS name of the game server ALB"
-  value       = aws_lb.game.dns_name
-}
-
 output "ecr_repository_url" {
   description = "ECR repository URL for the game server image"
   value       = aws_ecr_repository.game_server.repository_url
@@ -15,5 +10,5 @@ output "ecs_cluster_name" {
 
 output "ecs_service_name" {
   description = "ECS service name"
-  value       = aws_ecs_service.game.name
+  value       = var.container_image != "" ? aws_ecs_service.game[0].name : null
 }

--- a/infrastructure/terraform/modules/game-server/variables.tf
+++ b/infrastructure/terraform/modules/game-server/variables.tf
@@ -9,30 +9,20 @@ variable "vpc_id" {
 }
 
 variable "public_subnet_ids" {
-  description = "List of public subnet IDs for ALB"
-  type        = list(string)
-}
-
-variable "private_subnet_ids" {
-  description = "List of private subnet IDs for ECS instances"
+  description = "List of public subnet IDs for Fargate tasks"
   type        = list(string)
 }
 
 variable "container_image" {
-  description = "Docker image URI for the Colyseus server"
+  description = "Docker image URI for the Colyseus server. Empty string skips ECS Service creation."
   type        = string
+  default     = ""
 }
 
 variable "container_port" {
   description = "Port the Colyseus container listens on"
   type        = number
   default     = 2567
-}
-
-variable "instance_type" {
-  description = "EC2 instance type for ECS cluster"
-  type        = string
-  default     = "t3.small"
 }
 
 variable "desired_count" {
@@ -42,13 +32,13 @@ variable "desired_count" {
 }
 
 variable "cpu" {
-  description = "CPU units for the task (1024 = 1 vCPU)"
+  description = "CPU units for the Fargate task (256, 512, 1024, 2048, 4096)"
   type        = number
-  default     = 512
+  default     = 256
 }
 
 variable "memory" {
-  description = "Memory in MiB for the task"
+  description = "Memory in MiB for the Fargate task"
   type        = number
   default     = 512
 }

--- a/infrastructure/terraform/modules/game-server/variables.tf
+++ b/infrastructure/terraform/modules/game-server/variables.tf
@@ -13,6 +13,12 @@ variable "public_subnet_ids" {
   type        = list(string)
 }
 
+variable "force_delete_ecr" {
+  description = "Whether to force-delete all images in ECR on destroy"
+  type        = bool
+  default     = false
+}
+
 variable "container_image" {
   description = "Docker image URI for the Colyseus server. Empty string skips ECS Service creation."
   type        = string

--- a/infrastructure/terraform/modules/vpc/main.tf
+++ b/infrastructure/terraform/modules/vpc/main.tf
@@ -1,0 +1,54 @@
+# --- VPC ---
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "simoba-${var.environment}"
+  }
+}
+
+# --- Public Subnets ---
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "simoba-public-${var.environment}-${var.availability_zones[count.index]}"
+  }
+}
+
+# --- Internet Gateway ---
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "simoba-igw-${var.environment}"
+  }
+}
+
+# --- Route Table ---
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "simoba-public-rt-${var.environment}"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}

--- a/infrastructure/terraform/modules/vpc/outputs.tf
+++ b/infrastructure/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,9 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = aws_subnet.public[*].id
+}

--- a/infrastructure/terraform/modules/vpc/variables.tf
+++ b/infrastructure/terraform/modules/vpc/variables.tf
@@ -16,7 +16,12 @@ variable "public_subnet_cidrs" {
 }
 
 variable "availability_zones" {
-  description = "Availability zones for subnets"
+  description = "Availability zones for subnets (must match length of public_subnet_cidrs)"
   type        = list(string)
   default     = ["ap-northeast-1a", "ap-northeast-1c"]
+
+  validation {
+    condition     = length(var.availability_zones) == length(var.public_subnet_cidrs)
+    error_message = "availability_zones and public_subnet_cidrs must have the same length."
+  }
 }

--- a/infrastructure/terraform/modules/vpc/variables.tf
+++ b/infrastructure/terraform/modules/vpc/variables.tf
@@ -1,0 +1,22 @@
+variable "environment" {
+  description = "Environment name (dev, prod)"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "availability_zones" {
+  description = "Availability zones for subnets"
+  type        = list(string)
+  default     = ["ap-northeast-1a", "ap-northeast-1c"]
+}

--- a/openspec/changes/archive/2026-02-23-vpc-module/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-23-vpc-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-23

--- a/openspec/changes/archive/2026-02-23-vpc-module/design.md
+++ b/openspec/changes/archive/2026-02-23-vpc-module/design.md
@@ -1,0 +1,51 @@
+## Context
+
+現在の `game-server` モジュールは ALB + ECS on EC2 構成で、VPC/サブネットを外部変数として要求する。VPC は未作成のため `terraform plan` がハングする。また ALB + NAT Gateway で月額 $50+ かかり、個人プロジェクトには過剰。
+
+既存リソース（維持）: ECR, ECS Cluster, Task Execution IAM Role, CloudWatch Logs
+削除対象: ALB, ALB SG, Target Group, Listener, Launch Template, ASG, Capacity Provider, EC2 IAM Role/Instance Profile
+
+## Goals / Non-Goals
+
+**Goals:**
+- VPC を Terraform で管理し、game-server モジュールが自己完結できるようにする
+- game-server を Fargate + public IP に書き換えてコストを最小化する
+- `terraform plan` が入力待ちせず正常に完了する
+
+**Non-Goals:**
+- Private subnet / NAT Gateway
+- SSL/TLS 終端
+- オートスケーリング
+- LocalStack 環境の VPC 対応
+
+## Decisions
+
+### 1. Public subnet のみ、NAT Gateway なし
+**選択:** VPC に public subnet (2 AZ) のみ配置
+**理由:** Fargate タスクに public IP を付与すれば ECR pull も外部通信も直接可能。NAT Gateway ($32/月) が不要。
+**代替案:** Private subnet + NAT → コストが高く、単一タスクには不要
+
+### 2. Fargate (serverless) を使用、EC2 不要
+**選択:** ECS Fargate with `awsvpc` network mode
+**理由:** EC2 インスタンス管理不要、AMI 更新不要、使った分だけ課金。最小構成で ~$10/月。
+**代替案:** ECS on EC2 → EC2 管理が必要、固定コスト高い
+
+### 3. ALB を削除し、Fargate タスクに直接アクセス
+**選択:** Security Group で Colyseus ポート (2567) を直接公開
+**理由:** 単一タスクに ALB は不要。$16/月の削減。WebSocket は Fargate の public IP に直接接続。
+**代替案:** ALB を維持 → コスト増、単一タスクにはオーバースペック
+
+### 4. VPC CIDR は /16、サブネットは /24
+**選択:** VPC `10.0.0.0/16`, Public subnets `10.0.1.0/24`, `10.0.2.0/24`
+**理由:** AWS 推奨のサイズ。将来の拡張に十分な余裕。
+
+### 5. container_image のデフォルト値を設定
+**選択:** `container_image` にデフォルト `""` を設定し、空の場合は ECS Service を作成しない
+**理由:** 初回 `terraform apply` 時にコンテナイメージがまだ存在しない。`count` で条件分岐。
+
+## Risks / Trade-offs
+
+- **[Public IP の変動]** Fargate タスク再起動で IP が変わる → 将来 Elastic IP or DNS で対応（別チケット）
+- **[SSL なし]** 初期は HTTP/WS のみ → 開発段階では許容、本番前に対応
+- **[単一タスク]** 冗長性なし → 個人プロジェクトの初期段階では許容
+- **[既存 state との衝突]** まだ apply されていないので state は空。破壊的変更だがリスクなし

--- a/openspec/changes/archive/2026-02-23-vpc-module/proposal.md
+++ b/openspec/changes/archive/2026-02-23-vpc-module/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`game_server` モジュールが VPC/サブネットを要求するが、VPC がまだ存在しない。また現在の構成は ALB + ECS on EC2 で月額 $50+ かかり、個人プロジェクトにはオーバースペック。VPC を Terraform で管理し、game-server を Fargate + public IP の低コスト構成に書き換える。
+
+## What Changes
+
+- `infrastructure/terraform/modules/vpc/` を新規作成
+  - VPC, Public subnets (2 AZ), Internet Gateway, Route table
+  - Private subnet / NAT Gateway は不要（Fargate が public subnet で動くため）
+- `infrastructure/terraform/modules/game-server/` を Fargate 構成に書き換え
+  - **削除:** ALB, ALB Security Group, Target Group, Listener, Launch Template, ASG, Capacity Provider, EC2 IAM Role/Instance Profile
+  - **維持:** ECR, ECS Cluster, Task Execution IAM Role, CloudWatch Logs
+  - **変更:** Task Definition → Fargate 互換 (`awsvpc` network mode), ECS Service → Fargate + public IP
+- `infrastructure/terraform/environments/prod/main.tf` を更新
+  - VPC モジュール追加、game_server に VPC output を接続
+  - **BREAKING:** `vpc_id`, `public_subnet_ids`, `private_subnet_ids` 変数を削除
+
+## Non-goals
+
+- Private subnet / NAT Gateway（現時点では不要）
+- SSL/TLS 終端（別チケット、Let's Encrypt or ACM）
+- 複数タスクへのスケーリング
+- LocalStack 環境の VPC 対応
+
+## Capabilities
+
+### New Capabilities
+- `vpc-networking`: AWS VPC ネットワーク基盤（VPC, Public subnets, IGW, Route table）
+
+### Modified Capabilities
+- `game-server-infra`: ALB + ECS on EC2 構成から Fargate + public IP 構成に変更
+
+## Impact
+
+- `infrastructure/terraform/modules/vpc/` — 新規モジュール
+- `infrastructure/terraform/modules/game-server/` — 大幅書き換え（ALB/EC2 関連リソース削除）
+- `infrastructure/terraform/environments/prod/main.tf` — VPC モジュール追加、変数削除
+- `infrastructure/terraform/environments/prod/variables.tf` — `vpc_id`, `public_subnet_ids`, `private_subnet_ids` 削除
+- `infrastructure/terraform/environments/prod/terraform.tfvars` — 不要な変数削除
+- 月額コスト: ~$50+ → ~$10（Fargate 最小構成）

--- a/openspec/changes/archive/2026-02-23-vpc-module/specs/game-server-infra/spec.md
+++ b/openspec/changes/archive/2026-02-23-vpc-module/specs/game-server-infra/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: ECS on EC2 Terraform モジュール
 `infrastructure/terraform/modules/game-server/` に ECS Fargate デプロイ用の Terraform モジュールを提供しなければならない（SHALL）。ECS クラスター、Fargate タスク定義、ECS Service を定義しなければならない（SHALL）。タスクは `awsvpc` network mode で public IP を付与しなければならない（SHALL）。コンテナイメージが未指定の場合、ECS Service を作成しないこと（SHALL）。
@@ -21,3 +21,13 @@ Fargate タスク用のセキュリティグループを定義しなければな
 #### Scenario: 外部から Colyseus ポートにアクセスできる
 - **WHEN** 外部から Fargate タスクのポート 2567 に接続を試みる
 - **THEN** 接続が許可される
+
+## REMOVED Requirements
+
+### Requirement: ALB + WebSocket 対応
+**Reason**: Fargate + public IP 構成に変更。ALB を削除しコストを削減。
+**Migration**: クライアントは Fargate タスクの public IP に直接 WebSocket 接続する。
+
+### Requirement: docker-compose による Colyseus ローカル起動
+**Reason**: 本変更のスコープ外。ローカル開発環境は別途対応。
+**Migration**: なし（既存の docker-compose は変更しない）

--- a/openspec/changes/archive/2026-02-23-vpc-module/specs/vpc-networking/spec.md
+++ b/openspec/changes/archive/2026-02-23-vpc-module/specs/vpc-networking/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: VPC Terraform モジュール
+`infrastructure/terraform/modules/vpc/` に VPC ネットワーク基盤の Terraform モジュールを提供しなければならない（SHALL）。VPC、Public subnets（2 AZ）、Internet Gateway、Route table を定義しなければならない（SHALL）。
+
+#### Scenario: Terraform モジュールが有効な構成を生成する
+- **WHEN** `terraform plan` を VPC モジュールに対して実行する
+- **THEN** エラーなく実行計画が生成される
+
+#### Scenario: Public subnets が 2 AZ に配置される
+- **WHEN** VPC モジュールが適用される
+- **THEN** 2 つの異なるアベイラビリティゾーンに public subnet が作成される
+
+### Requirement: Internet Gateway によるインターネット接続
+VPC に Internet Gateway をアタッチし、public subnet からインターネットにアクセスできなければならない（SHALL）。
+
+#### Scenario: Public subnet のリソースがインターネットにアクセスできる
+- **WHEN** public subnet に配置された Fargate タスクが外部 API にリクエストを送信する
+- **THEN** Internet Gateway 経由で通信が成功する
+
+### Requirement: モジュール出力
+VPC モジュールは `vpc_id` と `public_subnet_ids` を output として公開しなければならない（SHALL）。
+
+#### Scenario: 他のモジュールが VPC output を参照できる
+- **WHEN** game-server モジュールが VPC モジュールの output を変数として受け取る
+- **THEN** `vpc_id` と `public_subnet_ids` が正しく渡される

--- a/openspec/changes/archive/2026-02-23-vpc-module/tasks.md
+++ b/openspec/changes/archive/2026-02-23-vpc-module/tasks.md
@@ -1,0 +1,24 @@
+## 1. VPC モジュール作成
+
+- [x] 1.1 `infrastructure/terraform/modules/vpc/` を新規作成（`main.tf`, `variables.tf`, `outputs.tf`）
+- [x] 1.2 VPC リソース（CIDR `10.0.0.0/16`）を定義
+- [x] 1.3 Public subnets（2 AZ: `10.0.1.0/24`, `10.0.2.0/24`）を定義
+- [x] 1.4 Internet Gateway + Route table（`0.0.0.0/0` → IGW）を定義
+- [x] 1.5 outputs に `vpc_id`, `public_subnet_ids` を公開
+
+## 2. game-server モジュール書き換え
+
+- [x] 2.1 ALB 関連リソースを削除（`aws_lb`, `aws_lb_target_group`, `aws_lb_listener`, `aws_security_group.alb`）
+- [x] 2.2 EC2 関連リソースを削除（`aws_launch_template`, `aws_autoscaling_group`, `aws_ecs_capacity_provider`, `aws_ecs_cluster_capacity_providers`, EC2 IAM Role/Instance Profile）
+- [x] 2.3 Security Group を Fargate 用に書き換え（ポート 2567 を直接公開）
+- [x] 2.4 Task Definition を Fargate 互換に変更（`awsvpc`, `FARGATE`）
+- [x] 2.5 ECS Service を Fargate + public IP 構成に変更（`network_configuration` 追加）
+- [x] 2.6 `container_image` が空の場合 Service/Task を作成しない（`count` 条件分岐）
+- [x] 2.7 variables.tf を更新（`private_subnet_ids`, `instance_type` 削除、`public_subnet_ids` の説明更新）
+- [x] 2.8 outputs.tf を更新（`alb_dns_name` 削除）
+
+## 3. prod 環境の更新
+
+- [x] 3.1 `prod/main.tf` に VPC モジュールを追加し、game_server に output を接続
+- [x] 3.2 `prod/variables.tf` から `vpc_id`, `public_subnet_ids`, `private_subnet_ids` を削除
+- [x] 3.3 `prod/terraform.tfvars` から不要な変数を削除（存在する場合）

--- a/openspec/specs/vpc-networking/spec.md
+++ b/openspec/specs/vpc-networking/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: VPC Terraform モジュール
+`infrastructure/terraform/modules/vpc/` に VPC ネットワーク基盤の Terraform モジュールを提供しなければならない（SHALL）。VPC、Public subnets（2 AZ）、Internet Gateway、Route table を定義しなければならない（SHALL）。
+
+#### Scenario: Terraform モジュールが有効な構成を生成する
+- **WHEN** `terraform plan` を VPC モジュールに対して実行する
+- **THEN** エラーなく実行計画が生成される
+
+#### Scenario: Public subnets が 2 AZ に配置される
+- **WHEN** VPC モジュールが適用される
+- **THEN** 2 つの異なるアベイラビリティゾーンに public subnet が作成される
+
+### Requirement: Internet Gateway によるインターネット接続
+VPC に Internet Gateway をアタッチし、public subnet からインターネットにアクセスできなければならない（SHALL）。
+
+#### Scenario: Public subnet のリソースがインターネットにアクセスできる
+- **WHEN** public subnet に配置された Fargate タスクが外部 API にリクエストを送信する
+- **THEN** Internet Gateway 経由で通信が成功する
+
+### Requirement: モジュール出力
+VPC モジュールは `vpc_id` と `public_subnet_ids` を output として公開しなければならない（SHALL）。
+
+#### Scenario: 他のモジュールが VPC output を参照できる
+- **WHEN** game-server モジュールが VPC モジュールの output を変数として受け取る
+- **THEN** `vpc_id` と `public_subnet_ids` が正しく渡される


### PR DESCRIPTION
## Summary
- Add VPC Terraform module (VPC, 2 public subnets in ap-northeast-1a/1c, Internet Gateway, route table)
- Rewrite game-server module from ALB + ECS on EC2 to Fargate + public IP
- Estimated cost reduction: ~$50/mo → ~$10/mo (no ALB, no NAT, no EC2)

## Changes

### New: `infrastructure/terraform/modules/vpc/`
- VPC (`10.0.0.0/16`), 2 public subnets, IGW, route table

### Rewritten: `infrastructure/terraform/modules/game-server/`
- **Removed:** ALB, ALB SG, Target Group, Listener, Launch Template, ASG, Capacity Provider, EC2 IAM Role/Instance Profile
- **Added:** Fargate-compatible Task Definition (`awsvpc`), ECS Service with `assign_public_ip = true`
- **Added:** Count guard — ECS Service/Task skipped when `container_image` is empty

### Updated: `infrastructure/terraform/environments/prod/`
- Added `module.vpc`, wired outputs to `game_server`
- Removed `vpc_id`, `public_subnet_ids`, `private_subnet_ids` variables

## Test plan
- [ ] `terraform init` succeeds with new module structure
- [ ] `terraform plan` completes without input prompts or errors
- [ ] Plan shows VPC, subnets, IGW, ECR, ECS cluster (no ALB, no EC2)
- [ ] ECS Service is skipped (no container image configured)
- [ ] `terraform apply` creates infrastructure successfully

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)