### PR TITLE
feat: XP/level sync pipeline with level-up and stats growth

### DIFF
--- a/openspec/changes/archive/2026-02-27-xp-level-sync/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-27-xp-level-sync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-27

--- a/openspec/changes/archive/2026-02-27-xp-level-sync/design.md
+++ b/openspec/changes/archive/2026-02-27-xp-level-sync/design.md
@@ -1,0 +1,80 @@
+## Context
+
+HUD にレベルバッジ・XP パイチャートが実装済みだが、サーバー→クライアントの同期パイプラインが欠落しているため常に Lv1/XP0 のまま。サーバーの `HeroSchema` には `xp` フィールドがあり、`ServerMinionSystem.processMinionDeaths` で `hero.xp += xpEach` が実行されているが、`level` フィールドが存在せず、レベルアップ判定もない。クライアント側は `HeroState` に `level`, `xp` フィールドが定義済みだが、`ServerHeroState` / `OnlineGameMode` でこれらを受け取っていない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- サーバー側でレベルアップ判定 + タレントポイント付与 + ステータス成長を行う
+- クライアント側で `xp`, `level`, `talentPoints` を同期し HUD に反映する
+- レベルアップ判定を純粋関数として実装しテスト容易にする
+
+**Non-Goals:**
+- タレント選択 UI・タレント取得ロジック（別 Issue）
+- レベルアップ演出・エフェクト
+- レベル連動リスポーンタイマー (#84)
+
+## Decisions
+
+### D1: レベルアップ判定は `shared/` の純粋関数
+
+レベルアップ判定ロジックを `shared/systems/levelUp.ts` に純粋関数として実装する。
+
+```typescript
+interface LevelUpResult {
+  readonly newLevel: number
+  readonly levelsGained: number
+}
+function computeLevelUp(currentLevel: number, xp: number): LevelUpResult
+```
+
+**理由:** `XP_THRESHOLDS` は `shared/constants.ts` に既にあり、判定ロジックはサーバー・クライアント双方で参照可能にしておくことで、将来のクライアント予測やテストが容易になる。Colyseus Schema への書き込みとロジックを分離する設計原則に沿う。
+
+**代替案:** `ServerMinionSystem` 内にインライン実装 → テスト性が低く、責務が混在するため不採用。
+
+### D2: ステータス成長は `ServerMinionSystem.processMinionDeaths` 内で XP 付与直後に適用
+
+XP 加算 → `computeLevelUp` → レベルが上がった場合のみ `HeroSchema` の各ステータスフィールドを更新する。
+
+```
+hero.xp += xpEach
+const { newLevel, levelsGained } = computeLevelUp(hero.level, hero.xp)
+if (levelsGained > 0) {
+  hero.level = newLevel
+  hero.talentPoints += levelsGained
+  // growth 適用: base + growth * (newLevel - 1) で再計算
+  applyStatsGrowth(hero, definition, newLevel)
+}
+```
+
+**理由:** XP 加算とレベルアップが同一 tick で処理されるため、中間状態がクライアントに同期されない。Colyseus は tick 末の state patch でまとめて送信するため、XP 変化 → level 変化 → stats 変化が1パッチで届く。
+
+### D3: ステータス成長関数 `applyStatsGrowth` でベース値から再計算
+
+レベルアップ時のステータス更新は `base + growth * (level - 1)` で再計算する方式。差分加算（`+= growth * levelsGained`）ではなく、常にベースから計算し直す。
+
+```typescript
+function applyStatsGrowth(hero: HeroSchema, def: HeroDefinition, newLevel: number): void
+```
+
+**理由:** 差分加算は浮動小数点誤差が蓄積しやすく、バフ解除後の値復元にも問題がある。ベース再計算なら常に正確な値が保証される。`maxHp` 増加時は `hp` も同量増やして「レベルアップで即死」を防ぐ。
+
+**代替案:** 差分加算 `+= growth * levelsGained` → 浮動小数点誤差リスクがあるため不採用。
+
+### D4: `HeroSchema` に `level: uint8`, `talentPoints: uint8` を追加
+
+`uint8` (0-255) で十分。`MAX_LEVEL=5`, タレントポイントは最大 4（Lv2-5 で各1）。既存の `xp: uint32` はそのまま利用。
+
+### D5: クライアント同期は既存パターンを踏襲
+
+`OnlineGameMode` のリスナーパターン（`$(hero).listen('field', schedule)`）に `xp`, `level`, `talentPoints` を追加。`notifyServerHeroUpdate` で `ServerHeroState` に含め、`applyServerHeroNonPositionState` で `HeroState` に反映する。既存の `HeroState` には `level`, `xp` が定義済みなので、`talentPoints` のみ追加が必要。
+
+### D6: `HeroState` に `talentPoints` フィールドを追加
+
+`shared/entities/Hero.ts` の `HeroState` に `talentPoints: number` を追加し、`createHeroState` で初期値 0 に設定する。
+
+## Risks / Trade-offs
+
+- **[複数レベルジャンプ]** → `computeLevelUp` が一括で最大レベルまで上げる設計で対応済み。テストで Lv1→Lv4 等のケースをカバーする。
+- **[maxHp 増加と hp]** → レベルアップ時に hp も増加させるが、現在 hp が maxHp を超えないようクランプが必要。`Math.min(hero.hp + hpGain, newMaxHp)` で対処。
+- **[Colyseus Schema 変更の後方互換]** → `level`, `talentPoints` はデフォルト値付きで追加するため、既存クライアントは 0/0 として受け取り問題なし。

--- a/openspec/changes/archive/2026-02-27-xp-level-sync/proposal.md
+++ b/openspec/changes/archive/2026-02-27-xp-level-sync/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+HUD にレベルバッジ・XP パイチャートが実装済み (#161) だが、サーバー → クライアントの XP/レベル同期パイプラインが欠落しており常に Lv1/XP0 のまま。サーバー側の `HeroSchema` に `level` フィールドがなく、レベルアップ判定もない。
+
+## What Changes
+
+- サーバー `HeroSchema` に `level`, `talentPoints` フィールドを追加し、XP 閾値超過時にレベルアップ + タレントポイント付与を行う
+- レベルアップ時に `talentPoints` を +1。タレント取得時に -1（タレント取得ロジック自体は本スコープ外）
+- クライアントの `ServerHeroState` / `OnlineGameMode` に `xp`, `level`, `talentPoints` を追加し同期パイプラインを完成させる
+- XP 閾値定数を `shared/constants.ts` に一元化する（既に移動済み、HUD 側の参照を確認）
+
+## Capabilities
+
+### New Capabilities
+- `xp-level-sync`: サーバー→クライアント間の XP/レベル同期パイプラインとレベルアップ処理
+
+### Modified Capabilities
+- `hero-stats`: `HeroSchema` に `level` フィールド追加、レベルアップによるステータス成長
+
+## Non-goals
+
+- タレント選択 UI・タレント取得ロジック（別 Issue。本スコープでは `talentPoints` の付与・同期のみ）
+- レベル連動リスポーンタイマー (#84)
+- レベルアップ演出・エフェクト（将来 Issue）
+- ヒーロースキルのレベル依存強化
+
+## Impact
+
+- `server/src/schema/HeroSchema.ts` — `level`, `talentPoints` フィールド追加
+- `server/src/game/ServerMinionSystem.ts` — XP 配布後のレベルアップ判定
+- `src/network/GameMode.ts` — `ServerHeroState` に `xp`, `level`, `talentPoints` 追加
+- `src/network/OnlineGameMode.ts` — `xp`, `level`, `talentPoints` のリスナー追加・抽出
+- `src/scenes/GameScene.ts` — `applyServerHeroNonPositionState` で `xp`, `level`, `talentPoints` 反映
+- 既存の `shared/constants.ts` に XP 定数は集約済み

--- a/openspec/changes/archive/2026-02-27-xp-level-sync/specs/hero-stats/spec.md
+++ b/openspec/changes/archive/2026-02-27-xp-level-sync/specs/hero-stats/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: HeroState の拡張
+HeroState に `stats: StatBlock`（実効ステータス）と `facing: number`（ラジアン角度）と `attackCooldown: number`（次の攻撃まで残り秒数）と `attackTargetId: string | null`（現在のターゲット ID）と `talentPoints: number`（未使用タレントポイント数、初期値 0）を持たなければならない（SHALL）。`stats` は試合中にバフ・レベルアップ等で変動する現在値を保持する。
+
+#### Scenario: createHeroState で初期状態を生成する
+- **WHEN** `createHeroState({ id, type: 'BLADE', team: 'blue', position })` を呼ぶ
+- **THEN** `stats` は `HERO_DEFINITIONS['BLADE'].base` と同じ値で初期化され、`facing` は 0、`attackCooldown` は 0、`attackTargetId` は `null`、`talentPoints` は 0 で初期化される
+
+#### Scenario: 実効ステータスがイミュータブルに更新される
+- **WHEN** ヒーローの移動速度がバフで変更される
+- **THEN** 新しい HeroState が `{ ...state, stats: { ...state.stats, speed: newSpeed } }` のように不変更新で生成される

--- a/openspec/changes/archive/2026-02-27-xp-level-sync/specs/xp-level-sync/spec.md
+++ b/openspec/changes/archive/2026-02-27-xp-level-sync/specs/xp-level-sync/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: サーバー側レベルアップ判定
+サーバーは XP 加算後に `XP_THRESHOLDS` を参照し、累積 XP が次レベルの閾値以上であればレベルを上げなければならない（SHALL）。1 回の XP 加算で複数レベル分の閾値を超えた場合、到達可能な最大レベルまで一括で上げなければならない（SHALL）。`MAX_LEVEL` を超えてはならない（SHALL NOT）。レベルアップ判定は純粋関数として実装し、`HeroSchema` への書き込みと分離しなければならない（SHALL）。
+
+#### Scenario: 閾値ちょうどでレベルアップ
+- **WHEN** level=1, xp=100 のヒーローに対しレベルアップ判定を行う
+- **THEN** 新しい level は 2 になる
+
+#### Scenario: 閾値未満ではレベルアップしない
+- **WHEN** level=1, xp=99 のヒーローに対しレベルアップ判定を行う
+- **THEN** level は 1 のまま変化しない
+
+#### Scenario: 複数レベルを一度に上がる
+- **WHEN** level=1, xp=600 のヒーローに対しレベルアップ判定を行う
+- **THEN** 新しい level は 4 になる（XP_THRESHOLDS[3]=600）
+
+#### Scenario: MAX_LEVEL を超えない
+- **WHEN** level=4, xp=2000 のヒーローに対しレベルアップ判定を行う
+- **THEN** 新しい level は MAX_LEVEL (5) になる
+
+### Requirement: レベルアップ時のタレントポイント付与
+レベルアップ時に上昇したレベル数と同じ数の `talentPoints` を加算しなければならない（SHALL）。例えば Lv1→Lv3 なら +2 ポイント。`talentPoints` の消費（タレント取得）は本スコープ外とする。
+
+#### Scenario: 1 レベルアップで 1 ポイント
+- **WHEN** level が 1 から 2 に上がる
+- **THEN** talentPoints が 1 加算される
+
+#### Scenario: 複数レベルアップで複数ポイント
+- **WHEN** level が 1 から 3 に上がる
+- **THEN** talentPoints が 2 加算される
+
+#### Scenario: レベルが変わらなければポイントは増えない
+- **WHEN** XP が加算されたが level が変化しない
+- **THEN** talentPoints は変化しない
+
+### Requirement: HeroSchema の level・talentPoints フィールド
+`HeroSchema` に `level: uint8`（初期値 1）と `talentPoints: uint8`（初期値 0）を追加しなければならない（SHALL）。Colyseus の state patch でクライアントに自動同期される。
+
+#### Scenario: ヒーロー生成時の初期値
+- **WHEN** GameRoom で新しいヒーローが生成される
+- **THEN** `level` は 1、`talentPoints` は 0 で初期化される
+
+#### Scenario: レベルアップ後の値
+- **WHEN** ヒーローの XP が 100 に達する
+- **THEN** `HeroSchema.level` が 2 に、`HeroSchema.talentPoints` が 1 に更新され、クライアントに同期される
+
+### Requirement: クライアント同期パイプライン
+`ServerHeroState` インターフェースに `xp`, `level`, `talentPoints` フィールドを追加しなければならない（SHALL）。`OnlineGameMode` で当該フィールドのリスナーを登録し、変更時に `GameScene` へ通知しなければならない（SHALL）。`applyServerHeroNonPositionState` で `xp`, `level`, `talentPoints` を `HeroState` に反映しなければならない（SHALL）。
+
+#### Scenario: サーバーで XP が変化した時にクライアントに反映される
+- **WHEN** サーバー側で `HeroSchema.xp` が 0 → 20 に変化する
+- **THEN** クライアントの `HeroState.xp` が 20 に更新される
+
+#### Scenario: サーバーでレベルアップした時にクライアントに反映される
+- **WHEN** サーバー側で `HeroSchema.level` が 1 → 2 に変化する
+- **THEN** クライアントの `HeroState.level` が 2 に更新され、HUD のレベルバッジが更新される
+
+#### Scenario: talentPoints がクライアントに反映される
+- **WHEN** サーバー側で `HeroSchema.talentPoints` が 0 → 1 に変化する
+- **THEN** クライアントの `HeroState.talentPoints` が 1 に更新される
+
+### Requirement: レベルアップ時のステータス成長
+レベルアップ時にヒーローの実効ステータスを `HeroDefinition.growth` に基づいて更新しなければならない（SHALL）。上昇したレベル数分の `growth` を `base` に加算した値を新しいステータスとしなければならない（SHALL）。`maxHp` 増加時は `hp` も同量増加させなければならない（SHALL）。
+
+#### Scenario: Lv1→Lv2 でステータスが成長する
+- **WHEN** BLADE ヒーローが Lv1 から Lv2 にレベルアップする
+- **THEN** `maxHp`, `attackDamage`, `speed` 等が `HERO_DEFINITIONS['BLADE'].growth` の値分だけ増加する
+
+#### Scenario: maxHp 増加時に hp も回復する
+- **WHEN** maxHp が 500 → 550 に増加する（growth.maxHp = 50）
+- **THEN** hp も 50 増加する（現在 hp + 50）
+
+#### Scenario: 複数レベルアップ時の成長量
+- **WHEN** Lv1 から Lv3 に 2 レベル上がる
+- **THEN** growth の 2 倍の値がステータスに加算される

--- a/openspec/changes/archive/2026-02-27-xp-level-sync/tasks.md
+++ b/openspec/changes/archive/2026-02-27-xp-level-sync/tasks.md
@@ -1,0 +1,25 @@
+## 1. Shared — レベルアップ純粋関数
+
+- [x] 1.1 `shared/systems/levelUp.ts` に `computeLevelUp(currentLevel, xp): LevelUpResult` を作成
+- [x] 1.2 `shared/systems/__tests__/levelUp.test.ts` にユニットテスト（閾値ちょうど、未満、複数レベルジャンプ、MAX_LEVEL 上限）
+
+## 2. Shared — HeroState 拡張
+
+- [x] 2.1 `shared/entities/Hero.ts` の `HeroState` に `talentPoints: number` を追加、`createHeroState` で初期値 0 に設定
+
+## 3. Server — Schema & レベルアップ
+
+- [x] 3.1 `server/src/schema/HeroSchema.ts` に `level: uint8`（初期値 1）、`talentPoints: uint8`（初期値 0）を追加
+- [x] 3.2 `server/src/game/ServerMinionSystem.ts` の `processMinionDeaths` で XP 加算後に `computeLevelUp` を呼び、レベルアップ時に `level`, `talentPoints` を更新
+- [x] 3.3 ステータス成長関数 `applyStatsGrowth(hero, definition, newLevel)` を作成し、レベルアップ時に `HeroSchema` のステータスフィールドを更新（maxHp 増加時は hp も増加）
+- [x] 3.4 `server/src/__tests__/levelUpIntegration.test.ts` にサーバー側レベルアップ統合テスト（XP 付与 → level 変化 → stats 成長 → talentPoints 付与）
+
+## 4. Client — 同期パイプライン
+
+- [x] 4.1 `src/network/GameMode.ts` の `ServerHeroState` に `xp`, `level`, `talentPoints` フィールドを追加
+- [x] 4.2 `src/network/OnlineGameMode.ts` で `xp`, `level`, `talentPoints` のリスナー追加と `notifyServerHeroUpdate` で抽出
+- [x] 4.3 `src/scenes/GameScene.ts` の `applyServerHeroNonPositionState` で `xp`, `level`, `talentPoints` を `HeroState` に反映
+
+## 5. Tests — 既存テスト確認
+
+- [x] 5.1 全ユニットテスト PASS 確認（`npm run test:unit`）

--- a/openspec/specs/hero-stats/spec.md
+++ b/openspec/specs/hero-stats/spec.md
@@ -34,11 +34,11 @@
 - **THEN** AURA 固有のベースステータス（中 HP、低攻撃力、中距離攻撃範囲、中速度）と成長量が返され、`canMoveWhileAttacking` は `false` である
 
 ### Requirement: HeroState の拡張
-HeroState に `stats: StatBlock`（実効ステータス）と `facing: number`（ラジアン角度）と `attackCooldown: number`（次の攻撃まで残り秒数）と `attackTargetId: string | null`（現在のターゲット ID）を持たなければならない（SHALL）。`stats` は試合中にバフ・レベルアップ等で変動する現在値を保持する。
+HeroState に `stats: StatBlock`（実効ステータス）と `facing: number`（ラジアン角度）と `attackCooldown: number`（次の攻撃まで残り秒数）と `attackTargetId: string | null`（現在のターゲット ID）と `talentPoints: number`（未使用タレントポイント数、初期値 0）を持たなければならない（SHALL）。`stats` は試合中にバフ・レベルアップ等で変動する現在値を保持する。
 
 #### Scenario: createHeroState で初期状態を生成する
 - **WHEN** `createHeroState({ id, type: 'BLADE', team: 'blue', position })` を呼ぶ
-- **THEN** `stats` は `HERO_DEFINITIONS['BLADE'].base` と同じ値で初期化され、`facing` は 0、`attackCooldown` は 0、`attackTargetId` は `null` で初期化される
+- **THEN** `stats` は `HERO_DEFINITIONS['BLADE'].base` と同じ値で初期化され、`facing` は 0、`attackCooldown` は 0、`attackTargetId` は `null`、`talentPoints` は 0 で初期化される
 
 #### Scenario: 実効ステータスがイミュータブルに更新される
 - **WHEN** ヒーローの移動速度がバフで変更される

--- a/openspec/specs/xp-level-sync/spec.md
+++ b/openspec/specs/xp-level-sync/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: サーバー側レベルアップ判定
+サーバーは XP 加算後に `XP_THRESHOLDS` を参照し、累積 XP が次レベルの閾値以上であればレベルを上げなければならない（SHALL）。1 回の XP 加算で複数レベル分の閾値を超えた場合、到達可能な最大レベルまで一括で上げなければならない（SHALL）。`MAX_LEVEL` を超えてはならない（SHALL NOT）。レベルアップ判定は純粋関数として実装し、`HeroSchema` への書き込みと分離しなければならない（SHALL）。
+
+#### Scenario: 閾値ちょうどでレベルアップ
+- **WHEN** level=1, xp=100 のヒーローに対しレベルアップ判定を行う
+- **THEN** 新しい level は 2 になる
+
+#### Scenario: 閾値未満ではレベルアップしない
+- **WHEN** level=1, xp=99 のヒーローに対しレベルアップ判定を行う
+- **THEN** level は 1 のまま変化しない
+
+#### Scenario: 複数レベルを一度に上がる
+- **WHEN** level=1, xp=600 のヒーローに対しレベルアップ判定を行う
+- **THEN** 新しい level は 4 になる（XP_THRESHOLDS[3]=600）
+
+#### Scenario: MAX_LEVEL を超えない
+- **WHEN** level=4, xp=2000 のヒーローに対しレベルアップ判定を行う
+- **THEN** 新しい level は MAX_LEVEL (5) になる
+
+### Requirement: レベルアップ時のタレントポイント付与
+レベルアップ時に上昇したレベル数と同じ数の `talentPoints` を加算しなければならない（SHALL）。例えば Lv1→Lv3 なら +2 ポイント。`talentPoints` の消費（タレント取得）は本スコープ外とする。
+
+#### Scenario: 1 レベルアップで 1 ポイント
+- **WHEN** level が 1 から 2 に上がる
+- **THEN** talentPoints が 1 加算される
+
+#### Scenario: 複数レベルアップで複数ポイント
+- **WHEN** level が 1 から 3 に上がる
+- **THEN** talentPoints が 2 加算される
+
+#### Scenario: レベルが変わらなければポイントは増えない
+- **WHEN** XP が加算されたが level が変化しない
+- **THEN** talentPoints は変化しない
+
+### Requirement: HeroSchema の level・talentPoints フィールド
+`HeroSchema` に `level: uint8`（初期値 1）と `talentPoints: uint8`（初期値 0）を追加しなければならない（SHALL）。Colyseus の state patch でクライアントに自動同期される。
+
+#### Scenario: ヒーロー生成時の初期値
+- **WHEN** GameRoom で新しいヒーローが生成される
+- **THEN** `level` は 1、`talentPoints` は 0 で初期化される
+
+#### Scenario: レベルアップ後の値
+- **WHEN** ヒーローの XP が 100 に達する
+- **THEN** `HeroSchema.level` が 2 に、`HeroSchema.talentPoints` が 1 に更新され、クライアントに同期される
+
+### Requirement: クライアント同期パイプライン
+`ServerHeroState` インターフェースに `xp`, `level`, `talentPoints` フィールドを追加しなければならない（SHALL）。`OnlineGameMode` で当該フィールドのリスナーを登録し、変更時に `GameScene` へ通知しなければならない（SHALL）。`applyServerHeroNonPositionState` で `xp`, `level`, `talentPoints` を `HeroState` に反映しなければならない（SHALL）。
+
+#### Scenario: サーバーで XP が変化した時にクライアントに反映される
+- **WHEN** サーバー側で `HeroSchema.xp` が 0 → 20 に変化する
+- **THEN** クライアントの `HeroState.xp` が 20 に更新される
+
+#### Scenario: サーバーでレベルアップした時にクライアントに反映される
+- **WHEN** サーバー側で `HeroSchema.level` が 1 → 2 に変化する
+- **THEN** クライアントの `HeroState.level` が 2 に更新され、HUD のレベルバッジが更新される
+
+#### Scenario: talentPoints がクライアントに反映される
+- **WHEN** サーバー側で `HeroSchema.talentPoints` が 0 → 1 に変化する
+- **THEN** クライアントの `HeroState.talentPoints` が 1 に更新される
+
+### Requirement: レベルアップ時のステータス成長
+レベルアップ時にヒーローの実効ステータスを `HeroDefinition.growth` に基づいて更新しなければならない（SHALL）。上昇したレベル数分の `growth` を `base` に加算した値を新しいステータスとしなければならない（SHALL）。`maxHp` 増加時は `hp` も同量増加させなければならない（SHALL）。
+
+#### Scenario: Lv1→Lv2 でステータスが成長する
+- **WHEN** BLADE ヒーローが Lv1 から Lv2 にレベルアップする
+- **THEN** `maxHp`, `attackDamage`, `speed` 等が `HERO_DEFINITIONS['BLADE'].growth` の値分だけ増加する
+
+#### Scenario: maxHp 増加時に hp も回復する
+- **WHEN** maxHp が 500 → 550 に増加する（growth.maxHp = 50）
+- **THEN** hp も 50 増加する（現在 hp + 50）
+
+#### Scenario: 複数レベルアップ時の成長量
+- **WHEN** Lv1 から Lv3 に 2 レベル上がる
+- **THEN** growth の 2 倍の値がステータスに加算される

--- a/server/src/__tests__/levelUpIntegration.test.ts
+++ b/server/src/__tests__/levelUpIntegration.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { MinionSchema } from '../schema/MinionSchema.js'
+import { HERO_DEFINITIONS } from '@shared/entities/Hero'
+import { XP_THRESHOLDS, MINION_XP_REWARD, MAX_LEVEL } from '@shared/constants'
+import {
+  processMinionDeaths,
+  applyStatsGrowth,
+  createMinionSystemContext,
+  type MinionSystemContext,
+} from '../game/ServerMinionSystem.js'
+
+function createTestHero(id: string, team: string, x: number): HeroSchema {
+  const hero = new HeroSchema()
+  const def = HERO_DEFINITIONS.BLADE
+  hero.id = id
+  hero.team = team
+  hero.x = x
+  hero.y = 360
+  hero.heroType = 'BLADE'
+  hero.hp = def.base.maxHp
+  hero.maxHp = def.base.maxHp
+  hero.speed = def.base.speed
+  hero.attackDamage = def.base.attackDamage
+  hero.attackRange = def.base.attackRange
+  hero.attackSpeed = def.base.attackSpeed
+  hero.radius = def.radius
+  hero.dead = false
+  hero.level = 1
+  hero.xp = 0
+  hero.talentPoints = 0
+  return hero
+}
+
+function createDeadMinion(id: string, team: string, x: number): MinionSchema {
+  const minion = new MinionSchema()
+  minion.id = id
+  minion.team = team
+  minion.x = x
+  minion.y = 360
+  minion.dead = true
+  minion.hp = 0
+  minion.maxHp = 100
+  return minion
+}
+
+describe('Level-up integration', () => {
+  let heroes: MapSchema<HeroSchema>
+  let minions: MapSchema<MinionSchema>
+  let ctx: MinionSystemContext
+
+  beforeEach(() => {
+    heroes = new MapSchema<HeroSchema>()
+    minions = new MapSchema<MinionSchema>()
+    ctx = createMinionSystemContext()
+  })
+
+  it('grants XP and levels up when threshold is reached', () => {
+    const hero = createTestHero('h1', 'blue', 800)
+    // Set XP just below level 2 threshold
+    hero.xp = XP_THRESHOLDS[1] - MINION_XP_REWARD
+    heroes.set('h1', hero)
+
+    const minion = createDeadMinion('m1', 'red', 800)
+    minions.set('m1', minion)
+
+    processMinionDeaths(ctx, minions, heroes, 0.016)
+
+    expect(hero.xp).toBe(XP_THRESHOLDS[1])
+    expect(hero.level).toBe(2)
+    expect(hero.talentPoints).toBe(1)
+  })
+
+  it('does not level up when XP is below threshold', () => {
+    const hero = createTestHero('h1', 'blue', 800)
+    hero.xp = 0
+    heroes.set('h1', hero)
+
+    const minion = createDeadMinion('m1', 'red', 800)
+    minions.set('m1', minion)
+
+    processMinionDeaths(ctx, minions, heroes, 0.016)
+
+    expect(hero.xp).toBe(MINION_XP_REWARD)
+    expect(hero.level).toBe(1)
+    expect(hero.talentPoints).toBe(0)
+  })
+
+  it('applies stats growth on level up', () => {
+    const hero = createTestHero('h1', 'blue', 800)
+    const def = HERO_DEFINITIONS.BLADE
+    hero.xp = XP_THRESHOLDS[1] - MINION_XP_REWARD
+    heroes.set('h1', hero)
+
+    const prevMaxHp = hero.maxHp
+    const minion = createDeadMinion('m1', 'red', 800)
+    minions.set('m1', minion)
+
+    processMinionDeaths(ctx, minions, heroes, 0.016)
+
+    expect(hero.maxHp).toBe(def.base.maxHp + def.growth.maxHp)
+    expect(hero.speed).toBe(def.base.speed + def.growth.speed)
+    // HP should have increased by the maxHp growth
+    expect(hero.hp).toBe(prevMaxHp + def.growth.maxHp)
+  })
+
+  it('handles multi-level jump and grants correct talent points', () => {
+    const hero = createTestHero('h1', 'blue', 800)
+    // Set XP so that after reward, hero reaches level 3 threshold
+    hero.xp = XP_THRESHOLDS[2] - MINION_XP_REWARD
+    heroes.set('h1', hero)
+
+    const minion = createDeadMinion('m1', 'red', 800)
+    minions.set('m1', minion)
+
+    processMinionDeaths(ctx, minions, heroes, 0.016)
+
+    expect(hero.level).toBe(3)
+    expect(hero.talentPoints).toBe(2) // jumped 2 levels
+  })
+
+  it('caps at MAX_LEVEL', () => {
+    const hero = createTestHero('h1', 'blue', 800)
+    hero.xp = 99999
+    hero.level = MAX_LEVEL
+    heroes.set('h1', hero)
+
+    const minion = createDeadMinion('m1', 'red', 800)
+    minions.set('m1', minion)
+
+    processMinionDeaths(ctx, minions, heroes, 0.016)
+
+    expect(hero.level).toBe(MAX_LEVEL)
+    expect(hero.talentPoints).toBe(0)
+  })
+
+  describe('applyStatsGrowth', () => {
+    it('recalculates stats from base + growth * (level - 1)', () => {
+      const hero = createTestHero('h1', 'blue', 800)
+      const def = HERO_DEFINITIONS.BLADE
+
+      applyStatsGrowth(hero, 3)
+
+      expect(hero.maxHp).toBe(def.base.maxHp + def.growth.maxHp * 2)
+      expect(hero.speed).toBe(def.base.speed + def.growth.speed * 2)
+      expect(hero.attackDamage).toBe(Math.round(def.base.attackDamage + def.growth.attackDamage * 2))
+      expect(hero.attackSpeed).toBe(def.base.attackSpeed + def.growth.attackSpeed * 2)
+    })
+
+    it('increases hp when maxHp grows', () => {
+      const hero = createTestHero('h1', 'blue', 800)
+      const def = HERO_DEFINITIONS.BLADE
+      hero.hp = def.base.maxHp // full HP
+
+      applyStatsGrowth(hero, 2)
+
+      const expectedMaxHp = def.base.maxHp + def.growth.maxHp
+      expect(hero.maxHp).toBe(expectedMaxHp)
+      expect(hero.hp).toBe(expectedMaxHp) // full HP stays full
+    })
+
+    it('does not let hp exceed maxHp', () => {
+      const hero = createTestHero('h1', 'blue', 800)
+      const def = HERO_DEFINITIONS.BLADE
+      hero.hp = def.base.maxHp // full HP
+
+      applyStatsGrowth(hero, 2)
+
+      expect(hero.hp).toBeLessThanOrEqual(hero.maxHp)
+    })
+
+    it('adds maxHp growth to current hp when hero is damaged', () => {
+      const hero = createTestHero('h1', 'blue', 800)
+      const def = HERO_DEFINITIONS.BLADE
+      hero.hp = 400 // damaged
+
+      applyStatsGrowth(hero, 2)
+
+      const expectedMaxHp = def.base.maxHp + def.growth.maxHp
+      expect(hero.maxHp).toBe(expectedMaxHp)
+      expect(hero.hp).toBe(400 + def.growth.maxHp)
+    })
+  })
+})

--- a/server/src/game/ServerMinionSystem.ts
+++ b/server/src/game/ServerMinionSystem.ts
@@ -1,5 +1,6 @@
 import { MapSchema } from '@colyseus/schema'
 import { isInAttackRange } from '@shared/combat'
+import { HERO_DEFINITIONS } from '@shared/entities/Hero'
 import { MELEE_MINION, RANGED_MINION } from '@shared/entities/Minion'
 import {
   MINION_WAVE_INTERVAL,
@@ -15,6 +16,8 @@ import {
   RANGED_Y,
   getWaveConfig,
 } from '@shared/constants'
+import type { HeroType } from '@shared/types'
+import { computeLevelUp } from '@shared/systems/levelUp'
 import type { MinionSchema } from '../schema/MinionSchema.js'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { TowerSchema } from '../schema/TowerSchema.js'
@@ -430,6 +433,29 @@ function separateTeam(team: MinionSchema[]): void {
   }
 }
 
+// --- Stats Growth ---
+
+/** Recalculate hero stats from base + growth * (level - 1). Mutates the HeroSchema. */
+export function applyStatsGrowth(hero: HeroSchema, newLevel: number): void {
+  const def = HERO_DEFINITIONS[hero.heroType as HeroType]
+  if (!def) {
+    throw new Error(`Unknown heroType: "${hero.heroType}"`)
+  }
+  const prevMaxHp = hero.maxHp
+
+  hero.maxHp = Math.round(def.base.maxHp + def.growth.maxHp * (newLevel - 1))
+  hero.speed = def.base.speed + def.growth.speed * (newLevel - 1)
+  hero.attackDamage = Math.round(def.base.attackDamage + def.growth.attackDamage * (newLevel - 1))
+  hero.attackRange = def.base.attackRange + def.growth.attackRange * (newLevel - 1)
+  hero.attackSpeed = def.base.attackSpeed + def.growth.attackSpeed * (newLevel - 1)
+
+  // Increase current HP by the same amount maxHp grew (prevent level-up death)
+  const hpGain = hero.maxHp - prevMaxHp
+  if (hpGain > 0) {
+    hero.hp = Math.min(hero.hp + hpGain, hero.maxHp)
+  }
+}
+
 // --- Death + XP Distribution ---
 
 export function processMinionDeaths(
@@ -462,6 +488,12 @@ export function processMinionDeaths(
         const xpEach = Math.floor(MINION_XP_REWARD / eligibleHeroes.length)
         for (const hero of eligibleHeroes) {
           hero.xp = hero.xp + xpEach
+          const { newLevel, levelsGained } = computeLevelUp(hero.level, hero.xp)
+          if (levelsGained > 0) {
+            hero.level = newLevel
+            hero.talentPoints = hero.talentPoints + levelsGained
+            applyStatsGrowth(hero, newLevel)
+          }
         }
       }
 

--- a/server/src/game/ServerMinionSystem.ts
+++ b/server/src/game/ServerMinionSystem.ts
@@ -14,6 +14,7 @@ import {
   RED_RANGED_X,
   MELEE_Y_OFFSETS,
   RANGED_Y,
+  MAX_LEVEL,
   getWaveConfig,
 } from '@shared/constants'
 import type { HeroType } from '@shared/types'
@@ -437,6 +438,9 @@ function separateTeam(team: MinionSchema[]): void {
 
 /** Recalculate hero stats from base + growth * (level - 1). Mutates the HeroSchema. */
 export function applyStatsGrowth(hero: HeroSchema, newLevel: number): void {
+  if (newLevel < 1 || newLevel > MAX_LEVEL) {
+    throw new Error(`applyStatsGrowth: newLevel ${newLevel} out of range`)
+  }
   const def = HERO_DEFINITIONS[hero.heroType as HeroType]
   if (!def) {
     throw new Error(`Unknown heroType: "${hero.heroType}"`)

--- a/server/src/schema/HeroSchema.ts
+++ b/server/src/schema/HeroSchema.ts
@@ -18,5 +18,7 @@ export class HeroSchema extends CombatEntitySchema {
   @type('float32') respawnTimer: number = 0
   @type('uint32') lastProcessedSeq: number = 0
   @type('uint32') xp: number = 0
+  @type('uint8') level: number = 1
+  @type('uint8') talentPoints: number = 0
   @type('boolean') isBot: boolean = false
 }

--- a/shared/entities/Hero.ts
+++ b/shared/entities/Hero.ts
@@ -82,6 +82,7 @@ export interface HeroState extends AttackerEntityState {
   readonly type: HeroType
   readonly level: number
   readonly xp: number
+  readonly talentPoints: number
   /** Seconds remaining until respawn (0 = alive or ready to respawn) */
   readonly respawnTimer: number
   /** Position where the hero died (reserved for custom respawn logic — Issue #84) */
@@ -110,6 +111,7 @@ export function createHeroState(params: CreateHeroParams): HeroState {
     radius: definition.radius,
     level: 1,
     xp: 0,
+    talentPoints: 0,
     stats,
     facing: 0,
     attackCooldown: 0,

--- a/shared/systems/__tests__/levelUp.test.ts
+++ b/shared/systems/__tests__/levelUp.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { computeLevelUp } from '../levelUp'
+import { MAX_LEVEL, XP_THRESHOLDS } from '@shared/constants'
+
+describe('computeLevelUp', () => {
+  it('returns no change when XP is below threshold', () => {
+    const result = computeLevelUp(1, 50)
+    expect(result).toEqual({ newLevel: 1, levelsGained: 0 })
+  })
+
+  it('levels up at exact threshold (Lv1 → Lv2 at 100 XP)', () => {
+    const result = computeLevelUp(1, 100)
+    expect(result).toEqual({ newLevel: 2, levelsGained: 1 })
+  })
+
+  it('levels up at exact threshold (Lv2 → Lv3 at 300 XP)', () => {
+    const result = computeLevelUp(2, 300)
+    expect(result).toEqual({ newLevel: 3, levelsGained: 1 })
+  })
+
+  it('handles multi-level jump (Lv1 → Lv4)', () => {
+    // XP_THRESHOLDS = [0, 100, 300, 600, 1000]
+    // 700 XP >= threshold[3]=600, so level 4
+    const result = computeLevelUp(1, 700)
+    expect(result).toEqual({ newLevel: 4, levelsGained: 3 })
+  })
+
+  it('caps at MAX_LEVEL', () => {
+    const result = computeLevelUp(1, 99999)
+    expect(result).toEqual({ newLevel: MAX_LEVEL, levelsGained: MAX_LEVEL - 1 })
+  })
+
+  it('returns no change when already at MAX_LEVEL', () => {
+    const result = computeLevelUp(MAX_LEVEL, 99999)
+    expect(result).toEqual({ newLevel: MAX_LEVEL, levelsGained: 0 })
+  })
+
+  it('does not level up when XP is 1 below threshold', () => {
+    const result = computeLevelUp(1, XP_THRESHOLDS[1] - 1)
+    expect(result).toEqual({ newLevel: 1, levelsGained: 0 })
+  })
+
+  it('handles XP exactly at MAX_LEVEL threshold', () => {
+    const result = computeLevelUp(1, XP_THRESHOLDS[MAX_LEVEL - 1])
+    expect(result).toEqual({ newLevel: MAX_LEVEL, levelsGained: MAX_LEVEL - 1 })
+  })
+
+  it('returns no change for 0 XP at level 1', () => {
+    const result = computeLevelUp(1, 0)
+    expect(result).toEqual({ newLevel: 1, levelsGained: 0 })
+  })
+})

--- a/shared/systems/levelUp.ts
+++ b/shared/systems/levelUp.ts
@@ -1,0 +1,27 @@
+import { MAX_LEVEL, XP_THRESHOLDS } from '@shared/constants'
+
+export interface LevelUpResult {
+  readonly newLevel: number
+  readonly levelsGained: number
+}
+
+/**
+ * Compute the new level based on current level and total XP.
+ * Iterates through XP_THRESHOLDS to find the highest level the XP qualifies for.
+ * Caps at MAX_LEVEL.
+ */
+export function computeLevelUp(currentLevel: number, xp: number): LevelUpResult {
+  const clamped = Math.max(1, Math.min(currentLevel, MAX_LEVEL))
+  let newLevel = clamped
+  for (let i = clamped; i < MAX_LEVEL; i++) {
+    if (xp >= XP_THRESHOLDS[i]) {
+      newLevel = i + 1
+    } else {
+      break
+    }
+  }
+  return {
+    newLevel,
+    levelsGained: newLevel - clamped,
+  }
+}

--- a/shared/systems/levelUp.ts
+++ b/shared/systems/levelUp.ts
@@ -9,6 +9,9 @@ export interface LevelUpResult {
  * Compute the new level based on current level and total XP.
  * Iterates through XP_THRESHOLDS to find the highest level the XP qualifies for.
  * Caps at MAX_LEVEL.
+ *
+ * Index-to-level mapping: XP_THRESHOLDS[i] is the cumulative XP required to
+ * reach level i+1. e.g. XP_THRESHOLDS[1]=100 means 100 XP → level 2.
  */
 export function computeLevelUp(currentLevel: number, xp: number): LevelUpResult {
   const clamped = Math.max(1, Math.min(currentLevel, MAX_LEVEL))

--- a/src/network/GameMode.ts
+++ b/src/network/GameMode.ts
@@ -16,6 +16,9 @@ export interface ServerHeroState {
   readonly attackCooldown: number
   readonly respawnTimer: number
   readonly lastProcessedSeq: number
+  readonly xp: number
+  readonly level: number
+  readonly talentPoints: number
 }
 
 /** Server-synced projectile for rendering */

--- a/src/network/OnlineGameMode.ts
+++ b/src/network/OnlineGameMode.ts
@@ -119,6 +119,9 @@ export class OnlineGameMode implements GameMode {
       $(hero).listen('radius', schedule)
       $(hero).listen('respawnTimer', schedule)
       $(hero).listen('lastProcessedSeq', schedule)
+      $(hero).listen('xp', schedule)
+      $(hero).listen('level', schedule)
+      $(hero).listen('talentPoints', schedule)
     })
 
     $(this.room.state.heroes).onRemove((_hero: SchemaInstance, sessionId: string) => {
@@ -210,6 +213,9 @@ export class OnlineGameMode implements GameMode {
       attackCooldown: hero.attackCooldown as number,
       respawnTimer: hero.respawnTimer as number,
       lastProcessedSeq: hero.lastProcessedSeq as number,
+      xp: hero.xp as number,
+      level: hero.level as number,
+      talentPoints: hero.talentPoints as number,
     }
     for (const cb of this.serverHeroUpdateCallbacks) cb(state)
   }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -461,6 +461,9 @@ export class GameScene extends Phaser.Scene {
       dead: state.dead,
       attackTargetId: state.attackTargetId || null,
       respawnTimer: state.respawnTimer,
+      xp: state.xp,
+      level: state.level,
+      talentPoints: state.talentPoints,
     }))
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default mergeConfig(
     test: {
       globals: true,
       environment: 'happy-dom',
-      include: ['src/**/__tests__/**/*.test.ts', 'server/src/__tests__/**/*.test.ts'],
+      include: ['src/**/__tests__/**/*.test.ts', 'server/src/__tests__/**/*.test.ts', 'shared/**/__tests__/**/*.test.ts'],
       coverage: {
         provider: 'v8',
         include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary
- Add `computeLevelUp` pure function in `shared/systems/levelUp.ts` for threshold-based level-up calculation
- Add `applyStatsGrowth` in `ServerMinionSystem` to recalculate hero stats from `base + growth * (level - 1)` on level-up
- Add `level: uint8`, `talentPoints: uint8` fields to `HeroSchema` for Colyseus state sync
- Add `talentPoints: number` to shared `HeroState` interface
- Wire full client sync pipeline: `OnlineGameMode` listeners → `ServerHeroState` → `applyServerHeroNonPositionState`
- Add 18 new tests (9 unit for computeLevelUp, 9 integration for server level-up flow)

## Test plan
- [x] `computeLevelUp` — threshold exact, below, multi-level jump, MAX_LEVEL cap (9 tests)
- [x] Server integration — XP grant → level change → stats growth → talentPoints (9 tests)
- [x] Full test suite: 540 tests pass across 53 files
- [ ] Manual: verify HUD level badge and XP pie chart update in-game after minion kills

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)