### PR TITLE
fix: use plan-time booleans for DNS record count

### DIFF
--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -82,10 +82,12 @@ module "game_server" {
 module "dns" {
   source = "../../modules/dns"
 
-  hosted_zone_id                 = var.hosted_zone_id
-  domain_name                    = var.domain_name
+  hosted_zone_id                  = var.hosted_zone_id
+  domain_name                     = var.domain_name
+  create_frontend_record          = true
   cloudfront_distribution_domain  = module.static_hosting.cloudfront_domain
   cloudfront_distribution_zone_id = module.static_hosting.cloudfront_hosted_zone_id
-  alb_dns_name                   = module.game_server.alb_dns_name
-  alb_zone_id                    = module.game_server.alb_zone_id
+  create_api_record               = true
+  alb_dns_name                    = module.game_server.alb_dns_name
+  alb_zone_id                     = module.game_server.alb_zone_id
 }

--- a/infrastructure/terraform/modules/dns/main.tf
+++ b/infrastructure/terraform/modules/dns/main.tf
@@ -1,6 +1,6 @@
 # --- Route 53: Frontend → CloudFront ---
 resource "aws_route53_record" "frontend" {
-  count = var.cloudfront_distribution_domain != "" ? 1 : 0
+  count = var.create_frontend_record ? 1 : 0
 
   zone_id = var.hosted_zone_id
   name    = var.domain_name
@@ -15,7 +15,7 @@ resource "aws_route53_record" "frontend" {
 
 # --- Route 53: API → ALB ---
 resource "aws_route53_record" "api" {
-  count = var.alb_dns_name != "" ? 1 : 0
+  count = var.create_api_record ? 1 : 0
 
   zone_id = var.hosted_zone_id
   name    = "api.${var.domain_name}"

--- a/infrastructure/terraform/modules/dns/variables.tf
+++ b/infrastructure/terraform/modules/dns/variables.tf
@@ -8,6 +8,12 @@ variable "domain_name" {
   type        = string
 }
 
+variable "create_frontend_record" {
+  description = "Whether to create the frontend A-alias record (simoba.yu-web.site → CloudFront)"
+  type        = bool
+  default     = false
+}
+
 variable "cloudfront_distribution_domain" {
   description = "CloudFront distribution domain name for frontend alias"
   type        = string
@@ -18,6 +24,12 @@ variable "cloudfront_distribution_zone_id" {
   description = "CloudFront distribution hosted zone ID"
   type        = string
   default     = ""
+}
+
+variable "create_api_record" {
+  description = "Whether to create the API A-alias record (api.simoba.yu-web.site → ALB)"
+  type        = bool
+  default     = false
 }
 
 variable "alb_dns_name" {


### PR DESCRIPTION
## Summary
- `terraform plan` が `Invalid count argument` で失敗する問題を修正
- DNS モジュールの `count` 条件を ALB/CloudFront 出力値（apply まで不明）から boolean 変数に変更

## Root Cause
`var.alb_dns_name != ""` は ALB 作成後にしか値が確定しないため、Terraform が plan 時に count を計算できなかった。

## Changes
- `modules/dns/variables.tf`: `create_frontend_record`, `create_api_record` (bool) を追加
- `modules/dns/main.tf`: count 条件を boolean 変数に変更
- `environments/prod/main.tf`: 両方 `true` を渡す

## Test Plan
- [ ] `terraform plan` がエラーなく完了すること