### PR TITLE
feat: level-dependent respawn timer scaling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,14 +26,52 @@ All game/tech specs live in `openspec/specs/`:
 
 ## Current Phase
 
-**Phase 1: Prototype (Bot Battle)**
-- No backend. Phaser.js standalone.
-- Static hosting only.
+**Phase 1: Prototype**
+- Online-first: Colyseus server + Phaser.js client.
 - Goal: "Fun in 5 minutes" validation.
 
 ## Design Principles
 
 - MOBA depth with .io accessibility
 - Geometric visual style (no image assets, Canvas shapes only)
-- Immutable state patterns (per coding-style rules)
 - Many small files, feature-based organization
+
+## Design Quality
+
+- **Reusability** — Don't repeat logic. Extract shared code to `shared/` or generic methods.
+- **Layered architecture** — Clear layer responsibilities: Schema → GameRoom → System → Pure functions.
+- **Separation of concerns** — 1 module = 1 responsibility. Separate judgment logic from state mutation (e.g. `checkTowerDestroyed()` vs `endMatch()`).
+- **Structural correctness** — Follow existing design patterns. Record reasons in design.md when introducing new patterns.
+- **Dependency direction** — Inheritance/implementation direction must be correct. Upper layers must not depend on lower layers.
+
+## Architecture: Online-First
+
+- **Server-authoritative is the standard** — Game logic lives on the server.
+- **No offline-only implementations** — Don't add individual logic to OfflineGameMode.
+- **Future:** Offline mode → local Colyseus server reusing the same GameRoom logic (Issue #143).
+
+## Coding Rules
+
+- **Immutability** — Domain layer creates new objects, no mutation. (Exception: Colyseus Schema is mutated directly on server.)
+- **File size** — 200-400 lines typical, 800 max. Split when larger.
+- **Feature-based organization** — Organize by feature/domain (`domain/systems/`, `scenes/effects/`), not by type (`models/`, `utils/`).
+- **No hardcoded balance values** — Game balance numbers (damage, timers, XP, growth rates, etc.) must be centralized in constant tables for easy tuning later.
+
+## Git Workflow
+
+- **Git Flow:** `main` ← `develop` ← `feature/xxx`
+- **GitHub default branch:** `develop` (PR auto-base, `Closes #XX` triggers on develop merge)
+- **Branch naming:** Full prefix only (`feature/`). Abbreviations like `feat/` are not allowed.
+
+## Development Flow
+
+1. **Plan** — Create an Issue
+2. **Branch** — `git checkout -b feature/xxx develop`
+3. **OpenSpec** — `/opsx:new` → `/opsx:continue` (review each artifact) → `/opsx:apply` → `/opsx:verify`
+   - Do NOT use `/opsx:ff` (skips user confirmation)
+4. **Test** — `npm run test:unit` + `npm run test:e2e` → all PASS
+5. **Self-review** — Run code-reviewer subagent, fix issues before presenting to user
+6. **PR** — `feature/*` → `develop`, include Summary + Test Plan
+7. **Review** — Address feedback → all checks PASS
+8. **Done** — `/opsx:archive` first → then merge PR (CI openspec-check detects unarchived changes)
+- **Out-of-scope work → create an Issue** (don't implement on the spot)

--- a/e2e/death-respawn.spec.ts
+++ b/e2e/death-respawn.spec.ts
@@ -42,7 +42,7 @@ test.describe('Death and Respawn', () => {
     expect(deadState.dead).toBe(true)
     expect(deadState.hp).toBeLessThanOrEqual(0)
 
-    // Wait for enemy to respawn (DEFAULT_RESPAWN_TIME = 5s)
+    // Wait for enemy to respawn (level-dependent: Lv1 = 3s, see RESPAWN_TIMES)
     await page.waitForFunction(
       () => !((window as unknown as TestWindow).__test__.getEnemyDead()),
       { timeout: 10000 }

--- a/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/design.md
+++ b/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/design.md
@@ -1,0 +1,60 @@
+## Context
+
+現在 `processDeathAndRespawn` はヒーロー死亡時に `DEFAULT_RESPAWN_TIME`（5秒）を直接使用している。death-respawn spec には「Configurable respawn time」要件があるが、実装は引数化されていない。Issue #84 ではレベルに応じてリスポーン時間を変動させ、終盤のデスペナルティを重くする。
+
+関連ファイル:
+- `shared/constants.ts` — `DEFAULT_RESPAWN_TIME = 5`
+- `server/src/game/ServerDeathSystem.ts` — `processDeathAndRespawn()`
+- `server/src/schema/HeroSchema.ts` — `level: uint8` (XP/level sync で追加済み)
+
+## Goals / Non-Goals
+
+**Goals:**
+- レベルに応じたリスポーン時間の算出ロジックを `shared/` に純粋関数として定義する
+- `processDeathAndRespawn` でヒーローの `level` を参照してリスポーン時間を決定する
+- 5分マッチに適したバランスのリスポーン秒数を設定する
+
+**Non-Goals:**
+- リスポーン時間の UI 表示変更（既に `respawnTimer` を表示しており、値が変わるだけで自動対応）
+- リスポーン位置のレベル連動
+- バフ/デバフによるリスポーン時間変動（将来課題）
+
+## Decisions
+
+### 1. 算出方式: 線形補間テーブル
+
+**選択:** レベルごとの固定テーブル `RESPAWN_TIMES: readonly number[]`
+
+**根拠:** 5段階（MAX_LEVEL=5）なのでテーブルが最もシンプルで調整しやすい。計算式より直感的にバランス調整可能。
+
+**代替案:**
+- 計算式 `base + perLevel * (level - 1)` — レベル数が少ないため過剰
+- 非線形式（二次関数等）— 5段階では差が出にくく複雑すぎる
+
+**値の設計:**
+- Lv1: 3秒（序盤は軽いペナルティ）
+- Lv2: 5秒
+- Lv3: 8秒
+- Lv4: 12秒
+- Lv5: 15秒（5分マッチの終盤で15秒は大きなペナルティ）
+
+### 2. 純粋関数の配置
+
+**選択:** `shared/systems/respawnTimer.ts` に `computeRespawnTime(level: number): number` を定義
+
+**根拠:** `computeLevelUp` と同じパターン。shared に置くことでサーバー・テスト両方から利用可能。
+
+### 3. processDeathAndRespawn の変更方針
+
+**選択:** 関数内部で `hero.level` から直接算出する（引数追加なし）
+
+**根拠:** `hero` (HeroSchema) は既に `level` フィールドを持っている。リスポーン時間は常にヒーロー自身のレベルで決まるため、外部から渡す必要がない。関数シグネチャ変更を避けることで呼び出し側への影響を最小化。
+
+**代替案:**
+- 引数でリスポーン時間を渡す — death-respawn spec の「Configurable respawn time」に沿うが、現状レベル以外の変動要因がなく過剰設計
+- コールバック関数で算出 — 同上
+
+## Risks / Trade-offs
+
+- **バランス調整リスク** → テーブル方式なので定数変更のみで対応可能。実際のプレイテストで調整。
+- **E2E テスト `death-respawn.spec.ts` への影響** → 固定5秒前提のウェイトがあれば修正が必要。ただしレベル1ヒーローなら3秒になるため、待機時間は短くなる方向で壊れにくい。

--- a/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/proposal.md
+++ b/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+現在リスポーン時間は固定5秒 (`DEFAULT_RESPAWN_TIME`) だが、レベルが上がっても同じペナルティでは終盤のデスの重みが薄い。レベル連動させることで、序盤は軽く・終盤は重いデスペナルティとなり、試合終盤の緊張感が増す。XP/レベルシステム (#162) が完成した今が導入タイミング。
+
+## What Changes
+
+- リスポーン時間をヒーローレベルに応じて変動させる計算式/テーブルを `shared/` に定義する
+- `ServerDeathSystem.processDeathAndRespawn` で固定値 `DEFAULT_RESPAWN_TIME` の代わりにレベル依存の値を使用する
+- `DEFAULT_RESPAWN_TIME` 定数は基本値として残し、レベル係数を追加する
+
+## Capabilities
+
+### New Capabilities
+- `respawn-timer-scaling`: リスポーン時間のレベル連動ロジック。レベル→リスポーン秒数の算出式、定数定義、純粋関数
+
+### Modified Capabilities
+- `death-respawn`: リスポーンタイマー設定時にレベル依存の値を使用するよう要件変更
+
+## Impact
+
+- `shared/constants.ts` — リスポーン時間関連の定数追加
+- `shared/systems/` — リスポーン時間算出の純粋関数追加
+- `server/src/game/ServerDeathSystem.ts` — `processDeathAndRespawn` でレベル依存タイマー使用
+- `server/src/__tests__/ServerDeathSystem.test.ts` — レベル連動テスト追加
+- クライアント側変更なし（`respawnTimer` は既に Schema 経由で同期済み）

--- a/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/specs/death-respawn/spec.md
+++ b/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/specs/death-respawn/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Configurable respawn time
+
+リスポーン時間はヒーローのレベルに応じて `computeRespawnTime(hero.level)` で算出しなければならない（SHALL）。`DEFAULT_RESPAWN_TIME` 定数は使用しない。
+
+#### Scenario: レベル1ヒーローの死亡
+
+- **WHEN** レベル1のヒーローが死亡する
+- **THEN** `respawnTimer` に 3秒がセットされる
+
+#### Scenario: レベル5ヒーローの死亡
+
+- **WHEN** レベル5のヒーローが死亡する
+- **THEN** `respawnTimer` に 15秒がセットされる
+
+#### Scenario: レベルアップ後の死亡
+
+- **WHEN** レベル3のヒーローが死亡する
+- **THEN** `respawnTimer` に 8秒がセットされる（死亡時点のレベルで算出）

--- a/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/specs/respawn-timer-scaling/spec.md
+++ b/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/specs/respawn-timer-scaling/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: レベル別リスポーン時間テーブル
+
+`RESPAWN_TIMES` 定数をレベルごとのリスポーン秒数テーブルとして定義しなければならない（SHALL）。インデックスはレベル値に対応し、`RESPAWN_TIMES[level]` でそのレベルのリスポーン秒数を取得できなければならない（SHALL）。
+
+#### Scenario: 各レベルのリスポーン時間
+
+- **WHEN** ヒーローのレベルが 1〜5 のいずれかである
+- **THEN** `RESPAWN_TIMES[level]` が以下の値を返す: Lv1=3秒, Lv2=5秒, Lv3=8秒, Lv4=12秒, Lv5=15秒
+
+### Requirement: リスポーン時間算出関数
+
+純粋関数 `computeRespawnTime(level: number): number` を提供しなければならない（SHALL）。`RESPAWN_TIMES` テーブルからレベルに応じたリスポーン秒数を返さなければならない（SHALL）。レベルが範囲外の場合は最も近い有効レベルにクランプしなければならない（SHALL）。
+
+#### Scenario: レベル1のリスポーン時間
+
+- **WHEN** `computeRespawnTime(1)` を呼ぶ
+- **THEN** 3 が返される
+
+#### Scenario: レベル5のリスポーン時間
+
+- **WHEN** `computeRespawnTime(5)` を呼ぶ
+- **THEN** 15 が返される
+
+#### Scenario: レベル0（範囲外下限）
+
+- **WHEN** `computeRespawnTime(0)` を呼ぶ
+- **THEN** レベル1と同じ値（3）が返される
+
+#### Scenario: MAX_LEVEL超過（範囲外上限）
+
+- **WHEN** `computeRespawnTime(10)` を呼ぶ
+- **THEN** レベル5（MAX_LEVEL）と同じ値（15）が返される

--- a/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/tasks.md
+++ b/openspec/changes/archive/2026-03-02-respawn-timer-level-scaling/tasks.md
@@ -1,0 +1,14 @@
+## 1. 定数・純粋関数 (spec: respawn-timer-scaling)
+
+- [x] 1.1 `RESPAWN_TIMES` テーブルを `shared/constants.ts` に追加する（`[0, 3, 5, 8, 12, 15]` — index=level）
+- [x] 1.2 `computeRespawnTime(level)` 純粋関数を `shared/systems/respawnTimer.ts` に作成する
+- [x] 1.3 `computeRespawnTime` のユニットテストを作成する（Lv1〜5、範囲外クランプ）
+
+## 2. サーバー統合 (spec: death-respawn)
+
+- [x] 2.1 `processDeathAndRespawn` で `DEFAULT_RESPAWN_TIME` の代わりに `computeRespawnTime(hero.level)` を使用する
+- [x] 2.2 `ServerDeathSystem.test.ts` にレベル連動リスポーンタイマーのテストを追加する
+
+## 3. 検証
+
+- [x] 3.1 全テスト実行（`npm run test:unit`）して PASS を確認する

--- a/openspec/specs/death-respawn/spec.md
+++ b/openspec/specs/death-respawn/spec.md
@@ -104,17 +104,22 @@
 
 ### Requirement: Configurable respawn time
 
-リスポーン時間は関数引数として外部から渡せる構造とする。デフォルト値は `DEFAULT_RESPAWN_TIME`（5秒）定数を使用する。
+リスポーン時間はヒーローのレベルに応じて `computeRespawnTime(hero.level)` で算出しなければならない（SHALL）。`DEFAULT_RESPAWN_TIME` 定数は使用しない。
 
-#### Scenario: Default respawn time
+#### Scenario: レベル1ヒーローの死亡
 
-- **WHEN** リスポーン時間が明示的に指定されていない
-- **THEN** `DEFAULT_RESPAWN_TIME`（5秒）が使用される
+- **WHEN** レベル1のヒーローが死亡する
+- **THEN** `respawnTimer` に 3秒がセットされる
 
-#### Scenario: Custom respawn time
+#### Scenario: レベル5ヒーローの死亡
 
-- **WHEN** リスポーン時間が引数で指定される
-- **THEN** 指定された秒数が `respawnTimer` にセットされる
+- **WHEN** レベル5のヒーローが死亡する
+- **THEN** `respawnTimer` に 15秒がセットされる
+
+#### Scenario: レベルアップ後の死亡
+
+- **WHEN** レベル3のヒーローが死亡する
+- **THEN** `respawnTimer` に 8秒がセットされる（死亡時点のレベルで算出）
 
 ### Requirement: Free camera during death
 

--- a/openspec/specs/respawn-timer-scaling/spec.md
+++ b/openspec/specs/respawn-timer-scaling/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: レベル別リスポーン時間テーブル
+
+`RESPAWN_TIMES` 定数をレベルごとのリスポーン秒数テーブルとして定義しなければならない（SHALL）。インデックスはレベル値に対応し、`RESPAWN_TIMES[level]` でそのレベルのリスポーン秒数を取得できなければならない（SHALL）。
+
+#### Scenario: 各レベルのリスポーン時間
+
+- **WHEN** ヒーローのレベルが 1〜5 のいずれかである
+- **THEN** `RESPAWN_TIMES[level]` が以下の値を返す: Lv1=3秒, Lv2=5秒, Lv3=8秒, Lv4=12秒, Lv5=15秒
+
+### Requirement: リスポーン時間算出関数
+
+純粋関数 `computeRespawnTime(level: number): number` を提供しなければならない（SHALL）。`RESPAWN_TIMES` テーブルからレベルに応じたリスポーン秒数を返さなければならない（SHALL）。レベルが範囲外の場合は最も近い有効レベルにクランプしなければならない（SHALL）。
+
+#### Scenario: レベル1のリスポーン時間
+
+- **WHEN** `computeRespawnTime(1)` を呼ぶ
+- **THEN** 3 が返される
+
+#### Scenario: レベル5のリスポーン時間
+
+- **WHEN** `computeRespawnTime(5)` を呼ぶ
+- **THEN** 15 が返される
+
+#### Scenario: レベル0（範囲外下限）
+
+- **WHEN** `computeRespawnTime(0)` を呼ぶ
+- **THEN** レベル1と同じ値（3）が返される
+
+#### Scenario: MAX_LEVEL超過（範囲外上限）
+
+- **WHEN** `computeRespawnTime(10)` を呼ぶ
+- **THEN** レベル5（MAX_LEVEL）と同じ値（15）が返される

--- a/server/src/__tests__/ServerDeathSystem.test.ts
+++ b/server/src/__tests__/ServerDeathSystem.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { MapSchema } from '@colyseus/schema'
 import { HeroSchema } from '../schema/HeroSchema.js'
 import { processDeathAndRespawn } from '../game/ServerDeathSystem.js'
-import { DEFAULT_RESPAWN_TIME } from '@shared/constants'
+import { RESPAWN_TIMES } from '@shared/constants'
 
 function createHero(id: string, overrides: Partial<Record<keyof HeroSchema, unknown>> = {}): HeroSchema {
   const hero = new HeroSchema()
@@ -42,14 +42,14 @@ describe('ServerDeathSystem', () => {
   })
 
   describe('processDeathAndRespawn', () => {
-    it('should set respawn timer for newly dead hero', () => {
+    it('should set respawn timer for newly dead hero based on level', () => {
       const hero = createLethalHero('hero-1')
       heroes.set('hero-1', hero)
 
       processDeathAndRespawn(heroes, getSpawnPosition, 0.1)
 
       expect(hero.dead).toBe(true)
-      expect(hero.respawnTimer).toBe(DEFAULT_RESPAWN_TIME)
+      expect(hero.respawnTimer).toBe(RESPAWN_TIMES[1]) // Level 1 = 3s
     })
 
     it('should clear attack state on death', () => {
@@ -164,9 +164,36 @@ describe('ServerDeathSystem', () => {
 
       expect(alive.dead).toBe(false)
       expect(dying.dead).toBe(true)
-      expect(dying.respawnTimer).toBe(DEFAULT_RESPAWN_TIME)
+      expect(dying.respawnTimer).toBe(RESPAWN_TIMES[1]) // Level 1 = 3s
       expect(dead.dead).toBe(true)
       expect(dead.respawnTimer).toBeCloseTo(2.0, 2)
+    })
+
+    it('should use level-dependent respawn time for level 1 hero', () => {
+      const hero = createLethalHero('hero-1', { level: 1 })
+      heroes.set('hero-1', hero)
+
+      processDeathAndRespawn(heroes, getSpawnPosition, 0.1)
+
+      expect(hero.respawnTimer).toBe(RESPAWN_TIMES[1]) // 3s
+    })
+
+    it('should use level-dependent respawn time for level 3 hero', () => {
+      const hero = createLethalHero('hero-1', { level: 3 })
+      heroes.set('hero-1', hero)
+
+      processDeathAndRespawn(heroes, getSpawnPosition, 0.1)
+
+      expect(hero.respawnTimer).toBe(RESPAWN_TIMES[3]) // 8s
+    })
+
+    it('should use level-dependent respawn time for level 5 hero', () => {
+      const hero = createLethalHero('hero-1', { level: 5 })
+      heroes.set('hero-1', hero)
+
+      processDeathAndRespawn(heroes, getSpawnPosition, 0.1)
+
+      expect(hero.respawnTimer).toBe(RESPAWN_TIMES[5]) // 15s
     })
   })
 })

--- a/server/src/game/ServerDeathSystem.ts
+++ b/server/src/game/ServerDeathSystem.ts
@@ -1,5 +1,5 @@
 import { MapSchema } from '@colyseus/schema'
-import { DEFAULT_RESPAWN_TIME } from '@shared/constants'
+import { computeRespawnTime } from '@shared/systems/respawnTimer'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { CombatEventMessage } from '@shared/messages'
 
@@ -25,7 +25,7 @@ export function processDeathAndRespawn(
     // Death detection — applyDamage() already sets dead=true when hp reaches 0,
     // so we detect newly dead heroes by dead=true with no respawn timer yet.
     if (hero.dead && hero.respawnTimer <= 0 && hero.hp <= 0) {
-      hero.respawnTimer = DEFAULT_RESPAWN_TIME
+      hero.respawnTimer = computeRespawnTime(hero.level)
       hero.attackTargetId = ''
       hero.attackCooldown = 0
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -19,7 +19,9 @@ export const ULTIMATE_ENHANCE_LEVEL = 5
 export const DODGE_COOLDOWN = 10 // seconds
 
 // Respawn
-export const DEFAULT_RESPAWN_TIME = 5 // seconds
+export const DEFAULT_RESPAWN_TIME = 5 // seconds (legacy fallback)
+/** Respawn time per level (seconds). Index = level. Lv1=3s … Lv5=15s. */
+export const RESPAWN_TIMES = [0, 3, 5, 8, 12, 15] as const
 
 // Camera (client-only but harmless to share)
 export const CAMERA_LERP = 0.1

--- a/shared/systems/__tests__/respawnTimer.test.ts
+++ b/shared/systems/__tests__/respawnTimer.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { computeRespawnTime } from '../respawnTimer'
+import { RESPAWN_TIMES, MAX_LEVEL } from '@shared/constants'
+
+describe('computeRespawnTime', () => {
+  it('returns 3s for level 1', () => {
+    expect(computeRespawnTime(1)).toBe(3)
+  })
+
+  it('returns 5s for level 2', () => {
+    expect(computeRespawnTime(2)).toBe(5)
+  })
+
+  it('returns 8s for level 3', () => {
+    expect(computeRespawnTime(3)).toBe(8)
+  })
+
+  it('returns 12s for level 4', () => {
+    expect(computeRespawnTime(4)).toBe(12)
+  })
+
+  it('returns 15s for level 5 (MAX_LEVEL)', () => {
+    expect(computeRespawnTime(5)).toBe(15)
+  })
+
+  it('clamps level 0 to level 1', () => {
+    expect(computeRespawnTime(0)).toBe(RESPAWN_TIMES[1])
+  })
+
+  it('clamps negative level to level 1', () => {
+    expect(computeRespawnTime(-5)).toBe(RESPAWN_TIMES[1])
+  })
+
+  it('clamps level above MAX_LEVEL to MAX_LEVEL', () => {
+    expect(computeRespawnTime(10)).toBe(RESPAWN_TIMES[MAX_LEVEL])
+  })
+
+  it('increases monotonically with level', () => {
+    for (let lvl = 2; lvl <= MAX_LEVEL; lvl++) {
+      expect(computeRespawnTime(lvl)).toBeGreaterThan(computeRespawnTime(lvl - 1))
+    }
+  })
+})

--- a/shared/systems/respawnTimer.ts
+++ b/shared/systems/respawnTimer.ts
@@ -1,0 +1,10 @@
+import { MAX_LEVEL, RESPAWN_TIMES } from '@shared/constants'
+
+/**
+ * Compute respawn time in seconds based on hero level.
+ * Clamps level to [1, MAX_LEVEL] range.
+ */
+export function computeRespawnTime(level: number): number {
+  const clamped = Math.max(1, Math.min(level, MAX_LEVEL))
+  return RESPAWN_TIMES[clamped]
+}


### PR DESCRIPTION
## Summary

- リスポーン時間をヒーローレベルに応じて変動させる（Lv1=3s, Lv2=5s, Lv3=8s, Lv4=12s, Lv5=15s）
- `RESPAWN_TIMES` テーブルを `shared/constants.ts` に追加し、`computeRespawnTime` 純粋関数で参照
- `ServerDeathSystem.processDeathAndRespawn` で固定値の代わりにレベル依存の値を使用
- `CLAUDE.md` にプロジェクト規約を追加（設計品質、アーキテクチャ、コーディングルール、開発フロー）

## Test plan

- [x] `computeRespawnTime` ユニットテスト 9件（全レベル + 範囲外クランプ + 単調増加）
- [x] `ServerDeathSystem` レベル連動テスト 3件追加（Lv1/3/5）
- [x] 既存テスト修正（`DEFAULT_RESPAWN_TIME` → `RESPAWN_TIMES[n]`）
- [x] 全552ユニットテスト PASS

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)