### PR TITLE
refactor: rename DeathEvent.heroId to entityId

### DIFF
--- a/server/src/__tests__/ServerDeathSystem.test.ts
+++ b/server/src/__tests__/ServerDeathSystem.test.ts
@@ -127,7 +127,7 @@ describe('ServerDeathSystem', () => {
       expect(events).toHaveLength(1)
       expect(events[0]).toEqual({
         kind: 'death',
-        event: { heroId: 'hero-1', type: 'death', position: { x: 500, y: 300 } },
+        event: { entityId: 'hero-1', type: 'death', position: { x: 500, y: 300 } },
       })
     })
 
@@ -140,7 +140,7 @@ describe('ServerDeathSystem', () => {
       expect(events).toHaveLength(1)
       expect(events[0]).toEqual({
         kind: 'death',
-        event: { heroId: 'hero-1', type: 'respawn', position: { x: BLUE_SPAWN.x, y: BLUE_SPAWN.y } },
+        event: { entityId: 'hero-1', type: 'respawn', position: { x: BLUE_SPAWN.x, y: BLUE_SPAWN.y } },
       })
     })
 

--- a/server/src/game/ServerDeathSystem.ts
+++ b/server/src/game/ServerDeathSystem.ts
@@ -32,7 +32,7 @@ export function processDeathAndRespawn(
       events.push({
         kind: 'death',
         event: {
-          heroId: sessionId,
+          entityId: sessionId,
           type: 'death',
           position: { x: hero.x, y: hero.y },
         },
@@ -57,7 +57,7 @@ export function processDeathAndRespawn(
         events.push({
           kind: 'death',
           event: {
-            heroId: sessionId,
+            entityId: sessionId,
             type: 'respawn',
             position: { x: spawn.x, y: spawn.y },
           },

--- a/server/src/game/ServerMinionSystem.ts
+++ b/server/src/game/ServerMinionSystem.ts
@@ -468,7 +468,7 @@ export function processMinionDeaths(
       events.push({
         kind: 'death',
         event: {
-          heroId: minion.id,
+          entityId: minion.id,
           type: 'death',
           position: { x: minion.x, y: minion.y },
         },

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -28,9 +28,9 @@ export interface DamageEvent {
   readonly sourceId: string
 }
 
-/** Fired when a hero dies or respawns */
+/** Fired when any entity dies or respawns (hero, minion, tower) */
 export interface DeathEvent {
-  readonly heroId: string
+  readonly entityId: string
   readonly type: 'death' | 'respawn'
   readonly position: { readonly x: number; readonly y: number }
 }

--- a/src/scenes/__tests__/GameScene.test.ts
+++ b/src/scenes/__tests__/GameScene.test.ts
@@ -309,7 +309,7 @@ describe('GameScene', () => {
       const call = (scene as any).handleDeathEvent.bind(scene)
 
       expect(() => call({
-        heroId: 'local-session',
+        entityId: 'local-session',
         type: 'death',
         position: { x: 100, y: 200 },
       })).not.toThrow()


### PR DESCRIPTION
## Summary
- `DeathEvent.heroId` was semantically incorrect — used for both hero and minion death events
- Renamed to `entityId` to accurately reflect any combat entity can trigger death events
- Updated all references in server systems, tests, and client tests

## Test plan
- [ ] Server tests pass (99 tests)
- [ ] Client tests pass (393 tests)

Closes #147