### PR TITLE
fix: rewrite E2E tests for solo play mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,8 @@ jobs:
 
       - run: npm ci
 
+      - run: cd server && npm ci
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:

--- a/e2e/death-respawn.spec.ts
+++ b/e2e/death-respawn.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test'
-import { type TestWindow, startOfflineGame, rightClickOnEnemy } from './helpers'
+import { type TestWindow, startSoloGame, rightClickOnEnemy } from './helpers'
 
 // Killing enemy takes ~15s (BLADE 60dmg * 0.8atk/s vs 650HP) + 5s respawn
 test.describe('Death and Respawn', () => {
   test.beforeEach(async ({ page }) => {
-    await startOfflineGame(page)
+    await startSoloGame(page)
   })
 
   test('enemy should die when HP reaches zero and respawn after timer', async ({ page }) => {

--- a/e2e/game-launch.spec.ts
+++ b/e2e/game-launch.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { startOfflineGame } from './helpers'
+import { startSoloGame } from './helpers'
 
 test.describe('Game Launch', () => {
   test('should render a canvas element inside game-container', async ({ page }) => {
@@ -21,8 +21,8 @@ test.describe('Game Launch', () => {
     expect(hasGame).toBe(true)
   })
 
-  test('should load GameScene after selecting Offline Play', async ({ page }) => {
-    await startOfflineGame(page)
+  test('should load GameScene after selecting Solo Play', async ({ page }) => {
+    await startSoloGame(page)
 
     const isActive = await page.evaluate(() => {
       const game = (window as unknown as { game: { scene: { isActive: (key: string) => boolean } } }).game

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -33,7 +33,8 @@ const WORLD_WIDTH = 3200
 const WORLD_HEIGHT = 720
 
 // Lobby button positions (must match LobbyScene layout)
-const OFFLINE_PLAY_BUTTON = { x: 640, y: 460 }
+// Online Battle: y=370, Solo Play: y=440
+const SOLO_PLAY_BUTTON = { x: 640, y: 440 }
 
 // Hero selection button positions (y=300, horizontal row centered at GAME_WIDTH/2)
 // HERO_BUTTON_WIDTH=96, HERO_BUTTON_GAP=12, 3 buttons
@@ -58,7 +59,7 @@ export async function waitForScene(page: Page, sceneKey: string): Promise<void> 
       return game?.scene?.isActive(key)
     },
     sceneKey,
-    { timeout: 10000 }
+    { timeout: 15000 }
   )
 }
 
@@ -68,14 +69,14 @@ export async function waitForScene(page: Page, sceneKey: string): Promise<void> 
 export async function waitForTestApi(page: Page): Promise<void> {
   await page.waitForFunction(
     () => (window as unknown as TestWindow).__test__ !== undefined,
-    { timeout: 10000 }
+    { timeout: 15000 }
   )
   await page.waitForTimeout(500)
 }
 
 /**
  * Click a hero selection button in the lobby.
- * Must be called after LobbyScene is active but before clicking "Offline Play".
+ * Must be called after LobbyScene is active but before clicking "Solo Play".
  */
 export async function selectHeroInLobby(page: Page, heroType: 'BLADE' | 'BOLT' | 'AURA'): Promise<void> {
   const canvas = page.locator('#game-container canvas')
@@ -93,11 +94,13 @@ export async function selectHeroInLobby(page: Page, heroType: 'BLADE' | 'BOLT' |
 }
 
 /**
- * Navigate to the page, click "Offline Play" in the lobby, and wait for GameScene.
+ * Navigate to the page, click "Solo Play" in the lobby, and wait for GameScene.
  * Use this as the standard entry point for E2E tests that need GameScene.
  * Pass heroType to select a specific hero before starting (default: BLADE).
+ *
+ * Requires the Colyseus server to be running (started by `npm run dev`).
  */
-export async function startOfflineGame(page: Page, heroType?: 'BLADE' | 'BOLT' | 'AURA'): Promise<void> {
+export async function startSoloGame(page: Page, heroType?: 'BLADE' | 'BOLT' | 'AURA'): Promise<void> {
   await page.goto('/')
 
   const canvas = page.locator('#game-container canvas')
@@ -115,8 +118,8 @@ export async function startOfflineGame(page: Page, heroType?: 'BLADE' | 'BOLT' |
   const scaleX = bounds.width / GAME_WIDTH
   const scaleY = bounds.height / GAME_HEIGHT
   await page.mouse.click(
-    bounds.x + OFFLINE_PLAY_BUTTON.x * scaleX,
-    bounds.y + OFFLINE_PLAY_BUTTON.y * scaleY
+    bounds.x + SOLO_PLAY_BUTTON.x * scaleX,
+    bounds.y + SOLO_PLAY_BUTTON.y * scaleY
   )
 
   await waitForTestApi(page)

--- a/e2e/hero-selection.spec.ts
+++ b/e2e/hero-selection.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { type TestWindow, startOfflineGame } from './helpers'
+import { type TestWindow, startSoloGame } from './helpers'
 
 test.describe('Hero Selection', () => {
   test('should start as BLADE by default', async ({ page }) => {
-    await startOfflineGame(page)
+    await startSoloGame(page)
 
     const heroType = await page.evaluate(
       () => (window as unknown as TestWindow).__test__.getHeroType()
@@ -12,7 +12,7 @@ test.describe('Hero Selection', () => {
   })
 
   test('should start as BOLT when selected in lobby', async ({ page }) => {
-    await startOfflineGame(page, 'BOLT')
+    await startSoloGame(page, 'BOLT')
 
     const state = await page.evaluate(() => {
       const api = (window as unknown as TestWindow).__test__
@@ -24,7 +24,7 @@ test.describe('Hero Selection', () => {
   })
 
   test('should start as AURA when selected in lobby', async ({ page }) => {
-    await startOfflineGame(page, 'AURA')
+    await startSoloGame(page, 'AURA')
 
     const state = await page.evaluate(() => {
       const api = (window as unknown as TestWindow).__test__

--- a/e2e/hp-bar.spec.ts
+++ b/e2e/hp-bar.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { type TestWindow, startOfflineGame, rightClickOnEnemy } from './helpers'
+import { type TestWindow, startSoloGame, rightClickOnEnemy } from './helpers'
 
 test.describe('HP Bar', () => {
   test.beforeEach(async ({ page }) => {
-    await startOfflineGame(page)
+    await startSoloGame(page)
   })
 
   test('should show HP bar even when hero is at full HP', async ({ page }) => {

--- a/e2e/lobby.spec.ts
+++ b/e2e/lobby.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { waitForScene, startOfflineGame } from './helpers'
+import { waitForScene, startSoloGame } from './helpers'
 
 test.describe('Lobby', () => {
   test('should display LobbyScene on game load', async ({ page }) => {
@@ -18,8 +18,8 @@ test.describe('Lobby', () => {
     expect(isLobbyActive).toBe(true)
   })
 
-  test('should transition to GameScene when "Offline Play" is clicked', async ({ page }) => {
-    await startOfflineGame(page)
+  test('should transition to GameScene when "Solo Play" is clicked', async ({ page }) => {
+    await startSoloGame(page)
 
     const isGameActive = await page.evaluate(() => {
       const game = (window as unknown as {

--- a/e2e/map-rendering.spec.ts
+++ b/e2e/map-rendering.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { startOfflineGame } from './helpers'
+import { startSoloGame } from './helpers'
 
 test.describe('Map Rendering', () => {
   test.beforeEach(async ({ page }) => {
-    await startOfflineGame(page)
+    await startSoloGame(page)
     // Allow a frame for rendering to complete
     await page.waitForTimeout(500)
   })

--- a/e2e/melee-attack.spec.ts
+++ b/e2e/melee-attack.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { type TestWindow, startOfflineGame, rightClickOnEnemy } from './helpers'
+import { type TestWindow, startSoloGame, rightClickOnEnemy } from './helpers'
 
 test.describe('Melee Attack', () => {
   test.beforeEach(async ({ page }) => {
-    await startOfflineGame(page)
+    await startSoloGame(page)
   })
 
   test('should display an enemy hero on the map', async ({ page }) => {

--- a/e2e/projectile-attack.spec.ts
+++ b/e2e/projectile-attack.spec.ts
@@ -41,7 +41,7 @@ test.describe('Projectile Attack', () => {
     // Wait briefly — projectile should be in flight before reaching target
     await page.waitForFunction(
       () => (window as unknown as TestWindow).__test__.getProjectileCount() >= 1,
-      { timeout: 3000 }
+      { timeout: 5000 }
     )
 
     const count = await page.evaluate(

--- a/e2e/projectile-attack.spec.ts
+++ b/e2e/projectile-attack.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { type TestWindow, startOfflineGame, rightClickOnEnemy } from './helpers'
+import { type TestWindow, startSoloGame, rightClickOnEnemy } from './helpers'
 
 test.describe('Projectile Attack', () => {
   test.beforeEach(async ({ page }) => {
-    await startOfflineGame(page, 'BOLT')
+    await startSoloGame(page, 'BOLT')
   })
 
   test('should reduce enemy HP when BOLT attacks with projectile', async ({ page }) => {
@@ -15,17 +15,16 @@ test.describe('Projectile Attack', () => {
       () => (window as unknown as TestWindow).__test__.getEnemyHp().current
     )
 
-    // BOLT attackRange=300, initial distance=200 → already in range
-    // Right-click on enemy using computed screen position
+    // Right-click on enemy to initiate attack
     const canvas = page.locator('#game-container canvas')
     await rightClickOnEnemy(page, canvas)
 
-    // Wait for projectile to fly and hit
+    // Wait for projectile to fly and hit (server-authoritative, needs more time)
     await page.waitForFunction(
       (initial) =>
         (window as unknown as TestWindow).__test__.getEnemyHp().current < initial,
       initialHp,
-      { timeout: 5000 }
+      { timeout: 10000 }
     )
 
     const finalHp = await page.evaluate(

--- a/e2e/tower-rendering.spec.ts
+++ b/e2e/tower-rendering.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { startOfflineGame, type TestWindow } from './helpers'
+import { startSoloGame, type TestWindow } from './helpers'
 
 test.describe('Tower Rendering', () => {
   test.beforeEach(async ({ page }) => {
-    await startOfflineGame(page)
+    await startSoloGame(page)
     await page.waitForTimeout(500)
   })
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,15 +3,15 @@ import { defineConfig, devices } from '@playwright/test'
 export default defineConfig({
   testDir: './e2e',
   snapshotPathTemplate: '{snapshotDir}/{testFileDir}/{testFileName}-snapshots/{arg}{ext}',
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env['CI'],
   retries: process.env['CI'] ? 2 : 0,
-  workers: process.env['CI'] ? 1 : undefined,
-  reporter: 'html',
+  workers: 1,
+  reporter: process.env['CI'] ? 'github' : 'html',
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
-    screenshot: 'on',
+    screenshot: 'only-on-failure',
     video: 'on-first-retry'
   },
   projects: [

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -151,7 +151,9 @@ export class GameScene extends Phaser.Scene {
 
     // E2E test API (dev only)
     if (import.meta.env.DEV) {
-      registerTestApi(this.entityManager)
+      registerTestApi(this.entityManager, {
+        getProjectileCount: () => this.serverProjectiles.length,
+      })
     }
 
     // Network

--- a/src/test/e2eTestApi.ts
+++ b/src/test/e2eTestApi.ts
@@ -42,6 +42,7 @@ function getEnemyHero(entityManager: EntityManager): HeroState {
 
 export function registerTestApi(
   entityManager: EntityManager,
+  options?: { getProjectileCount?: () => number },
 ): void {
   window.__test__ = {
     getHeroType: () => getLocalHero(entityManager).type,
@@ -63,7 +64,7 @@ export function registerTestApi(
       return { x, y }
     },
     getEnemyDead: () => getEnemyHero(entityManager).dead,
-    getProjectileCount: () => 0, // Projectiles are server-managed; E2E tests should check visually
+    getProjectileCount: () => options?.getProjectileCount?.() ?? 0,
     getHeroAttackTarget: () => getLocalHero(entityManager).attackTargetId,
     getTowers: () =>
       entityManager.allEntities


### PR DESCRIPTION
## Summary
- Replace `startOfflineGame()` with `startSoloGame()` across all 9 E2E test files — OfflineGameMode was removed in #157
- Fix Solo Play button coordinates in helpers.ts (y=460 → y=440)
- Restore `getProjectileCount` via `GameScene.serverProjectiles` callback (was hardcoded to 0)
- Increase `waitForFunction` timeouts for server-authoritative latency
- Optimize Playwright config: `workers=1`, `screenshot: 'only-on-failure'`, sequential execution

## Performance improvements
- `workers: 1` (was unlimited locally) — reduces CPU contention, no more PC stutter
- `fullyParallel: false` — sequential test execution
- `screenshot: 'only-on-failure'` (was `'on'`) — less I/O overhead

## Test plan
- [x] All 24 E2E tests pass locally (3.1 min)
- [x] All 496 unit tests pass
- [ ] CI: unit-test job passes
- [ ] CI: e2e-test job passes

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)