### PR TITLE
fix: homing projectiles, target-only hit, and ranged attack pause

### DIFF
--- a/server/src/__tests__/ServerMovementSystem.test.ts
+++ b/server/src/__tests__/ServerMovementSystem.test.ts
@@ -97,5 +97,37 @@ describe('ServerMovementSystem', () => {
 
       expect(hero.facing).toBe(1.5)
     })
+
+    it('should suppress movement during attack pause', () => {
+      const hero = createHero({ attackPauseTimer: 0.15 })
+      const input = createInput({ moveDir: { x: 1, y: 0 } })
+      processMovement(hero, input, 0.05)
+
+      expect(hero.x).toBe(100) // Did not move
+      expect(hero.attackPauseTimer).toBeCloseTo(0.1, 2)
+    })
+
+    it('should resume movement after attack pause expires', () => {
+      const hero = createHero({ attackPauseTimer: 0.05 })
+      const input = createInput({ moveDir: { x: 1, y: 0 } })
+
+      // First tick: pause still active, consume remaining timer
+      processMovement(hero, input, 0.05)
+      expect(hero.x).toBe(100) // Still paused
+      expect(hero.attackPauseTimer).toBe(0)
+
+      // Second tick: pause expired, movement resumes
+      processMovement(hero, input, 0.5)
+      expect(hero.x).toBe(200) // 100 + 200 * 0.5
+    })
+
+    it('should still update facing during attack pause', () => {
+      const hero = createHero({ attackPauseTimer: 0.15 })
+      const input = createInput({ facing: 2.5, moveDir: { x: 1, y: 0 } })
+      processMovement(hero, input, 0.05)
+
+      expect(hero.facing).toBe(2.5) // Facing updated even during pause
+      expect(hero.x).toBe(100) // But position unchanged
+    })
   })
 })

--- a/server/src/__tests__/ServerProjectileSystem.test.ts
+++ b/server/src/__tests__/ServerProjectileSystem.test.ts
@@ -160,12 +160,26 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 195, y: 100, targetId: 'ally', team: 'blue', damage: 60 })
       projectiles.set(proj.id, proj)
 
-      // Target is found but dead check is false, so projectile still homes
-      // However applyDamageToTarget handles the damage application
       processProjectiles(projectiles, heroes, towers, 0.01)
 
-      // Projectile should still be consumed (it reached its target)
+      // Friendly fire guard: no damage applied, projectile removed
+      expect(ally.hp).toBe(650)
       expect(projectiles.size).toBe(0)
