### PR TITLE
chore: update specs for online-first, Node 22 CI, coverage report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - run: npm ci
@@ -33,14 +33,21 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - run: npm ci
 
       - run: cd server && npm ci
 
-      - run: npm run test:unit
+      - run: npm run test:coverage
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
 
   openspec-check:
     if: github.event.pull_request.draft == false
@@ -68,7 +75,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - run: npm ci

--- a/openspec/specs/dev-phases.md
+++ b/openspec/specs/dev-phases.md
@@ -1,52 +1,45 @@
 # Development Phases
 
-## Phase 1: Prototype (Bot Battle) ← CURRENT
+## Phase 1: Prototype ← CURRENT
 
 **Goal:** Validate "fun in 5 minutes"
 
-**Scope:** No backend. Phaser.js standalone. Static hosting only.
+**Scope:** Online-first. Colyseus server-authoritative + Phaser.js client.
 
 **Deliverables:**
-- [ ] Map rendering (single lane, bases, tower, bushes)
-- [ ] Character movement (WASD + mouse aim)
-- [ ] Basic attack and skill system (Q, E, R, Space dodge)
-- [ ] 3 heroes playable (BLADE, BOLT, AURA)
-- [ ] Minion auto-spawn and lane walking
-- [ ] XP gain by proximity, level-up talent choices
-- [ ] Bot AI (enemy team + ally if needed)
-- [ ] Match tempo events (3min buff, 4min boss, 5min sudden death)
-- [ ] Win/lose condition and match reset
-
-**Tech:** Phaser.js + Vite + TypeScript. Deploy to S3 + CloudFront or any static host.
-
----
-
-## Phase 2: 1v1 Online
-
-**Goal:** Validate real-time multiplayer
-
-**Deliverables:**
-- [ ] Colyseus game server setup
-- [ ] Server-authoritative game logic migration
-- [ ] Client-side prediction + interpolation
+- [x] Map rendering (single lane, bases, tower, bushes)
+- [x] Character movement (WASD + mouse aim)
+- [x] Basic attack and skill system (Q, E, R)
+- [x] 3 heroes playable (BLADE, BOLT, AURA)
+- [x] Minion auto-spawn and lane walking
+- [x] XP gain by proximity, level-up talent choices
+- [x] Bot AI (enemy team + ally if needed)
+- [x] Match tempo events (3min buff, 4min boss, 5min sudden death)
+- [x] Win/lose condition and match reset
+- [x] Colyseus game server setup
+- [x] Server-authoritative game logic
+- [x] Client-side prediction + interpolation
+- [x] Talent tree system with skill slots
 - [ ] ECS on EC2 deployment
-- [ ] 2-player online match
+
+**Tech:** Phaser.js + Vite + TypeScript + Colyseus. Deploy to S3 + CloudFront (client) + ECS on EC2 (server).
 
 ---
 
-## Phase 3: 2v2 Full Match
+## Phase 2: 2v2 Online Match
 
-**Goal:** Public release
+**Goal:** Public release with full 2v2
 
 **Deliverables:**
 - [ ] Room-based matchmaking (Colyseus built-in)
 - [ ] Mid-match join / Bot replacement on disconnect
 - [ ] Hero and map balance tuning
 - [ ] Basic UI (hero select, match result)
+- [ ] Monitoring and metrics (active rooms, player count, tick performance)
 
 ---
 
-## Phase 4: Expansion (Future)
+## Phase 3: Expansion (Future)
 
 - Additional heroes per type
 - Ranking system

--- a/openspec/specs/tech-architecture.md
+++ b/openspec/specs/tech-architecture.md
@@ -10,9 +10,7 @@
 - **Hosting:** S3 + CloudFront (static files)
 - **Language:** TypeScript (strict mode)
 
-## Backend (Phase 2+)
-
-Phase 1 has no backend. Bot-only, runs entirely client-side.
+## Backend
 
 - **Game Server:** Colyseus (Node.js)
 - **Protocol:** WebSocket (server-authoritative)


### PR DESCRIPTION
## Summary
- **Specs 整合性**: tech-architecture.md から「Phase 1 has no backend」を削除、dev-phases.md を online-first に書き換え。Phase 2 のサーバー関連 deliverables は Phase 1 に統合（実装済み）
- **Node 22 統一**: CI の node-version を 18 → 22 に更新（Dockerfile と統一、Closes #138）
- **CI カバレッジ**: `test:unit` → `test:coverage` に変更し、coverage レポートを artifact としてアップロード（14日保持）

## Test plan
- [x] 全 617 ユニットテスト PASS（ローカル確認済み）
- [ ] CI で Node 22 でのビルド・テストが通ること
- [ ] coverage artifact がアップロードされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)