### PR TITLE
fix: resolve frontend and server build errors

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,6 +13,11 @@ RUN npm ci
 
 COPY server/src/ ./src/
 COPY server/tsconfig.json ./
+
+# shared/ imports bare specifiers (e.g. @logtape/logtape) which tsc resolves
+# from the file's directory. Symlink so ../node_modules finds server's deps.
+RUN ln -s /app/server/node_modules /app/node_modules
+
 RUN npm run build
 
 # --- Production stage ---

--- a/server/src/__tests__/ServerMinionSystem.test.ts
+++ b/server/src/__tests__/ServerMinionSystem.test.ts
@@ -495,7 +495,7 @@ describe('processMinionDeaths', () => {
     const events2 = processMinionDeaths(ctx, minions, heroes, 0.01)
 
     // Second call should not emit another death event
-    expect(events2.filter((e) => e.event.type === 'death')).toHaveLength(0)
+    expect(events2.filter((e) => e.kind === 'death')).toHaveLength(0)
   })
 
   it('should remove minion from map after cleanup delay expires', () => {

--- a/server/src/game/ServerBotTalentSystem.ts
+++ b/server/src/game/ServerBotTalentSystem.ts
@@ -48,7 +48,7 @@ export function spendBotTalents(
       if (candidates.length === 0) break
 
       const randomIndex = Math.floor(Math.random() * candidates.length)
-      const talentId = candidates[randomIndex]
+      const talentId = candidates[randomIndex]!
       const acquired = acquireTalent(hero, talentId, treeDef)
       if (!acquired) break
     }

--- a/server/src/game/ServerTalentSystem.ts
+++ b/server/src/game/ServerTalentSystem.ts
@@ -139,7 +139,7 @@ export function recalculateEffectiveStats(
       }
     } else {
       // HeroSchema field names match StatBlock keys
-      ;(hero as Record<string, number>)[stat] = value
+      ;(hero as unknown as Record<string, number>)[stat] = value
     }
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["src/**/*.ts", "../shared/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "../shared/**/*.test.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     open: true
   },
   build: {
+    target: 'esnext',
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary
- フロントエンド・サーバー両方のデプロイActions失敗を修正
- ローカルでビルド・テスト・lint全て通過確認済み

## Changes

### Frontend (Deploy Frontend)
- `vite.config.ts`: `build.target = 'esnext'` を追加し、`src/main.ts` の top-level await をサポート

### Server (Deploy Game Server)
- `server/tsconfig.json`: テストファイル (`*.test.ts`) をコンパイル対象から除外（vitest型エラー・暗黙any回避）
- `server/Dockerfile`: `/app/node_modules` → `/app/server/node_modules` のシンボリックリンクを追加（`shared/logging.ts` が `@logtape/logtape` を解決できるように）
- `ServerMinionSystem.test.ts`: `e.event.type` → `e.kind` に修正（union型のプロパティアクセスエラー）
- `ServerBotTalentSystem.ts`: 配列インデックスに non-null assertion 追加（`noUncheckedIndexedAccess`）
- `ServerTalentSystem.ts`: `unknown` 経由キャストに修正（HeroSchema → Record）

## Test plan
- [x] `npx tsc --noEmit` (frontend) — pass
- [x] `npx tsc --noEmit` (server) — pass
- [x] `npm run build` (frontend) — pass
- [x] `npm run build` (server) — pass
- [x] `npm test` — 670 unit tests pass
- [x] `npm run test:e2e` — 11 E2E tests pass
- [x] `npm run lint` — pass
- [ ] Deploy Frontend Action — verify after merge
- [ ] Deploy Game Server Action — verify after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)