### PR TITLE
feat: add structured logging system with LogTape

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,13 @@ export default tseslint.config(
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
+      'no-console': 'warn',
+    },
+  },
+  {
+    files: ['**/*.test.ts', '**/__tests__/**'],
+    rules: {
+      'no-console': 'off',
     },
   },
   {

--- a/openspec/changes/archive/2026-02-27-logging-system/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-27-logging-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-27

--- a/openspec/changes/archive/2026-02-27-logging-system/design.md
+++ b/openspec/changes/archive/2026-02-27-logging-system/design.md
@@ -1,0 +1,114 @@
+## Context
+
+現状ロギングは `console.error` 1箇所（client）と `console.log` 1箇所（server）のみ。
+Phase 2 でオンラインマルチプレイが動いており、クライアント・サーバー間の問題調査に構造化ログが必要。
+
+LogTape v2.x を採用し、フロントエンド（Phaser/Vite）とバックエンド（Colyseus/Node.js）で統一的なログ基盤を整備する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- LogTape を導入し、フロントエンド/バックエンドで同一ライブラリ・同一カテゴリ規約のロギングを実現
+- バックエンドで CloudWatch Logs Insights 対応の構造化 JSON 出力
+- 既存 `console.*` 呼び出しの完全置き換え
+- ESLint ルールで今後の `console.*` 直接使用を抑制
+
+**Non-Goals:**
+- CloudWatch SDK の直接利用（ECS stdout 連携で十分）
+- リモートロギング（クライアント→サーバー）
+- ログレベルのランタイム動的変更 UI
+
+## Decisions
+
+### D1: パッケージ配置 — ルート `package.json` に追加
+
+`@logtape/logtape` はルートの `package.json` の `dependencies` に追加する。
+`shared/` から import するため、サーバー側の `server/package.json` にも追加する。
+
+**代替案**: shared 専用パッケージとして workspace に切り出す → 現時点では workspace 構成が過剰。
+
+### D2: ログ設定の配置
+
+| 環境 | 設定ファイル | 内容 |
+|------|------------|------|
+| Frontend | `src/config/logging.ts` | `configure()` でコンソール sink、環境別レベル |
+| Backend | `server/src/config/logging.ts` | `configure()` で JSON sink + コンソール sink |
+
+各エントリポイント（`src/main.ts`, `server/src/index.ts`）の最初で `await configure(...)` を呼ぶ。
+
+**代替案**: shared に統一設定 → sink が環境依存（ブラウザ console vs Node.js stdout）なので分離が自然。
+
+### D3: カテゴリ定数の定義場所
+
+カテゴリ文字列をハードコードせず、`shared/logging.ts` にカテゴリファクトリを置く：
+
+```typescript
+// shared/logging.ts
+import { getLogger } from '@logtape/logtape'
+
+export const createClientLogger = (subsystem: string) =>
+  getLogger(['simoba', 'client', subsystem])
+
+export const createServerLogger = (subsystem: string) =>
+  getLogger(['simoba', 'server', subsystem])
+```
+
+使用側：
+```typescript
+// src/scenes/GameScene.ts
+import { createClientLogger } from '@shared/logging'
+const logger = createClientLogger('scene')
+
+// server/src/rooms/GameRoom.ts
+import { createServerLogger } from '@shared/logging'
+const logger = createServerLogger('room')
+```
+
+### D4: バックエンド JSON sink の実装
+
+LogTape のカスタム sink で `process.stdout.write` に JSON を出力する：
+
+```typescript
+function jsonStdoutSink(record: LogRecord): void {
+  const entry = {
+    timestamp: record.timestamp.toISOString(),
+    level: record.level,
+    category: record.category.join('.'),
+    message: renderMessage(record),
+    ...record.properties,
+  }
+  process.stdout.write(JSON.stringify(entry) + '\n')
+}
+```
+
+CloudWatch Logs Insights クエリ例:
+```
+fields @timestamp, category, message
+| filter level = "error"
+| sort @timestamp desc
+```
+
+**代替案**: `@logtape/cloudwatch-logs` を使う → ECS awslogs ドライバーが stdout を自動転送するため不要。将来移行は容易。
+
+### D5: ESLint `no-console` ルール
+
+`eslint.config.mjs` に `no-console: "warn"` を追加する。現在のフラット config 形式に準拠。
+
+- `src/**/*.ts` と `server/src/**/*.ts` に適用
+- テストファイル（`**/*.test.ts`, `**/__tests__/**`）は除外
+- 移行中に `// eslint-disable-next-line no-console` が必要な箇所はロガーに置き換えるので不要になる
+
+### D6: フロントエンドログ初期化タイミング
+
+`src/main.ts` で `new Phaser.Game(gameConfig)` の**前**に `await configure(...)` を呼ぶ。
+LogTape の `configure()` は async だが、トップレベル await が使える（Vite ESM ビルド）。
+
+## Risks / Trade-offs
+
+- **[Risk] LogTape がメンテナンス停止** → ゼロ依存・5KB なので fork または薄いラッパー経由で自前実装に差し替え可能。`shared/logging.ts` のファクトリ関数が唯一の結合点。
+- **[Risk] ログ出力がゲーム FPS に影響** → LogTape は 214ns/iter。60Hz ティック（16.6ms）に対して無視できる。大量ログ時は `lowestLevel` で抑制。
+- **[Trade-off] JSON sink は自前実装** → `@logtape/cloudwatch-logs` を使えば公式だが、stdout 出力のみなら 10行のカスタム sink で十分。
+
+## Open Questions
+
+（なし — 技術選定・配置・設定方針は確定済み）

--- a/openspec/changes/archive/2026-02-27-logging-system/proposal.md
+++ b/openspec/changes/archive/2026-02-27-logging-system/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+プロジェクト全体でロギングが最小限（client: `console.error` 1箇所、server: `console.log` 1箇所）しかなく、デバッグ・運用監視・問題切り分けが困難。Phase 2 のオンラインマルチプレイヤーが動き始めた今、クライアント・サーバー間の問題調査に構造化されたログが不可欠になった。
+
+## What Changes
+
+- **新規**: LogTape（`@logtape/logtape`）を導入 — ゼロ依存、5.3KB、ブラウザ/Node.js 両対応
+- **新規**: フロントエンド用ログ設定（コンソール sink、開発時 debug 以上、本番時 warn 以上）
+- **新規**: バックエンド用ログ設定（構造化 JSON sink → stdout、CloudWatch Logs Insights 対応）
+- **置換**: 既存の `console.log` / `console.error` を LogTape ロガー呼び出しに置き換え
+- **新規**: 階層カテゴリによるフィルタリング（`["simoba", "server", "room"]`, `["simoba", "client", "scene"]` 等）
+
+## 技術選定: LogTape
+
+| 項目 | 詳細 |
+|------|------|
+| パッケージ | `@logtape/logtape` v2.x |
+| サイズ | 5.3 KB (min+gz)、依存関係ゼロ |
+| ランタイム | Node.js / ブラウザ / Deno / Bun — polyfill 不要 |
+| Vite 互換 | ネイティブ ESM、バンドル設定不要 |
+| 構造化ログ | テンプレートリテラル + プロパティ |
+| パフォーマンス | 214ns/iter（Pino: 326ns、Winston: 2,050ns） |
+| 拡張性 | CloudWatch Logs sink、OpenTelemetry sink 等が公式パッケージ |
+
+**Pino を選ばなかった理由**: Worker Threads ベースで Vite バンドルに専用プラグインと Node.js polyfill が必要。ブラウザ対応が二級市民。
+
+**自前実装を選ばなかった理由**: LogTape の階層カテゴリ・sink 抽象・構造化ログの品質を再発明するのは非合理。万が一メンテナンスが止まっても、ゼロ依存なので fork または薄いラッパー経由で自前実装に差し替え可能。
+
+## AWS 連携方針
+
+- バックエンドは **stdout に構造化 JSON** を出力。ECS タスクの awslogs ドライバーが自動で CloudWatch Logs に転送
+- JSON 形式により CloudWatch Logs Insights でフィルタ・集計クエリが可能（例: `fields @timestamp, category, message | filter level = "error"`）
+- CloudWatch SDK やカスタム連携コードは不要 — ECS のインフラ層が処理する
+- 将来の拡張: `@logtape/cloudwatch-logs` sink で直接連携、メトリクスフィルタでエラー率アラーム等
+
+## Non-goals
+
+- CloudWatch SDK の直接利用やカスタムログ転送（ECS の stdout 連携で十分）
+- 外部ログ収集サービス（Datadog 等）の追加統合
+- クライアントからサーバーへのログ送信（リモートロギング）
+- パフォーマンスプロファイリングツールの導入
+
+## Capabilities
+
+### New Capabilities
+
+- `logging`: LogTape ベースのログ基盤。フロントエンド/バックエンド設定、階層カテゴリ、環境別ログレベル制御、構造化 JSON 出力
+
+### Modified Capabilities
+
+（既存スペックの要件変更なし — 実装レベルの `console.*` 置換のみ）
+
+## Impact
+
+- **依存関係**: `@logtape/logtape` を追加（ルート `package.json`、shared で使用するため）
+- **shared/**: ログ設定・カテゴリ定義のユーティリティ
+- **src/**: フロントエンドログ初期化、既存 `console.error` の置き換え（`src/scenes/GameScene.ts`）
+- **server/**: バックエンドログ初期化（JSON sink）、既存 `console.log` の置き換え（`server/src/index.ts`）、Colyseus ルームライフサイクルのログ追加
+- **参照スペック**: `openspec/specs/tech-architecture.md`、`openspec/specs/online-multiplayer/`

--- a/openspec/changes/archive/2026-02-27-logging-system/specs/logging/spec.md
+++ b/openspec/changes/archive/2026-02-27-logging-system/specs/logging/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: LogTape dependency
+The project SHALL use `@logtape/logtape` v2.x as the logging library. The package SHALL be installed at the workspace root so both frontend (`src/`) and backend (`server/`) can import it.
+
+#### Scenario: Package installation
+- **WHEN** `npm install` is run at the project root
+- **THEN** `@logtape/logtape` is available for import in both `src/` and `server/` code
+
+### Requirement: Hierarchical category convention
+All loggers SHALL use hierarchical categories with `"simoba"` as the root. The second level SHALL distinguish `"client"` and `"server"`. The third level and beyond SHALL identify the subsystem.
+
+Category examples:
+- `["simoba", "client", "scene"]` — scene lifecycle
+- `["simoba", "client", "network"]` — network/connection events
+- `["simoba", "server", "room"]` — Colyseus room lifecycle
+- `["simoba", "server", "game"]` — game logic (systems, combat)
+- `["simoba", "server", "system"]` — server startup/shutdown
+
+#### Scenario: Client logger creation
+- **WHEN** a frontend module creates a logger with `getLogger(["simoba", "client", "scene"])`
+- **THEN** the logger inherits sink and level settings from parent categories `["simoba", "client"]` and `["simoba"]`
+
+#### Scenario: Server logger creation
+- **WHEN** a backend module creates a logger with `getLogger(["simoba", "server", "room"])`
+- **THEN** the logger inherits sink and level settings from parent categories `["simoba", "server"]` and `["simoba"]`
+
+### Requirement: Frontend log configuration
+The frontend SHALL configure LogTape at application startup (before Phaser game creation) with a console sink. In development mode (`import.meta.env.DEV`), the lowest level SHALL be `"debug"`. In production mode, the lowest level SHALL be `"warning"`.
+
+#### Scenario: Development mode logging
+- **WHEN** the app runs in development mode (`import.meta.env.DEV === true`)
+- **THEN** logs at debug level and above are output to the browser console
+
+#### Scenario: Production mode logging
+- **WHEN** the app runs in production mode (`import.meta.env.DEV === false`)
+- **THEN** only logs at warning level and above are output to the browser console
+- **THEN** debug and info logs are suppressed
+
+### Requirement: Backend log configuration
+The backend SHALL configure LogTape at server startup (before Colyseus server listen) with a structured JSON sink writing to stdout. In development mode (`NODE_ENV !== "production"`), an additional human-readable console sink SHALL be configured. In production mode, only the JSON sink SHALL be active.
+
+#### Scenario: Production JSON output
+- **WHEN** the server runs in production mode (`NODE_ENV === "production"`)
+- **THEN** each log line is a single JSON object written to stdout containing at minimum: `timestamp` (ISO 8601), `level`, `category` (dot-joined string), and `message`
+
+#### Scenario: Development console output
+- **WHEN** the server runs in development mode (`NODE_ENV !== "production"`)
+- **THEN** logs are output to the console in a human-readable format
+- **THEN** a JSON sink to stdout is also active for testing the production format
+
+### Requirement: Structured log properties
+Loggers SHALL attach contextual properties to log messages using LogTape's structured logging API. Properties SHALL include domain-relevant data (e.g., `roomId`, `playerId`, `sceneKey`) without embedding them in message strings.
+
+#### Scenario: Room event with properties
+- **WHEN** a server room logs a join event
+- **THEN** the log record contains structured properties like `{ roomId: "abc123", playerId: "xyz", playerCount: 3 }` accessible for JSON serialization and CloudWatch Logs Insights queries
+
+### Requirement: Replace existing console calls
+All existing `console.log`, `console.error`, `console.warn`, and `console.debug` calls in the codebase SHALL be replaced with the appropriate LogTape logger method.
+
+#### Scenario: GameScene error replacement
+- **WHEN** `GameScene` encounters a missing gameMode
+- **THEN** it logs via `logger.error` instead of `console.error`
+
+#### Scenario: Server startup replacement
+- **WHEN** the Colyseus server starts listening
+- **THEN** it logs via `logger.info` instead of `console.log`, including the port as a structured property
+
+### Requirement: Server room lifecycle logging
+The Colyseus `GameRoom` SHALL log key lifecycle events: room creation, player join, player leave, room disposal. Each log SHALL include the `roomId` and relevant context.
+
+#### Scenario: Room created
+- **WHEN** a GameRoom `onCreate` is called
+- **THEN** an info-level log is emitted with category `["simoba", "server", "room"]` and property `roomId`
+
+#### Scenario: Player joins
+- **WHEN** a player joins a GameRoom
+- **THEN** an info-level log is emitted with `roomId`, `playerId` (sessionId), and current `playerCount`
+
+#### Scenario: Player leaves
+- **WHEN** a player leaves a GameRoom
+- **THEN** an info-level log is emitted with `roomId`, `playerId`, and remaining `playerCount`
+
+#### Scenario: Room disposed
+- **WHEN** a GameRoom `onDispose` is called
+- **THEN** an info-level log is emitted with `roomId`
+
+### Requirement: Client scene lifecycle logging
+The Phaser game client SHALL log scene transitions at debug level with category `["simoba", "client", "scene"]`.
+
+#### Scenario: Scene created
+- **WHEN** a scene's `create` method is called
+- **THEN** a debug-level log is emitted with the scene key
+
+#### Scenario: Scene shutdown
+- **WHEN** a scene's `shutdown` method is called
+- **THEN** a debug-level log is emitted with the scene key
+
+### Requirement: ESLint console restriction
+An ESLint rule SHALL warn on direct `console.*` usage in `src/` and `server/src/` to encourage using the logger instead. Test files and configuration files SHALL be excluded from this rule.
+
+#### Scenario: Direct console usage in source code
+- **WHEN** a developer writes `console.log(...)` in a source file
+- **THEN** ESLint emits a warning suggesting to use the logger
+
+#### Scenario: Console usage in test files
+- **WHEN** a developer writes `console.log(...)` in a test file (`*.test.ts`)
+- **THEN** ESLint does NOT emit a warning

--- a/openspec/changes/archive/2026-02-27-logging-system/tasks.md
+++ b/openspec/changes/archive/2026-02-27-logging-system/tasks.md
@@ -1,0 +1,27 @@
+## 1. Setup
+
+- [x] 1.1 Install `@logtape/logtape` in root `package.json` and `server/package.json`
+- [x] 1.2 Create `shared/logging.ts` with `createClientLogger` / `createServerLogger` factory functions
+
+## 2. Backend Logging
+
+- [x] 2.1 Create `server/src/config/logging.ts` with JSON stdout sink + console sink, environment-based level config
+- [x] 2.2 Initialize LogTape in `server/src/index.ts` (before server listen), replace existing `console.log` with logger
+- [x] 2.3 Add room lifecycle logging to `server/src/rooms/GameRoom.ts` (onCreate, onJoin, onLeave, onDispose)
+
+## 3. Frontend Logging
+
+- [x] 3.1 Create `src/config/logging.ts` with console sink, environment-based level config
+- [x] 3.2 Initialize LogTape in `src/main.ts` (before Phaser game creation), add top-level await
+- [x] 3.3 Replace `console.error` in `src/scenes/GameScene.ts` with logger, add scene lifecycle logging (create, shutdown)
+
+## 4. ESLint & Quality
+
+- [x] 4.1 Add `no-console: "warn"` rule to `eslint.config.mjs` for source files, exclude test files
+- [x] 4.2 Remove existing `// eslint-disable-next-line no-console` comments that are now covered by logger
+
+## 5. Tests
+
+- [x] 5.1 Add unit tests for `shared/logging.ts` (factory function returns correct category loggers)
+- [x] 5.2 Add unit tests for `server/src/config/logging.ts` (JSON sink output format, level filtering)
+- [x] 5.3 Verify existing tests pass with LogTape initialization (no side effects)

--- a/openspec/specs/logging/spec.md
+++ b/openspec/specs/logging/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: LogTape dependency
+The project SHALL use `@logtape/logtape` v2.x as the logging library. The package SHALL be installed at the workspace root so both frontend (`src/`) and backend (`server/`) can import it.
+
+#### Scenario: Package installation
+- **WHEN** `npm install` is run at the project root
+- **THEN** `@logtape/logtape` is available for import in both `src/` and `server/` code
+
+### Requirement: Hierarchical category convention
+All loggers SHALL use hierarchical categories with `"simoba"` as the root. The second level SHALL distinguish `"client"` and `"server"`. The third level and beyond SHALL identify the subsystem.
+
+Category examples:
+- `["simoba", "client", "scene"]` — scene lifecycle
+- `["simoba", "client", "network"]` — network/connection events
+- `["simoba", "server", "room"]` — Colyseus room lifecycle
+- `["simoba", "server", "game"]` — game logic (systems, combat)
+- `["simoba", "server", "system"]` — server startup/shutdown
+
+#### Scenario: Client logger creation
+- **WHEN** a frontend module creates a logger with `getLogger(["simoba", "client", "scene"])`
+- **THEN** the logger inherits sink and level settings from parent categories `["simoba", "client"]` and `["simoba"]`
+
+#### Scenario: Server logger creation
+- **WHEN** a backend module creates a logger with `getLogger(["simoba", "server", "room"])`
+- **THEN** the logger inherits sink and level settings from parent categories `["simoba", "server"]` and `["simoba"]`
+
+### Requirement: Frontend log configuration
+The frontend SHALL configure LogTape at application startup (before Phaser game creation) with a console sink. In development mode (`import.meta.env.DEV`), the lowest level SHALL be `"debug"`. In production mode, the lowest level SHALL be `"warning"`.
+
+#### Scenario: Development mode logging
+- **WHEN** the app runs in development mode (`import.meta.env.DEV === true`)
+- **THEN** logs at debug level and above are output to the browser console
+
+#### Scenario: Production mode logging
+- **WHEN** the app runs in production mode (`import.meta.env.DEV === false`)
+- **THEN** only logs at warning level and above are output to the browser console
+- **THEN** debug and info logs are suppressed
+
+### Requirement: Backend log configuration
+The backend SHALL configure LogTape at server startup (before Colyseus server listen) with a structured JSON sink writing to stdout. In development mode (`NODE_ENV !== "production"`), an additional human-readable console sink SHALL be configured. In production mode, only the JSON sink SHALL be active.
+
+#### Scenario: Production JSON output
+- **WHEN** the server runs in production mode (`NODE_ENV === "production"`)
+- **THEN** each log line is a single JSON object written to stdout containing at minimum: `timestamp` (ISO 8601), `level`, `category` (dot-joined string), and `message`
+
+#### Scenario: Development console output
+- **WHEN** the server runs in development mode (`NODE_ENV !== "production"`)
+- **THEN** logs are output to the console in a human-readable format
+- **THEN** a JSON sink to stdout is also active for testing the production format
+
+### Requirement: Structured log properties
+Loggers SHALL attach contextual properties to log messages using LogTape's structured logging API. Properties SHALL include domain-relevant data (e.g., `roomId`, `playerId`, `sceneKey`) without embedding them in message strings.
+
+#### Scenario: Room event with properties
+- **WHEN** a server room logs a join event
+- **THEN** the log record contains structured properties like `{ roomId: "abc123", playerId: "xyz", playerCount: 3 }` accessible for JSON serialization and CloudWatch Logs Insights queries
+
+### Requirement: Replace existing console calls
+All existing `console.log`, `console.error`, `console.warn`, and `console.debug` calls in the codebase SHALL be replaced with the appropriate LogTape logger method.
+
+#### Scenario: GameScene error replacement
+- **WHEN** `GameScene` encounters a missing gameMode
+- **THEN** it logs via `logger.error` instead of `console.error`
+
+#### Scenario: Server startup replacement
+- **WHEN** the Colyseus server starts listening
+- **THEN** it logs via `logger.info` instead of `console.log`, including the port as a structured property
+
+### Requirement: Server room lifecycle logging
+The Colyseus `GameRoom` SHALL log key lifecycle events: room creation, player join, player leave, room disposal. Each log SHALL include the `roomId` and relevant context.
+
+#### Scenario: Room created
+- **WHEN** a GameRoom `onCreate` is called
+- **THEN** an info-level log is emitted with category `["simoba", "server", "room"]` and property `roomId`
+
+#### Scenario: Player joins
+- **WHEN** a player joins a GameRoom
+- **THEN** an info-level log is emitted with `roomId`, `playerId` (sessionId), and current `playerCount`
+
+#### Scenario: Player leaves
+- **WHEN** a player leaves a GameRoom
+- **THEN** an info-level log is emitted with `roomId`, `playerId`, and remaining `playerCount`
+
+#### Scenario: Room disposed
+- **WHEN** a GameRoom `onDispose` is called
+- **THEN** an info-level log is emitted with `roomId`
+
+### Requirement: Client scene lifecycle logging
+The Phaser game client SHALL log scene transitions at debug level with category `["simoba", "client", "scene"]`.
+
+#### Scenario: Scene created
+- **WHEN** a scene's `create` method is called
+- **THEN** a debug-level log is emitted with the scene key
+
+#### Scenario: Scene shutdown
+- **WHEN** a scene's `shutdown` method is called
+- **THEN** a debug-level log is emitted with the scene key
+
+### Requirement: ESLint console restriction
+An ESLint rule SHALL warn on direct `console.*` usage in `src/` and `server/src/` to encourage using the logger instead. Test files and configuration files SHALL be excluded from this rule.
+
+#### Scenario: Direct console usage in source code
+- **WHEN** a developer writes `console.log(...)` in a source file
+- **THEN** ESLint emits a warning suggesting to use the logger
+
+#### Scenario: Console usage in test files
+- **WHEN** a developer writes `console.log(...)` in a test file (`*.test.ts`)
+- **THEN** ESLint does NOT emit a warning

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "simoba",
       "version": "0.1.0",
       "dependencies": {
+        "@logtape/logtape": "^2.0.4",
         "colyseus.js": "^0.16.22",
         "phaser": "^3.87.0"
       },
@@ -883,6 +884,15 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@logtape/logtape": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@logtape/logtape/-/logtape-2.0.4.tgz",
+      "integrity": "sha512-Z4COeAMdedcBFuFkXaPFvDPOVuHoEom1hwNnPCIkSyojyikuNguplwPoSG+kZthWrS7GiOJo1USQyjWwIFfTKA==",
+      "funding": [
+        "https://github.com/sponsors/dahlia"
+      ],
+      "license": "MIT"
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format": "prettier --write \"src/**/*.ts\""
   },
   "dependencies": {
+    "@logtape/logtape": "^2.0.4",
     "colyseus.js": "^0.16.22",
     "phaser": "^3.87.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "vitest run",
     "test:e2e": "playwright test",
     "test:coverage": "vitest run --coverage",
-    "lint": "eslint src/",
+    "lint": "eslint src/ server/src/",
     "format": "prettier --write \"src/**/*.ts\""
   },
   "dependencies": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
         "@colyseus/core": "^0.16.5",
         "@colyseus/schema": "^3.0.76",
         "@colyseus/ws-transport": "^0.16.5",
