### PR TITLE
feat: game server deploy workflow (Closes #129)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,9 +21,14 @@ openspec/
 .claude/
 
 # Frontend (not needed for server build)
+src/
 public/
 index.html
 vite.config.ts
+tsconfig.json
+tsconfig.node.json
+package.json
+package-lock.json
 
 # Environment
 .env

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+node_modules
+.git
+.gitignore
+dist
+*.md
+LICENSE
+
+# Tests
+tests/
+e2e/
+playwright.config.ts
+playwright-report/
+test-results/
+coverage/
+
+# Infrastructure & config
+infrastructure/
+openspec/
+.github/
+.vscode/
+.claude/
+
+# Frontend (not needed for server build)
+public/
+index.html
+vite.config.ts
+
+# Environment
+.env
+.env.*
+*.log

--- a/.github/workflows/deploy-game-server.yml
+++ b/.github/workflows/deploy-game-server.yml
@@ -70,6 +70,8 @@ jobs:
             --query 'taskDefinition' \
             --output json 2>/dev/null || echo "")
 
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
           if [ -n "$EXISTING" ]; then
             # Update image in existing task definition
             NEW_DEF=$(echo "$EXISTING" | jq \
@@ -85,7 +87,7 @@ jobs:
             "networkMode": "awsvpc",
             "cpu": "256",
             "memory": "512",
-            "executionRoleArn": "simoba-ecs-exec-prod",
+            "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/simoba-ecs-exec-prod",
             "containerDefinitions": [{
               "name": "${CONTAINER_NAME}",
               "image": "${IMAGE_URI}",
@@ -138,6 +140,7 @@ jobs:
           fi
 
       - name: Deploy Summary
+        if: always()
         env:
           IMAGE_URI: ${{ steps.build.outputs.image_uri }}
           TASK_DEF_ARN: ${{ steps.task-def.outputs.task_def_arn }}

--- a/.github/workflows/deploy-game-server.yml
+++ b/.github/workflows/deploy-game-server.yml
@@ -1,0 +1,154 @@
+name: Deploy Game Server
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-game-server
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-1
+  ECS_CLUSTER: simoba-game-prod
+  ECS_SERVICE: simoba-game-prod
+  TASK_FAMILY: simoba-game-prod
+  CONTAINER_NAME: colyseus
+
+jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check actor is repository owner
+        if: github.actor != github.repository_owner
+        run: |
+          echo "::error::Only the repository owner can run this workflow."
+          exit 1
+
+  build-and-deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    needs: authorize
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: deploy-game-server-${{ github.run_id }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        id: build
+        env:
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY_URL }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE_URI="${ECR_REPOSITORY}:${IMAGE_TAG}"
+          docker build -f server/Dockerfile -t "${IMAGE_URI}" .
+          docker push "${IMAGE_URI}"
+          echo "image_uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
+
+      - name: Register new task definition
+        id: task-def
+        env:
+          IMAGE_URI: ${{ steps.build.outputs.image_uri }}
+        run: |
+          # Try to get existing task definition
+          EXISTING=$(aws ecs describe-task-definition \
+            --task-definition "$TASK_FAMILY" \
+            --query 'taskDefinition' \
+            --output json 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING" ]; then
+            # Update image in existing task definition
+            NEW_DEF=$(echo "$EXISTING" | jq \
+              --arg image "$IMAGE_URI" \
+              '.containerDefinitions[0].image = $image |
+               del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)')
+          else
+            # Create minimal task definition for first deploy
+            NEW_DEF=$(cat <<TASKDEF
+          {
+            "family": "${TASK_FAMILY}",
+            "requiresCompatibilities": ["FARGATE"],
+            "networkMode": "awsvpc",
+            "cpu": "256",
+            "memory": "512",
+            "executionRoleArn": "simoba-ecs-exec-prod",
+            "containerDefinitions": [{
+              "name": "${CONTAINER_NAME}",
+              "image": "${IMAGE_URI}",
+              "essential": true,
+              "portMappings": [{"containerPort": 2567, "protocol": "tcp"}],
+              "environment": [{"name": "PORT", "value": "2567"}],
+              "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                  "awslogs-group": "/ecs/simoba-game-prod",
+                  "awslogs-region": "${AWS_REGION}",
+                  "awslogs-stream-prefix": "colyseus",
+                  "awslogs-create-group": "true"
+                }
+              }
+            }]
+          }
+          TASKDEF
+          )
+          fi
+
+          # Register new task definition revision
+          TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "$NEW_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+          echo "task_def_arn=${TASK_DEF_ARN}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to ECS
+        env:
+          TASK_DEF_ARN: ${{ steps.task-def.outputs.task_def_arn }}
+        run: |
+          # Check if service exists
+          SERVICE_EXISTS=$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --query 'services[?status==`ACTIVE`].serviceName' \
+            --output text 2>/dev/null || echo "")
+
+          if [ -n "$SERVICE_EXISTS" ]; then
+            aws ecs update-service \
+              --cluster "$ECS_CLUSTER" \
+              --service "$ECS_SERVICE" \
+              --task-definition "$TASK_DEF_ARN" \
+              --force-new-deployment \
+              --no-cli-pager
+          else
+            echo "::warning::ECS Service '${ECS_SERVICE}' does not exist. Create it via Terraform first (set container_image variable)."
+            exit 1
+          fi
+
+      - name: Deploy Summary
+        env:
+          IMAGE_URI: ${{ steps.build.outputs.image_uri }}
+          TASK_DEF_ARN: ${{ steps.task-def.outputs.task_def_arn }}
+        run: |
+          echo "## Game Server Deploy Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Item | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Branch** | \`${{ github.ref_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Commit** | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Image** | \`${IMAGE_URI}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Task Definition** | \`${TASK_DEF_ARN}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **ECS Cluster** | \`${ECS_CLUSTER}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **ECS Service** | \`${ECS_SERVICE}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ Terraform の Plan / Apply / Destroy を手動で実行する。
 
 フロー: Checkout → `npm ci` → `npm run build` → S3 sync → CloudFront invalidation
 
+### Game Server Deploy
+
+ゲームサーバーの Docker イメージをビルドし、ECR にプッシュ、ECS サービスを再デプロイする。
+
+1. **Actions** タブ → **Deploy Game Server** → **Run workflow**
+2. デプロイしたいブランチを選択して実行
+
+フロー: Checkout → OIDC 認証 → ECR ログイン → Docker ビルド & プッシュ (SHA タグ) → タスク定義更新 → ECS force-new-deployment
+
 ### 初回セットアップ
 
 **AWS 側:**
@@ -60,13 +69,14 @@ Terraform の Plan / Apply / Destroy を手動で実行する。
 | `AWS_ROLE_ARN` | OIDC で引き受ける IAM ロールの ARN |
 | `S3_BUCKET_NAME` | フロントエンドデプロイ先の S3 バケット名 |
 | `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront ディストリビューション ID |
+| `ECR_REPOSITORY_URL` | ECR リポジトリ URL (ゲームサーバーデプロイ用) |
 
 Environment `prod-deploy` を作成し、Required Reviewers を設定。
 
 ### 制限
 
 - リポジトリオーナーのみ実行可能
-- 同時実行は concurrency グループで防止（Terraform / Frontend それぞれ独立）
+- 同時実行は concurrency グループで防止（Terraform / Frontend / Game Server それぞれ独立）
 
 ## Project Structure
 

--- a/openspec/changes/archive/2026-02-23-game-server-deploy/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-23-game-server-deploy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-23

--- a/openspec/changes/archive/2026-02-23-game-server-deploy/design.md
+++ b/openspec/changes/archive/2026-02-23-game-server-deploy/design.md
@@ -1,0 +1,50 @@
+## Context
+
+フロントエンドデプロイ (`deploy-frontend.yml`) は S3 sync + CloudFront invalidation で完成済み。ゲームサーバー側は Terraform で ECR リポジトリ・ECS Fargate クラスター・タスク定義の基盤が構築済みだが、Docker イメージのビルド・プッシュ・ECS 再デプロイのパイプラインが存在しない。
+
+既存リソース:
+- `server/Dockerfile` — マルチステージビルド（builder + production）
+- `infrastructure/terraform/modules/game-server/main.tf` — ECR, ECS Cluster, Fargate Task Definition, Service
+- `.github/workflows/deploy-frontend.yml` — 参考パターン（authorize + OIDC + deploy）
+
+## Goals / Non-Goals
+
+**Goals:**
+- 手動トリガーで任意ブランチからゲームサーバーをデプロイ可能にする
+- Docker イメージビルド → ECR プッシュ → ECS 再デプロイの一連のフローを自動化
+- `deploy-frontend.yml` と一貫したパターン（authorize, OIDC, Job Summary）
+
+**Non-Goals:**
+- 自動デプロイ（push/merge トリガー）
+- Blue/Green や Canary デプロイ戦略
+- サービスディスカバリ・DNS 更新
+- ヘルスチェックや rollback の自動化
+
+## Decisions
+
+### 1. ECS デプロイ方式: aws ecs update-service --force-new-deployment
+
+**選択**: AWS CLI で直接タスク定義登録 + サービス更新
+**理由**: Terraform はインフラ定義用であり、デプロイのたびに `terraform apply` を走らせるのは重い。AWS CLI の `register-task-definition` + `update-service` が最もシンプル。
+**代替案**: `aws-actions/amazon-ecs-deploy-task-definition` アクション — 便利だが、タスク定義 JSON の管理が複雑になる。CLI で十分。
+
+### 2. イメージタグ戦略: コミット SHA
+
+**選択**: `${{ github.sha }}` をイメージタグに使用（ECR は IMMUTABLE タグ設定済み）
+**理由**: IMMUTABLE タグのため `latest` は上書きできない。SHA タグならどのコミットのイメージか追跡可能。
+**代替案**: セマンティックバージョニング — 手動管理が必要でオーバーヘッド大。
+
+### 3. タスク定義の更新方法: 現在の定義を取得して image だけ差し替え
+
+**選択**: `aws ecs describe-task-definition` で現在の定義を取得 → `containerDefinitions[0].image` を新イメージに差し替え → `register-task-definition` で新リビジョン登録
+**理由**: Terraform で管理されているタスク定義の設定（CPU, メモリ, ポート, ログ設定等）を壊さずにイメージだけ更新できる。
+
+### 4. ビルドコンテキスト: リポジトリルート
+
+**選択**: Docker ビルドコンテキストはリポジトリルート、Dockerfile は `server/Dockerfile`
+**理由**: Dockerfile が `COPY shared/ ./shared/` でルートからの相対パスを使っているため。`.dockerignore` でコンテキストサイズを制限。
+
+## Risks / Trade-offs
+
+- **[Terraform とのドリフト]** → CLI でタスク定義を更新すると Terraform state とずれる。次の `terraform apply` で上書きされる可能性。→ Terraform 側の `container_image` 変数を空にしておけばタスク定義自体が Terraform 管理外（count=0）。デプロイ時に CLI で直接作成する。
+- **[初回デプロイ]** → ECS Service が存在しない初回は `update-service` が失敗する。→ 初回は `create-service` を使うか、Terraform で `container_image` を指定して先にサービスを作っておく。ワークフローでは存在確認をして分岐。

--- a/openspec/changes/archive/2026-02-23-game-server-deploy/proposal.md
+++ b/openspec/changes/archive/2026-02-23-game-server-deploy/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Terraform で ECR/ECS Fargate 基盤は構築済みだが、Docker イメージのビルド・プッシュと ECS サービス更新を行うデプロイパイプラインが存在しない。フロントエンドの S3 デプロイワークフロー (`deploy-frontend.yml`) は完成しており、ゲームサーバー側にも同等の CI/CD が必要。
+
+## What Changes
+
+- GitHub Actions ワークフロー `deploy-game-server.yml` を新規作成
+  - `workflow_dispatch` で手動トリガー（ブランチ選択可能）
+  - Docker イメージビルド & ECR プッシュ
+  - ECS サービスの新タスク定義で再デプロイ（force new deployment）
+  - OIDC 認証（既存 IAM ロール再利用）
+  - オーナーのみ実行可能（authorize ジョブ）
+  - Job Summary でデプロイ結果表示
+- `.dockerignore` を新規作成（ビルドコンテキスト最適化）
+
+## Non-goals
+
+- Dockerfile の変更（既に `server/Dockerfile` が存在）
+- 自動デプロイ（push トリガー）— 手動 dispatch のみ
+- Blue/Green や Rolling デプロイ戦略 — Fargate デフォルトで十分
+- サービスディスカバリや DNS 更新 — Phase 2+ の別チケット
+
+## Capabilities
+
+### New Capabilities
+- `game-server-deploy-workflow`: ゲームサーバーの Docker ビルド・ECR プッシュ・ECS 再デプロイを行う GitHub Actions ワークフロー
+
+### Modified Capabilities
+
+(なし)
+
+## Impact
+
+- `.github/workflows/deploy-game-server.yml` — 新規ファイル
+- `.dockerignore` — 新規ファイル
+- `README.md` — デプロイ手順セクション更新
+- AWS Secrets: `AWS_ROLE_ARN` (既存), `ECR_REPOSITORY_URL` (新規)
+- 既存の `server/Dockerfile` と `infrastructure/terraform/modules/game-server/` に依存

--- a/openspec/changes/archive/2026-02-23-game-server-deploy/specs/game-server-deploy-workflow/spec.md
+++ b/openspec/changes/archive/2026-02-23-game-server-deploy/specs/game-server-deploy-workflow/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: ゲームサーバーデプロイワークフロー
+`.github/workflows/deploy-game-server.yml` に GitHub Actions ワークフローを提供しなければならない（SHALL）。`workflow_dispatch` で手動トリガーし、任意のブランチから実行可能でなければならない（SHALL）。
+
+#### Scenario: ワークフローが手動トリガーで実行できる
+- **WHEN** GitHub Actions UI から `Deploy Game Server` ワークフローを手動実行する
+- **THEN** 選択したブランチのコードでワークフローが開始される
+
+### Requirement: オーナー認可
+リポジトリオーナー以外のユーザーがワークフローを実行した場合、エラーで中断しなければならない（SHALL）。
+
+#### Scenario: オーナー以外が実行するとエラーになる
+- **WHEN** リポジトリオーナー以外のユーザーがワークフローを実行する
+- **THEN** `authorize` ジョブがエラーで失敗し、デプロイは実行されない
+
+### Requirement: Docker イメージビルドと ECR プッシュ
+`server/Dockerfile` を使って Docker イメージをビルドし、ECR リポジトリにプッシュしなければならない（SHALL）。イメージタグには Git コミット SHA を使用しなければならない（SHALL）。
+
+#### Scenario: Docker イメージが ECR にプッシュされる
+- **WHEN** デプロイワークフローのビルドステップが完了する
+- **THEN** ECR リポジトリに `<commit-sha>` タグ付きのイメージが存在する
+
+### Requirement: ECS サービス再デプロイ
+新しいタスク定義を登録し、ECS サービスを更新して新しいタスクを起動しなければならない（SHALL）。`--force-new-deployment` で強制再デプロイしなければならない（SHALL）。
+
+#### Scenario: ECS サービスが新しいイメージで更新される
+- **WHEN** ECR プッシュ後に ECS デプロイステップが実行される
+- **THEN** 新しいタスク定義が登録され、ECS サービスが更新される
+
+### Requirement: OIDC 認証
+AWS 認証は OIDC を使用し、`aws-actions/configure-aws-credentials@v4` でキーレス認証を行わなければならない（SHALL）。
+
+#### Scenario: OIDC でキーレス認証される
+- **WHEN** AWS Credentials ステップが実行される
+- **THEN** `secrets.AWS_ROLE_ARN` を使って OIDC トークン交換で一時認証情報を取得する
+
+### Requirement: デプロイサマリー
+ワークフロー完了時に GitHub Job Summary にデプロイ結果を表示しなければならない（SHALL）。ブランチ名、コミット SHA、イメージ URI、ECS クラスター・サービス名を含めなければならない（SHALL）。
+
+#### Scenario: Job Summary にデプロイ情報が表示される
+- **WHEN** デプロイワークフローが正常完了する
+- **THEN** Job Summary にブランチ、コミット SHA、イメージ URI、ECS 情報のテーブルが表示される
+
+### Requirement: .dockerignore
+プロジェクトルートに `.dockerignore` を配置し、ビルドに不要なファイルを除外しなければならない（SHALL）。`node_modules`、`.git`、`dist`、テストファイル、インフラコードを除外しなければならない（SHALL）。
+
+#### Scenario: Docker ビルドコンテキストが最適化される
+- **WHEN** Docker イメージをビルドする
+- **THEN** `.dockerignore` で指定されたファイルがビルドコンテキストに含まれない

--- a/openspec/changes/archive/2026-02-23-game-server-deploy/tasks.md
+++ b/openspec/changes/archive/2026-02-23-game-server-deploy/tasks.md
@@ -1,0 +1,15 @@
+## 1. ビルドコンテキスト最適化
+
+- [x] 1.1 `.dockerignore` をプロジェクトルートに作成（node_modules, .git, dist, tests, infrastructure, openspec 等を除外）
+
+## 2. GitHub Actions ワークフロー
+
+- [x] 2.1 `.github/workflows/deploy-game-server.yml` を作成 — workflow_dispatch, concurrency, permissions, env 定義
+- [x] 2.2 authorize ジョブ — オーナー以外のユーザーをブロック
+- [x] 2.3 build-and-deploy ジョブ — checkout, OIDC 認証, ECR ログイン, Docker ビルド & プッシュ（SHA タグ）
+- [x] 2.4 ECS デプロイステップ — 現タスク定義取得 → image 差し替え → 新リビジョン登録 → サービス更新（force-new-deployment）
+- [x] 2.5 Job Summary ステップ — ブランチ、コミット SHA、イメージ URI、ECS クラスター・サービス名を表示
+
+## 3. ドキュメント更新
+
+- [x] 3.1 `README.md` にゲームサーバーデプロイの手順と必要な Secrets (`ECR_REPOSITORY_URL`) を追記

--- a/openspec/specs/game-server-deploy-workflow/spec.md
+++ b/openspec/specs/game-server-deploy-workflow/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: ゲームサーバーデプロイワークフロー
+`.github/workflows/deploy-game-server.yml` に GitHub Actions ワークフローを提供しなければならない（SHALL）。`workflow_dispatch` で手動トリガーし、任意のブランチから実行可能でなければならない（SHALL）。
+
+#### Scenario: ワークフローが手動トリガーで実行できる
+- **WHEN** GitHub Actions UI から `Deploy Game Server` ワークフローを手動実行する
+- **THEN** 選択したブランチのコードでワークフローが開始される
+
+### Requirement: オーナー認可
+リポジトリオーナー以外のユーザーがワークフローを実行した場合、エラーで中断しなければならない（SHALL）。
+
+#### Scenario: オーナー以外が実行するとエラーになる
+- **WHEN** リポジトリオーナー以外のユーザーがワークフローを実行する
+- **THEN** `authorize` ジョブがエラーで失敗し、デプロイは実行されない
+
+### Requirement: Docker イメージビルドと ECR プッシュ
+`server/Dockerfile` を使って Docker イメージをビルドし、ECR リポジトリにプッシュしなければならない（SHALL）。イメージタグには Git コミット SHA を使用しなければならない（SHALL）。
+
+#### Scenario: Docker イメージが ECR にプッシュされる
+- **WHEN** デプロイワークフローのビルドステップが完了する
+- **THEN** ECR リポジトリに `<commit-sha>` タグ付きのイメージが存在する
+
+### Requirement: ECS サービス再デプロイ
+新しいタスク定義を登録し、ECS サービスを更新して新しいタスクを起動しなければならない（SHALL）。`--force-new-deployment` で強制再デプロイしなければならない（SHALL）。
+
+#### Scenario: ECS サービスが新しいイメージで更新される
+- **WHEN** ECR プッシュ後に ECS デプロイステップが実行される
+- **THEN** 新しいタスク定義が登録され、ECS サービスが更新される
+
+### Requirement: OIDC 認証
+AWS 認証は OIDC を使用し、`aws-actions/configure-aws-credentials@v4` でキーレス認証を行わなければならない（SHALL）。
+
+#### Scenario: OIDC でキーレス認証される
+- **WHEN** AWS Credentials ステップが実行される
+- **THEN** `secrets.AWS_ROLE_ARN` を使って OIDC トークン交換で一時認証情報を取得する
+
+### Requirement: デプロイサマリー
+ワークフロー完了時に GitHub Job Summary にデプロイ結果を表示しなければならない（SHALL）。ブランチ名、コミット SHA、イメージ URI、ECS クラスター・サービス名を含めなければならない（SHALL）。
+
+#### Scenario: Job Summary にデプロイ情報が表示される
+- **WHEN** デプロイワークフローが正常完了する
+- **THEN** Job Summary にブランチ、コミット SHA、イメージ URI、ECS 情報のテーブルが表示される
+
+### Requirement: .dockerignore
+プロジェクトルートに `.dockerignore` を配置し、ビルドに不要なファイルを除外しなければならない（SHALL）。`node_modules`、`.git`、`dist`、テストファイル、インフラコードを除外しなければならない（SHALL）。
+
+#### Scenario: Docker ビルドコンテキストが最適化される
+- **WHEN** Docker イメージをビルドする
+- **THEN** `.dockerignore` で指定されたファイルがビルドコンテキストに含まれない


### PR DESCRIPTION
## Summary
- ゲームサーバーの Docker ビルド → ECR プッシュ → ECS 再デプロイを行う GitHub Actions ワークフロー (`deploy-game-server.yml`) を追加
- `.dockerignore` を追加してビルドコンテキストを最適化
- README に Game Server Deploy セクションと `ECR_REPOSITORY_URL` シークレットを追記
- `deploy.yml` の `terraform plan` exit code キャプチャを修正 — `tee` パイプ経由の `PIPESTATUS` が不正確だった問題を解消し、apply アクション選択時に apply ジョブが正しく起動するようにした

## Test plan
- [ ] GitHub Actions UI から `Deploy Game Server` ワークフローが表示される
- [ ] ワークフロー YAML の構文が正しい (`actionlint` or GitHub UI で確認)
- [ ] `.dockerignore` が Docker ビルド時に不要ファイルを除外する
- [ ] README の Deploy セクションが正しく表示される
- [ ] Terraform Deploy ワークフローで `apply` 選択時に承認ゲート → apply が実行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)