### PR TITLE
fix: remove website_endpoint output after S3 OAC migration

### DIFF
--- a/infrastructure/terraform/environments/prod/outputs.tf
+++ b/infrastructure/terraform/environments/prod/outputs.tf
@@ -8,11 +8,6 @@ output "bucket_name" {
   value       = module.static_hosting.bucket_name
 }
 
-output "website_endpoint" {
-  description = "S3 website endpoint URL"
-  value       = module.static_hosting.website_endpoint
-}
-
 output "cloudfront_domain" {
   description = "CloudFront distribution domain name"
   value       = module.static_hosting.cloudfront_domain

--- a/infrastructure/terraform/modules/static-hosting/outputs.tf
+++ b/infrastructure/terraform/modules/static-hosting/outputs.tf
@@ -8,11 +8,6 @@ output "bucket_name" {
   value       = aws_s3_bucket.game_client.id
 }
 
-output "website_endpoint" {
-  description = "S3 website endpoint URL"
-  value       = aws_s3_bucket_website_configuration.game_client.website_endpoint
-}
-
 output "cloudfront_domain" {
   description = "CloudFront distribution domain name"
   value       = var.enable_cloudfront ? aws_cloudfront_distribution.game_cdn[0].domain_name : null


### PR DESCRIPTION
## Summary
- S3 OAC 移行で `aws_s3_bucket_website_configuration` リソースを削除したが、`outputs.tf` にまだ参照が残っていた
- モジュール側 (`static-hosting/outputs.tf`) と環境側 (`prod/outputs.tf`) の両方から `website_endpoint` output を削除

## Context
PR #136 マージ後に `terraform plan` が失敗するため、cherry-pick で修正。

## Test Plan
- [ ] `terraform plan` がエラーなく実行できること