+        "@logtape/logtape": "^2.0.4",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "tsx": "^4.21.0"
@@ -528,6 +529,15 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@logtape/logtape": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@logtape/logtape/-/logtape-2.0.4.tgz",
+      "integrity": "sha512-Z4COeAMdedcBFuFkXaPFvDPOVuHoEom1hwNnPCIkSyojyikuNguplwPoSG+kZthWrS7GiOJo1USQyjWwIFfTKA==",
+      "funding": [
+        "https://github.com/sponsors/dahlia"
+      ],
       "license": "MIT"
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "@colyseus/core": "^0.16.5",
     "@colyseus/schema": "^3.0.76",
     "@colyseus/ws-transport": "^0.16.5",
+    "@logtape/logtape": "^2.0.4",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "tsx": "^4.21.0"

--- a/server/src/__tests__/logging.test.ts
+++ b/server/src/__tests__/logging.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@logtape/logtape', () => ({
+  configure: vi.fn(),
+  getConsoleSink: vi.fn(() => 'console-sink'),
+  getStreamSink: vi.fn(() => 'stream-sink'),
+  getJsonLinesFormatter: vi.fn(() => 'json-formatter'),
+}))
+
+vi.mock('node:stream', () => ({
+  default: {
+    Writable: {
+      toWeb: vi.fn(() => 'web-writable'),
+    },
+  },
+}))
+
+import { configure, getConsoleSink, getStreamSink, getJsonLinesFormatter } from '@logtape/logtape'
+import { setupServerLogging } from '../config/logging.js'
+
+describe('server/config/logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('configures JSON sink for production', async () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+
+    await setupServerLogging()
+
+    expect(getJsonLinesFormatter).toHaveBeenCalledWith({ categorySeparator: '.' })
+    expect(getStreamSink).toHaveBeenCalled()
+    expect(configure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loggers: [
+          expect.objectContaining({
+            category: ['simoba', 'server'],
+            lowestLevel: 'info',
+            sinks: ['json'],
+          }),
+        ],
+      })
+    )
+    // Console sink should NOT be created in production
+    expect(getConsoleSink).not.toHaveBeenCalled()
+
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('configures both JSON and console sinks for development', async () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+
+    await setupServerLogging()
+
+    expect(getStreamSink).toHaveBeenCalled()
+    expect(getConsoleSink).toHaveBeenCalled()
+    expect(configure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loggers: [
+          expect.objectContaining({
+            category: ['simoba', 'server'],
+            lowestLevel: 'debug',
+            sinks: ['json', 'console'],
+          }),
+        ],
+      })
+    )
+
+    process.env.NODE_ENV = originalEnv
+  })
+})