+    })
+
+    it('should apply damage when projectile is exactly at target position', () => {
+      const target = createHero('enemy', { x: 200, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('enemy', target)
+
+      // Projectile spawned exactly at target position (distToTarget === 0)
+      const proj = createProjectile({ x: 200, y: 100, targetId: 'enemy', team: 'blue', damage: 60 })
+      projectiles.set(proj.id, proj)
+
+      const events = processProjectiles(projectiles, heroes, towers, 0.01)
+
+      expect(target.hp).toBe(590)
+      expect(projectiles.size).toBe(0)
+      expect(events).toHaveLength(1)
     })
 
     it('should return DamageEvent on hit', () => {

--- a/server/src/__tests__/ServerProjectileSystem.test.ts
+++ b/server/src/__tests__/ServerProjectileSystem.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { MapSchema } from '@colyseus/schema'
 import { HeroSchema } from '../schema/HeroSchema.js'
 import { TowerSchema } from '../schema/TowerSchema.js'
+import { MinionSchema } from '../schema/MinionSchema.js'
 import { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import { processProjectiles } from '../game/ServerProjectileSystem.js'
 
@@ -12,6 +13,7 @@ function createProjectile(overrides: Partial<Record<keyof ProjectileSchema, unkn
   proj.y = 100
   proj.targetX = 300
   proj.targetY = 100
+  proj.targetId = 'enemy'
   proj.speed = 400
   proj.damage = 60
   proj.ownerId = 'attacker'
@@ -45,33 +47,81 @@ describe('ServerProjectileSystem', () => {
     projectiles = new MapSchema<ProjectileSchema>()
   })
 
-  describe('processProjectiles', () => {
-    it('should move projectile toward target', () => {
-      const proj = createProjectile({ x: 100, y: 100, targetX: 300, targetY: 100, speed: 400 })
+  describe('processProjectiles — homing', () => {
+    it('should move projectile toward target entity position', () => {
+      const target = createHero('enemy', { x: 300, y: 100, team: 'red' })
+      heroes.set('enemy', target)
+
+      const proj = createProjectile({ x: 100, y: 100, targetId: 'enemy', speed: 400 })
       projectiles.set(proj.id, proj)
 
       processProjectiles(projectiles, heroes, towers, 0.25)
 
       expect(proj.x).toBeCloseTo(200, 0) // 100 + 400 * 0.25
       expect(proj.y).toBeCloseTo(100, 0)
-      expect(projectiles.size).toBe(1) // Still alive
+      expect(projectiles.size).toBe(1)
     })
 
-    it('should remove projectile when it arrives at target position', () => {
-      const proj = createProjectile({ x: 290, y: 100, targetX: 300, targetY: 100, speed: 400 })
+    it('should home toward moving target', () => {
+      const target = createHero('enemy', { x: 300, y: 100, team: 'red' })
+      heroes.set('enemy', target)
+
+      const proj = createProjectile({ x: 100, y: 100, targetId: 'enemy', speed: 400 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 1) // Overshoots
+      // First tick: target at (300, 100)
+      processProjectiles(projectiles, heroes, towers, 0.1)
+      const x1 = proj.x
 
-      expect(projectiles.size).toBe(0) // Removed
+      // Target moves up
+      target.y = 200
+
+      // Second tick: projectile should now home toward (300, 200)
+      processProjectiles(projectiles, heroes, towers, 0.1)
+
+      // Projectile should have a y component now (moving toward new target position)
+      expect(proj.y).toBeGreaterThan(100)
+      expect(proj.x).toBeGreaterThan(x1)
     })
 
-    it('should apply damage on collision with enemy hero', () => {
+    it('should update targetX/targetY for client interpolation', () => {
+      const target = createHero('enemy', { x: 300, y: 100, team: 'red' })
+      heroes.set('enemy', target)
+
+      const proj = createProjectile({ x: 100, y: 100, targetId: 'enemy' })
+      projectiles.set(proj.id, proj)
+
+      // Move target
+      target.x = 400
+      target.y = 200
+
+      processProjectiles(projectiles, heroes, towers, 0.1)
+
+      expect(proj.targetX).toBe(400)
+      expect(proj.targetY).toBe(200)
+    })
+
+    it('should only damage designated target, not other enemies on path', () => {
+      const bystander = createHero('bystander', { x: 150, y: 100, team: 'red', radius: 22, hp: 650 })
+      const target = createHero('enemy', { x: 300, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('bystander', bystander)
+      heroes.set('enemy', target)
+
+      // Projectile flies through bystander toward enemy
+      const proj = createProjectile({ x: 145, y: 100, targetId: 'enemy', team: 'blue', damage: 60 })
+      projectiles.set(proj.id, proj)
+
+      processProjectiles(projectiles, heroes, towers, 0.01)
+
+      expect(bystander.hp).toBe(650) // No damage to bystander
+      expect(projectiles.size).toBe(1) // Projectile not consumed
+    })
+
+    it('should apply damage when reaching designated target', () => {
       const target = createHero('enemy', { x: 200, y: 100, team: 'red', radius: 22, hp: 650 })
       heroes.set('enemy', target)
 
-      // Place projectile very close to target
-      const proj = createProjectile({ x: 195, y: 100, targetX: 300, targetY: 100, team: 'blue', damage: 60 })
+      const proj = createProjectile({ x: 195, y: 100, targetId: 'enemy', team: 'blue', damage: 60 })
       projectiles.set(proj.id, proj)
 
       processProjectiles(projectiles, heroes, towers, 0.01)
@@ -80,57 +130,49 @@ describe('ServerProjectileSystem', () => {
       expect(projectiles.size).toBe(0) // Removed after hit
     })
 
-    it('should not damage same-team entities', () => {
-      const ally = createHero('ally', { x: 200, y: 100, team: 'blue', radius: 22, hp: 650 })
-      heroes.set('ally', ally)
-
-      const proj = createProjectile({ x: 195, y: 100, targetX: 300, targetY: 100, team: 'blue', damage: 60 })
-      projectiles.set(proj.id, proj)
-
-      processProjectiles(projectiles, heroes, towers, 0.01)
-
-      expect(ally.hp).toBe(650) // No damage to ally
-      expect(projectiles.size).toBe(1) // Not consumed
-    })
-
-    it('should not damage dead entities', () => {
-      const target = createHero('enemy', { x: 200, y: 100, team: 'red', radius: 22, hp: 0, dead: true })
+    it('should remove projectile if target dies', () => {
+      const target = createHero('enemy', { x: 300, y: 100, team: 'red', hp: 0, dead: true })
       heroes.set('enemy', target)
 
-      const proj = createProjectile({ x: 195, y: 100, targetX: 300, targetY: 100, team: 'blue', damage: 60 })
+      const proj = createProjectile({ x: 100, y: 100, targetId: 'enemy' })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.01)
+      processProjectiles(projectiles, heroes, towers, 0.1)
 
-      expect(target.hp).toBe(0)
-    })
-
-    it('should apply damage to towers', () => {
-      const tower = new TowerSchema()
-      tower.id = 'tower-red'
-      tower.x = 200
-      tower.y = 100
-      tower.hp = 1500
-      tower.maxHp = 1500
-      tower.dead = false
-      tower.team = 'red'
-      tower.radius = 24
-      towers.set('tower-red', tower)
-
-      const proj = createProjectile({ x: 195, y: 100, targetX: 300, targetY: 100, team: 'blue', damage: 45 })
-      projectiles.set(proj.id, proj)
-
-      processProjectiles(projectiles, heroes, towers, 0.01)
-
-      expect(tower.hp).toBe(1455) // 1500 - 45
       expect(projectiles.size).toBe(0)
     })
 
-    it('should return DamageEvent on collision', () => {
+    it('should remove projectile if target entity disappears', () => {
+      // No target entity in the map
+      const proj = createProjectile({ x: 100, y: 100, targetId: 'nonexistent' })
+      projectiles.set(proj.id, proj)
+
+      processProjectiles(projectiles, heroes, towers, 0.1)
+
+      expect(projectiles.size).toBe(0)
+    })
+
+    it('should not damage same-team entities even if designated', () => {
+      const ally = createHero('ally', { x: 200, y: 100, team: 'blue', radius: 22, hp: 650 })
+      heroes.set('ally', ally)
+
+      // Edge case: targetId points to an ally (shouldn't happen normally)
+      const proj = createProjectile({ x: 195, y: 100, targetId: 'ally', team: 'blue', damage: 60 })
+      projectiles.set(proj.id, proj)
+
+      // Target is found but dead check is false, so projectile still homes
+      // However applyDamageToTarget handles the damage application
+      processProjectiles(projectiles, heroes, towers, 0.01)
+
+      // Projectile should still be consumed (it reached its target)
+      expect(projectiles.size).toBe(0)
+    })
+
+    it('should return DamageEvent on hit', () => {
       const target = createHero('enemy', { x: 200, y: 100, team: 'red', radius: 22, hp: 650 })
       heroes.set('enemy', target)
 
-      const proj = createProjectile({ x: 195, y: 100, targetX: 300, targetY: 100, team: 'blue', damage: 60, ownerId: 'shooter' })
+      const proj = createProjectile({ x: 195, y: 100, targetId: 'enemy', team: 'blue', damage: 60, ownerId: 'shooter' })
       projectiles.set(proj.id, proj)
 
       const events = processProjectiles(projectiles, heroes, towers, 0.01)
@@ -143,27 +185,75 @@ describe('ServerProjectileSystem', () => {
     })
 
     it('should return empty events when no collision', () => {
-      const proj = createProjectile({ x: 100, y: 100, targetX: 300, targetY: 100 })
+      const target = createHero('enemy', { x: 500, y: 100, team: 'red' })
+      heroes.set('enemy', target)
+
+      const proj = createProjectile({ x: 100, y: 100, targetId: 'enemy' })
       projectiles.set(proj.id, proj)
 
       const events = processProjectiles(projectiles, heroes, towers, 0.01)
       expect(events).toHaveLength(0)
     })
 
-    it('should handle multiple projectiles', () => {
-      const target = createHero('enemy', { x: 300, y: 100, team: 'red', radius: 22, hp: 650 })
-      heroes.set('enemy', target)
+    it('should handle multiple projectiles with different targets', () => {
+      const enemy1 = createHero('enemy1', { x: 200, y: 100, team: 'red', radius: 22, hp: 650 })
+      const enemy2 = createHero('enemy2', { x: 400, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('enemy1', enemy1)
+      heroes.set('enemy2', enemy2)
 
-      const proj1 = createProjectile({ id: 'proj-1', x: 295, y: 100, targetX: 400, targetY: 100, damage: 30 })
-      const proj2 = createProjectile({ id: 'proj-2', x: 100, y: 100, targetX: 400, targetY: 100, damage: 30 })
+      const proj1 = createProjectile({ id: 'proj-1', x: 195, y: 100, targetId: 'enemy1', damage: 30 })
+      const proj2 = createProjectile({ id: 'proj-2', x: 100, y: 100, targetId: 'enemy2', damage: 30 })
       projectiles.set(proj1.id, proj1)
       projectiles.set(proj2.id, proj2)
 
       processProjectiles(projectiles, heroes, towers, 0.01)
 
-      // proj1 should hit, proj2 still alive
-      expect(target.hp).toBe(620) // 650 - 30
-      expect(projectiles.size).toBe(1)
+      expect(enemy1.hp).toBe(620) // hit by proj1
+      expect(enemy2.hp).toBe(650) // proj2 still in flight
+      expect(projectiles.size).toBe(1) // proj2 still alive
+    })
+
+    it('should apply damage to towers when targeted', () => {
+      const tower = new TowerSchema()
+      tower.id = 'tower-red'
+      tower.x = 200
+      tower.y = 100
+      tower.hp = 1500
+      tower.maxHp = 1500
+      tower.dead = false
+      tower.team = 'red'
+      tower.radius = 24
+      towers.set('tower-red', tower)
+
+      const proj = createProjectile({ x: 195, y: 100, targetId: 'tower-red', team: 'blue', damage: 45 })
+      projectiles.set(proj.id, proj)
+
+      processProjectiles(projectiles, heroes, towers, 0.01)
+
+      expect(tower.hp).toBe(1455)
+      expect(projectiles.size).toBe(0)
+    })
+
+    it('should home toward minion target', () => {
+      const minions = new MapSchema<MinionSchema>()
+      const minion = new MinionSchema()
+      minion.id = 'minion-1'
+      minion.x = 300
+      minion.y = 100
+      minion.hp = 100
+      minion.maxHp = 100
+      minion.dead = false
+      minion.team = 'red'
+      minion.radius = 12
+      minions.set('minion-1', minion)
+
+      const proj = createProjectile({ x: 295, y: 100, targetId: 'minion-1', damage: 50 })
+      projectiles.set(proj.id, proj)
+
+      processProjectiles(projectiles, heroes, towers, 0.01, minions)
+
+      expect(minion.hp).toBe(50)
+      expect(projectiles.size).toBe(0)
     })
   })
 })

--- a/server/src/game/ServerCombatManager.ts
+++ b/server/src/game/ServerCombatManager.ts
@@ -1,6 +1,7 @@
 import { MapSchema } from '@colyseus/schema'
 import { isInAttackRange } from '@shared/combat'
 import { HERO_DEFINITIONS } from '@shared/entities/Hero'
+import { RANGED_ATTACK_PAUSE_DURATION } from '@shared/constants'
 import type { HeroType } from '@shared/types'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { TowerSchema } from '../schema/TowerSchema.js'
@@ -151,11 +152,15 @@ export function processHeroCombat(
       proj.y = hero.y
       proj.targetX = target.x
       proj.targetY = target.y
+      proj.targetId = hero.attackTargetId
       proj.speed = def.projectileSpeed
       proj.damage = hero.attackDamage
       proj.ownerId = heroId
       proj.team = hero.team
       projectiles.set(proj.id, proj)
+
+      // Brief movement pause when firing while moving
+      hero.attackPauseTimer = RANGED_ATTACK_PAUSE_DURATION
 
       events.push({
         kind: 'attack',

--- a/server/src/game/ServerMinionSystem.ts
+++ b/server/src/game/ServerMinionSystem.ts
@@ -325,6 +325,7 @@ function fireAttack(
     proj.y = minion.y
     proj.targetX = target.x
     proj.targetY = target.y
+    proj.targetId = target.id
     proj.speed = minion.projectileSpeed
     proj.damage = minion.attackDamage
     proj.ownerId = minionId

--- a/server/src/game/ServerMovementSystem.ts
+++ b/server/src/game/ServerMovementSystem.ts
@@ -5,6 +5,7 @@ import type { InputMessage } from '@shared/messages'
 /**
  * Server-side movement system.
  * Applies moveDir input to hero position with map boundary clamping.
+ * Movement is suppressed during the brief attack pause after firing a ranged attack.
  */
 export function processMovement(
   hero: HeroSchema,
@@ -16,6 +17,12 @@ export function processMovement(
 
   // Always apply facing from input (attack facing must sync even when stationary)
   hero.facing = input.facing
+
+  // Tick down attack pause timer
+  if (hero.attackPauseTimer > 0) {
+    hero.attackPauseTimer = Math.max(0, hero.attackPauseTimer - deltaTime)
+    return // Suppress movement during ranged attack pause
+  }
 
   const { moveDir } = input
 

--- a/server/src/game/ServerProjectileSystem.ts
+++ b/server/src/game/ServerProjectileSystem.ts
@@ -5,18 +5,31 @@ import type { TowerSchema } from '../schema/TowerSchema.js'
 import type { MinionSchema } from '../schema/MinionSchema.js'
 import type { CombatEventMessage } from '@shared/messages'
 import { applyDamageToTarget } from './combatUtils.js'
+import { DEFAULT_PROJECTILE_RADIUS } from '@shared/constants'
 
-interface DamageTarget {
-  id: string
-  x: number
-  y: number
-  hp: number
-  dead: boolean
-  radius: number
-  team: string
+interface TargetPosition {
+  readonly x: number
+  readonly y: number
+  readonly radius: number
+  readonly dead: boolean
 }
 
-import { DEFAULT_PROJECTILE_RADIUS } from '@shared/constants'
+function findTargetPosition(
+  targetId: string,
+  heroes: MapSchema<HeroSchema>,
+  towers: MapSchema<TowerSchema>,
+  minions?: MapSchema<MinionSchema>,
+): TargetPosition | null {
+  const hero = heroes.get(targetId)
+  if (hero) return { x: hero.x, y: hero.y, radius: hero.radius, dead: hero.dead }
+  const tower = towers.get(targetId)
+  if (tower) return { x: tower.x, y: tower.y, radius: tower.radius, dead: tower.dead }
+  if (minions) {
+    const minion = minions.get(targetId)
+    if (minion) return { x: minion.x, y: minion.y, radius: minion.radius, dead: minion.dead }
+  }
+  return null
+}
 
 function distanceSq(x1: number, y1: number, x2: number, y2: number): number {
   const dx = x2 - x1
@@ -24,31 +37,11 @@ function distanceSq(x1: number, y1: number, x2: number, y2: number): number {
   return dx * dx + dy * dy
 }
 
-function getAllDamageTargets(
-  heroes: MapSchema<HeroSchema>,
-  towers: MapSchema<TowerSchema>,
-  minions?: MapSchema<MinionSchema>,
-): DamageTarget[] {
-  const targets: DamageTarget[] = []
-  heroes.forEach((h, id) => {
-    targets.push({ id, x: h.x, y: h.y, hp: h.hp, dead: h.dead, radius: h.radius, team: h.team })
-  })
-  towers.forEach((t, id) => {
-    targets.push({ id, x: t.x, y: t.y, hp: t.hp, dead: t.dead, radius: t.radius, team: t.team })
-  })
-  if (minions) {
-    minions.forEach((m, id) => {
-      targets.push({ id, x: m.x, y: m.y, hp: m.hp, dead: m.dead, radius: m.radius, team: m.team })
-    })
-  }
-  return targets
-}
-
 /**
  * Process all projectiles for one tick.
- * Moves each projectile toward its target position, checks collision against
- * enemy entities, applies damage on hit, and removes arrived/hit projectiles.
- * Returns DamageEvent for each hit.
+ * Each projectile homes toward its designated target entity.
+ * Damage is only applied to the designated target (not any entity on the path).
+ * Projectiles are removed when they reach the target, the target dies, or the target disappears.
  */
 export function processProjectiles(
   projectiles: MapSchema<ProjectileSchema>,
@@ -59,13 +52,25 @@ export function processProjectiles(
 ): CombatEventMessage[] {
   const events: CombatEventMessage[] = []
   const toRemove: string[] = []
-  const targets = getAllDamageTargets(heroes, towers, minions)
 
   projectiles.forEach((proj, projId) => {
-    // Move toward target position
-    const dx = proj.targetX - proj.x
-    const dy = proj.targetY - proj.y
+    // Look up current target position
+    const target = findTargetPosition(proj.targetId, heroes, towers, minions)
+
+    // Remove projectile if target is gone or dead
+    if (!target || target.dead) {
+      toRemove.push(projId)
+      return
+    }
+
+    // Update homing direction — always fly toward current target position
+    const dx = target.x - proj.x
+    const dy = target.y - proj.y
     const distToTarget = Math.sqrt(dx * dx + dy * dy)
+
+    // Also update targetX/targetY for client-side interpolation
+    proj.targetX = target.x
+    proj.targetY = target.y
 
     if (distToTarget === 0) {
       toRemove.push(projId)
@@ -77,43 +82,25 @@ export function processProjectiles(
     const ny = dy / distToTarget
 
     if (moveDistance >= distToTarget) {
-      // Arrived at target position
-      proj.x = proj.targetX
-      proj.y = proj.targetY
+      proj.x = target.x
+      proj.y = target.y
     } else {
       proj.x = proj.x + nx * moveDistance
       proj.y = proj.y + ny * moveDistance
     }
 
-    // Check collision against enemy entities
-    let hit = false
-    for (const target of targets) {
-      if (target.dead) continue
-      if (target.team === proj.team) continue
-
-      const collisionDist = target.radius + DEFAULT_PROJECTILE_RADIUS
-      if (distanceSq(proj.x, proj.y, target.x, target.y) <= collisionDist * collisionDist) {
-        applyDamageToTarget(target.id, proj.damage, heroes, towers, minions, proj.ownerId)
-        events.push({
-          kind: 'damage',
-          event: {
-            targetId: target.id,
-            amount: proj.damage,
-            sourceId: proj.ownerId,
-          },
-        })
-        hit = true
-        break
-      }
-    }
-
-    if (hit) {
-      toRemove.push(projId)
-      return
-    }
-
-    // Remove if arrived at destination without hitting
-    if (moveDistance >= distToTarget) {
+    // Check collision with designated target only
+    const collisionDist = target.radius + DEFAULT_PROJECTILE_RADIUS
+    if (distanceSq(proj.x, proj.y, target.x, target.y) <= collisionDist * collisionDist) {
+      applyDamageToTarget(proj.targetId, proj.damage, heroes, towers, minions, proj.ownerId)
+      events.push({
+        kind: 'damage',
+        event: {
+          targetId: proj.targetId,
+          amount: proj.damage,
+          sourceId: proj.ownerId,
+        },
+      })
       toRemove.push(projId)
     }
   })

--- a/server/src/game/ServerProjectileSystem.ts
+++ b/server/src/game/ServerProjectileSystem.ts
@@ -12,6 +12,7 @@ interface TargetPosition {
   readonly y: number
   readonly radius: number
   readonly dead: boolean
+  readonly team: string
 }
 
 function findTargetPosition(
@@ -21,12 +22,12 @@ function findTargetPosition(
   minions?: MapSchema<MinionSchema>,
 ): TargetPosition | null {
   const hero = heroes.get(targetId)
-  if (hero) return { x: hero.x, y: hero.y, radius: hero.radius, dead: hero.dead }
+  if (hero) return { x: hero.x, y: hero.y, radius: hero.radius, dead: hero.dead, team: hero.team }
   const tower = towers.get(targetId)
-  if (tower) return { x: tower.x, y: tower.y, radius: tower.radius, dead: tower.dead }
+  if (tower) return { x: tower.x, y: tower.y, radius: tower.radius, dead: tower.dead, team: tower.team }
   if (minions) {
     const minion = minions.get(targetId)
-    if (minion) return { x: minion.x, y: minion.y, radius: minion.radius, dead: minion.dead }
+    if (minion) return { x: minion.x, y: minion.y, radius: minion.radius, dead: minion.dead, team: minion.team }
   }
   return null
 }
@@ -57,8 +58,8 @@ export function processProjectiles(
     // Look up current target position
     const target = findTargetPosition(proj.targetId, heroes, towers, minions)
 
-    // Remove projectile if target is gone or dead
-    if (!target || target.dead) {
+    // Remove projectile if target is gone, dead, or same team (friendly fire guard)
+    if (!target || target.dead || target.team === proj.team) {
       toRemove.push(projId)
       return
     }
@@ -72,7 +73,17 @@ export function processProjectiles(
     proj.targetX = target.x
     proj.targetY = target.y
 
+    // Already at target position — apply damage immediately
     if (distToTarget === 0) {
+      applyDamageToTarget(proj.targetId, proj.damage, heroes, towers, minions, proj.ownerId)
+      events.push({
+        kind: 'damage',
+        event: {
+          targetId: proj.targetId,
+          amount: proj.damage,
+          sourceId: proj.ownerId,
+        },
+      })
       toRemove.push(projId)
       return
     }

--- a/server/src/game/ServerTowerSystem.ts
+++ b/server/src/game/ServerTowerSystem.ts
@@ -139,6 +139,7 @@ export function processTowerCombat(
     proj.y = tower.y
     proj.targetX = target.x
     proj.targetY = target.y
+    proj.targetId = target.id
     proj.speed = tower.projectileSpeed
     proj.damage = tower.attackDamage
     proj.ownerId = towerId

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -339,18 +339,7 @@ export class GameRoom extends Room<GameRoomState> {
       MinionSchema,
     )
 
-    // 1. Apply movement from inputs
-    heroes.forEach((hero, sessionId) => {
-      const input = this.playerInputs.get(sessionId)
-      processMovement(hero, input, deltaTime)
-
-      // Update lastProcessedSeq
-      if (input) {
-        hero.lastProcessedSeq = input.seq
-      }
-    })
-
-    // 2. Process hero combat (attacks)
+    // 1. Process hero combat first (sets attackPauseTimer for ranged attacks)
     heroes.forEach((hero, heroId) => {
       const input = this.playerInputs.get(heroId)
       const heroEvents = processHeroCombat(
@@ -365,6 +354,17 @@ export class GameRoom extends Room<GameRoomState> {
         minions,
       )
       events.push(...heroEvents)
+    })
+
+    // 2. Apply movement from inputs (respects attackPauseTimer set above)
+    heroes.forEach((hero, sessionId) => {
+      const input = this.playerInputs.get(sessionId)
+      processMovement(hero, input, deltaTime)
+
+      // Update lastProcessedSeq
+      if (input) {
+        hero.lastProcessedSeq = input.seq
+      }
     })
 
     // 2.5. Process minion behavior (march / chase / attack)

--- a/server/src/schema/HeroSchema.ts
+++ b/server/src/schema/HeroSchema.ts
@@ -28,4 +28,6 @@ export class HeroSchema extends CombatEntitySchema {
   @type('boolean') isBot: boolean = false
   // Server-only: not synced to clients (no @type decorator)
   lastAttackerSessionId: string = ''
+  /** Brief movement pause after firing a ranged attack (seconds remaining) */
+  attackPauseTimer: number = 0
 }

--- a/server/src/schema/ProjectileSchema.ts
+++ b/server/src/schema/ProjectileSchema.ts
@@ -13,4 +13,6 @@ export class ProjectileSchema extends Schema {
   @type('int16') damage: number = 0
   @type('string') ownerId: string = ''
   @type('string') team: string = 'blue'
+  /** The entity this projectile homes toward. Damage only applies to this target. */
+  @type('string') targetId: string = ''
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -48,6 +48,9 @@ export const DEFAULT_ENTITY_RADIUS = 20
 // Projectile
 export const DEFAULT_PROJECTILE_RADIUS = 5
 
+// Ranged attack pause — brief stop when firing a ranged attack while moving
+export const RANGED_ATTACK_PAUSE_DURATION = 0.15 // seconds
+
 // Hero kill
 export const HERO_KILL_XP_REWARD = 150 // XP granted to killer on hero kill
 

--- a/shared/entities/Hero.ts
+++ b/shared/entities/Hero.ts
@@ -6,8 +6,6 @@ export interface HeroDefinition {
   /** Per-level stat growth (added per level-up). Uses StatBlock so base + growth share the same shape. */
   readonly growth: StatBlock
   readonly radius: number
-  /** Whether the hero can move while performing basic attacks */
-  readonly canMoveWhileAttacking: boolean
   /** Projectile travel speed in px/sec. 0 = melee (instant damage). */
   readonly projectileSpeed: number
   /** Projectile collision/draw radius in px. 0 for melee heroes. */
@@ -31,7 +29,6 @@ export const HERO_DEFINITIONS: Record<HeroType, HeroDefinition> = {
       attackSpeed: 0.05,
     },
     radius: 22,
-    canMoveWhileAttacking: true,
     projectileSpeed: 0,
     projectileRadius: 0,
   },
@@ -51,7 +48,6 @@ export const HERO_DEFINITIONS: Record<HeroType, HeroDefinition> = {
       attackSpeed: 0.05,
     },
     radius: 18,
-    canMoveWhileAttacking: false,
     projectileSpeed: 600,
     projectileRadius: 4,
   },
@@ -71,7 +67,6 @@ export const HERO_DEFINITIONS: Record<HeroType, HeroDefinition> = {
       attackSpeed: 0.03,
     },
     radius: 20,
-    canMoveWhileAttacking: false,
     projectileSpeed: 400,
     projectileRadius: 5,
   },

--- a/src/domain/entities/__tests__/Hero.test.ts
+++ b/src/domain/entities/__tests__/Hero.test.ts
@@ -3,16 +3,13 @@ import { HERO_DEFINITIONS } from '@/domain/entities/heroDefinitions'
 import type { HeroType } from '@/domain/types'
 
 describe('HeroDefinition', () => {
-  it('should set canMoveWhileAttacking to true for BLADE', () => {
-    expect(HERO_DEFINITIONS.BLADE.canMoveWhileAttacking).toBe(true)
+  it('melee hero (BLADE) has projectileSpeed 0', () => {
+    expect(HERO_DEFINITIONS.BLADE.projectileSpeed).toBe(0)
   })
 
-  it('should set canMoveWhileAttacking to false for BOLT', () => {
-    expect(HERO_DEFINITIONS.BOLT.canMoveWhileAttacking).toBe(false)
-  })
-
-  it('should set canMoveWhileAttacking to false for AURA', () => {
-    expect(HERO_DEFINITIONS.AURA.canMoveWhileAttacking).toBe(false)
+  it('ranged heroes have projectileSpeed > 0', () => {
+    expect(HERO_DEFINITIONS.BOLT.projectileSpeed).toBeGreaterThan(0)
+    expect(HERO_DEFINITIONS.AURA.projectileSpeed).toBeGreaterThan(0)
   })
 })
 

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -7,7 +7,6 @@ import {
   CAMERA_LERP,
 } from '@/domain/constants'
 import { type HeroState } from '@/domain/entities/Hero'
-import { HERO_DEFINITIONS } from '@/domain/entities/heroDefinitions'
 import { isHero, isMinion, isTower } from '@/domain/entities/typeGuards'
 import { updateFacing } from '@/domain/systems/updateFacing'
 import { findClickTarget } from '@/domain/systems/findClickTarget'
@@ -286,8 +285,6 @@ export class GameScene extends Phaser.Scene {
     const localHeroId = this.entityManager.localHeroId
     const localHero = this.entityManager.getEntity(localHeroId) as HeroState
     const input = this.inputHandler.read(localHero.position)
-    const isMoving = input.movement.x !== 0 || input.movement.y !== 0
-
     const localDead = localHero.dead
 
     // --- Local hero actions (skip if dead) ---
@@ -296,7 +293,7 @@ export class GameScene extends Phaser.Scene {
       ? { ...input, attack: false, targeting: { phase: 'idle' as const } }
       : input
     if (!localDead) {
-      this.updateOnlineInput(deltaSeconds, effectiveInput, isMoving)
+      this.updateOnlineInput(deltaSeconds, effectiveInput)
     } else {
       // Dead: free camera movement with WASD
       this.updateFreeCamera(input.movement, deltaSeconds)
@@ -365,8 +362,7 @@ export class GameScene extends Phaser.Scene {
   /** Send input to server + apply local facing/target updates. */
   private updateOnlineInput(
     _deltaSeconds: number,
-    input: { movement: { x: number; y: number }; attack: boolean; aimWorldPosition: Position },
-    isMoving: boolean
+    input: { movement: { x: number; y: number }; attack: boolean; aimWorldPosition: Position }
   ): void {
     if (!this.entitySync.inputBuffer) return
 
@@ -385,11 +381,8 @@ export class GameScene extends Phaser.Scene {
       attackTargetId = target?.id ?? null
     }
 
-    // Clear target on move if hero can't move while attacking
-    if (isMoving && attackTargetId !== null
-      && !HERO_DEFINITIONS[localHero.type].canMoveWhileAttacking) {
-      attackTargetId = null
-    }
+    // Ranged heroes: server handles the brief attack pause via attackPauseTimer.
+    // Client always sends both moveDir and attackTargetId; no client-side clearing needed.
 
     // Facing
     const attackTarget = attackTargetId !== null


### PR DESCRIPTION
Closes #191

## Summary
- 遠距離攻撃の弾が対象を追尾するように修正（毎tickターゲットの現在位置に向かって飛行）
- 弾は指定した対象にのみダメージを与える（途中の敵に当たらない）
- 移動キー長押し中でも遠距離攻撃が発射可能（発射時に150msの短い足止め→移動再開）

## Changes

### ProjectileSchema
- `targetId` フィールド追加（追尾対象のエンティティID）

### ServerProjectileSystem (全面書き換え)
- 毎tick、`targetId`のエンティティ位置を取得して追尾方向を更新
- `targetX/targetY`もtick毎に更新（クライアント補間用）
- 衝突判定は指定ターゲットのみ（他のエンティティは無視）
- ターゲットが死亡/消失した場合は弾を削除

### ServerCombatManager / ServerMinionSystem / ServerTowerSystem
- 弾生成時に `proj.targetId` を設定

### ServerMovementSystem
- `attackPauseTimer > 0` の間、移動を抑制（facing更新は継続）
- タイマーは毎tickデクリメント

### HeroSchema
- `attackPauseTimer` (server-only) 追加

### shared/constants.ts
- `RANGED_ATTACK_PAUSE_DURATION = 0.15` 追加

## Test plan
- [x] 677 unit tests pass (7 new tests added)
- [x] `npm run lint` pass
- [x] `npx tsc --noEmit` (frontend + server) pass
- [ ] E2E: ranged hero (BOLT/AURA) fires homing projectiles
- [ ] E2E: projectile tracks moving target
- [ ] E2E: movement continues after brief pause on ranged attack

🤖 Generated with [Claude Code](https://claude.com/claude-code)