--- a/server/src/config/logging.ts
+++ b/server/src/config/logging.ts
@@ -1,0 +1,37 @@
+import {
+  configure,
+  getConsoleSink,
+  getStreamSink,
+  getJsonLinesFormatter,
+} from '@logtape/logtape'
+import stream from 'node:stream'
+
+export async function setupServerLogging(): Promise<void> {
+  const isProduction = process.env.NODE_ENV === 'production'
+  const sinks: Record<string, ReturnType<typeof getConsoleSink>> = {}
+  const sinkNames: string[] = []
+
+  // JSON sink → stdout (always active, CloudWatch Logs Insights compatible)
+  sinks.json = getStreamSink(
+    stream.Writable.toWeb(process.stdout),
+    { formatter: getJsonLinesFormatter({ categorySeparator: '.' }) },
+  )
+  sinkNames.push('json')
+
+  // Console sink (dev only, human-readable)
+  if (!isProduction) {
+    sinks.console = getConsoleSink()
+    sinkNames.push('console')
+  }
+
+  await configure({
+    sinks,
+    loggers: [
+      {
+        category: ['simoba', 'server'],
+        lowestLevel: isProduction ? 'info' : 'debug',
+        sinks: sinkNames,
+      },
+    ],
+  })
+}

--- a/server/src/config/logging.ts
+++ b/server/src/config/logging.ts
@@ -1,4 +1,5 @@
 import {
+  type Sink,
   configure,
   getConsoleSink,
   getStreamSink,
@@ -8,7 +9,7 @@ import stream from 'node:stream'
 
 export async function setupServerLogging(): Promise<void> {
   const isProduction = process.env.NODE_ENV === 'production'
-  const sinks: Record<string, ReturnType<typeof getConsoleSink>> = {}
+  const sinks: Record<string, Sink> = {}
   const sinkNames: string[] = []
 
   // JSON sink → stdout (always active, CloudWatch Logs Insights compatible)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,5 +37,5 @@ const gameServer = new Server({
 gameServer.define('game', GameRoom)
 
 gameServer.listen(PORT).then(() => {
-  logger.info`Colyseus server listening on ws://localhost:${PORT}`
+  logger.info('Colyseus server listening', { port: PORT })
 })

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,12 @@ import cors from 'cors'
 import { Server } from '@colyseus/core'
 import { WebSocketTransport } from '@colyseus/ws-transport'
 import { GameRoom } from './rooms/GameRoom.js'
+import { setupServerLogging } from './config/logging.js'
+import { createServerLogger } from '@shared/logging'
+
+await setupServerLogging()
+
+const logger = createServerLogger('system')
 
 const PORT = Number(process.env.PORT) || 2567
 const ALLOWED_ORIGINS = process.env.CORS_ORIGINS
@@ -31,6 +37,5 @@ const gameServer = new Server({
 gameServer.define('game', GameRoom)
 
 gameServer.listen(PORT).then(() => {
-  // eslint-disable-next-line no-console
-  console.log(`Colyseus server listening on ws://localhost:${PORT}`)
+  logger.info`Colyseus server listening on ws://localhost:${PORT}`
 })

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -23,6 +23,9 @@ import {
   createMinionSystemContext,
 } from '../game/ServerMinionSystem.js'
 import { generateBotInputs } from '../game/ServerBotSystem.js'
+import { createServerLogger } from '@shared/logging'
+
+const logger = createServerLogger('room')
 
 export const MAX_PLAYERS = 2
 
@@ -64,6 +67,7 @@ export class GameRoom extends Room<GameRoomState> {
 
   onCreate(options?: Record<string, unknown>): void {
     this.setState(new GameRoomState())
+    logger.info('Room created', { roomId: this.roomId })
 
     // Solo mode: 1 player + bot
     if (options?.mode === 'solo') {
@@ -87,6 +91,11 @@ export class GameRoom extends Room<GameRoomState> {
   onJoin(client: Client, options?: Record<string, unknown>): void {
     const hero = this.createHero(client.sessionId, options?.heroType)
     this.state.heroes.set(client.sessionId, hero)
+    logger.info('Player joined', {
+      roomId: this.roomId,
+      playerId: client.sessionId,
+      playerCount: this.state.heroes.size,
+    })
 
     if (this.isSoloMode) {
       // Solo mode: add bot to enemy team, start immediately
@@ -172,9 +181,15 @@ export class GameRoom extends Room<GameRoomState> {
   onLeave(client: Client): void {
     this.state.heroes.delete(client.sessionId)
     this.playerInputs.delete(client.sessionId)
+    logger.info('Player left', {
+      roomId: this.roomId,
+      playerId: client.sessionId,
+      playerCount: this.state.heroes.size,
+    })
   }
 
   onDispose(): void {
+    logger.info('Room disposed', { roomId: this.roomId })
     resetProjectileIdCounter()
     resetTowerProjectileIdCounter()
     this.minionCtx = createMinionSystemContext()

--- a/shared/logging.ts
+++ b/shared/logging.ts
@@ -1,0 +1,11 @@
+import { getLogger, type Logger } from '@logtape/logtape'
+
+const ROOT_CATEGORY = 'simoba'
+
+export function createClientLogger(subsystem: string): Logger {
+  return getLogger([ROOT_CATEGORY, 'client', subsystem])
+}
+
+export function createServerLogger(subsystem: string): Logger {
+  return getLogger([ROOT_CATEGORY, 'server', subsystem])
+}

--- a/src/config/logging.ts
+++ b/src/config/logging.ts
@@ -1,0 +1,16 @@
+import { configure, getConsoleSink } from '@logtape/logtape'
+
+export async function setupClientLogging(): Promise<void> {
+  await configure({
+    sinks: {
+      console: getConsoleSink(),
+    },
+    loggers: [
+      {
+        category: ['simoba', 'client'],
+        lowestLevel: import.meta.env.DEV ? 'debug' : 'warning',
+        sinks: ['console'],
+      },
+    ],
+  })
+}

--- a/src/domain/__tests__/logging.test.ts
+++ b/src/domain/__tests__/logging.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@logtape/logtape', () => {
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    getChild: vi.fn(),
+  }
+  return {
+    getLogger: vi.fn(() => mockLogger),
+  }
+})
+
+import { getLogger } from '@logtape/logtape'
+import { createClientLogger, createServerLogger } from '@shared/logging'
+
+describe('shared/logging', () => {
+  describe('createClientLogger', () => {
+    it('creates a logger with correct client category', () => {
+      createClientLogger('scene')
+      expect(getLogger).toHaveBeenCalledWith(['simoba', 'client', 'scene'])
+    })
+
+    it('creates loggers with different subsystems', () => {
+      createClientLogger('network')
+      expect(getLogger).toHaveBeenCalledWith(['simoba', 'client', 'network'])
+    })
+  })
+
+  describe('createServerLogger', () => {
+    it('creates a logger with correct server category', () => {
+      createServerLogger('room')
+      expect(getLogger).toHaveBeenCalledWith(['simoba', 'server', 'room'])
+    })
+
+    it('creates loggers with different subsystems', () => {
+      createServerLogger('system')
+      expect(getLogger).toHaveBeenCalledWith(['simoba', 'server', 'system'])
+    })
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
 import Phaser from 'phaser'
 import { gameConfig } from '@/config/gameConfig'
+import { setupClientLogging } from '@/config/logging'
+
+await setupClientLogging()
 
 const game = new Phaser.Game(gameConfig)
 

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -32,6 +32,9 @@ import { MinionRenderer } from '@/scenes/effects/MinionRenderer'
 import type { MinionState } from '@shared/entities/Minion'
 import { registerTestApi } from '@/test/e2eTestApi'
 import { GameHud } from '@/scenes/ui/GameHud'
+import { createClientLogger } from '@shared/logging'
+
+const logger = createClientLogger('scene')
 
 const FREE_CAMERA_SPEED = 400
 
@@ -84,7 +87,7 @@ export class GameScene extends Phaser.Scene {
 
   init(data?: { gameMode?: GameMode; localTeam?: Team; localPosition?: Position; heroType?: HeroType }): void {
     if (!data?.gameMode) {
-      console.error('GameScene: No gameMode provided, returning to LobbyScene')
+      logger.error('No gameMode provided, returning to LobbyScene')
       this.scene.start('LobbyScene')
       return
     }
@@ -96,6 +99,7 @@ export class GameScene extends Phaser.Scene {
 
   create(): void {
     if (!this.gameMode) return
+    logger.debug('Scene created', { sceneKey: this.scene.key })
 
     renderMap(this)
     this.physics.world.setBounds(0, 0, WORLD_WIDTH, WORLD_HEIGHT)
@@ -242,6 +246,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   shutdown(): void {
+    logger.debug('Scene shutdown', { sceneKey: this.scene.key })
     this.gameHud.destroy()
   }
 


### PR DESCRIPTION
## Summary
- Integrate `@logtape/logtape` v2.x for structured logging on both frontend and backend
- Backend: JSON stdout sink (CloudWatch Logs compatible) + console sink (dev only), hierarchical categories `simoba.server.*`
- Frontend: Console sink with environment-based level filtering (`debug` in dev, `warning` in prod), categories `simoba.client.*`
- Add `no-console` ESLint rule to enforce logger usage over direct `console.*` calls
- Shared logger factory in `shared/logging.ts` (`createClientLogger` / `createServerLogger`)

## Test plan
- [x] 522 unit tests pass (0 failures)
- [x] Server logging config tests — production (JSON only) and development (JSON + console) modes
- [x] Shared logging factory tests — correct category hierarchy for client and server loggers
- [ ] E2E: verify no console errors in browser during gameplay

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)