### PR TITLE
feat: add base HP regeneration (#190)

### DIFF
--- a/server/src/__tests__/ServerBaseRegenSystem.test.ts
+++ b/server/src/__tests__/ServerBaseRegenSystem.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { isHeroInBase, processBaseRegen } from '../game/ServerBaseRegenSystem.js'
+import { BASES, BASE_HP_REGEN_PER_SEC } from '@shared/constants'
+
+function createHero(overrides: Partial<Record<keyof HeroSchema, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.id = 'hero-1'
+  hero.x = 50
+  hero.y = 360
+  hero.hp = 300
+  hero.maxHp = 650
+  hero.dead = false
+  hero.team = 'blue'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+describe('ServerBaseRegenSystem', () => {
+  describe('isHeroInBase', () => {
+    it('should return true for blue hero inside blue base', () => {
+      const hero = createHero({ x: 50, y: 360, team: 'blue' })
+      expect(isHeroInBase(hero)).toBe(true)
+    })
+
+    it('should return false for blue hero outside blue base', () => {
+      const hero = createHero({ x: 500, y: 360, team: 'blue' })
+      expect(isHeroInBase(hero)).toBe(false)
+    })
+
+    it('should return true for red hero inside red base', () => {
+      const base = BASES.red
+      const hero = createHero({ x: base.x + 50, y: base.y + 50, team: 'red' })
+      expect(isHeroInBase(hero)).toBe(true)
+    })
+
+    it('should return false for red hero inside blue base', () => {
+      const hero = createHero({ x: 50, y: 360, team: 'red' })
+      expect(isHeroInBase(hero)).toBe(false)
+    })
+
+    it('should return true at base boundary edges', () => {
+      const base = BASES.blue
+      const hero = createHero({ x: base.x, y: base.y, team: 'blue' })
+      expect(isHeroInBase(hero)).toBe(true)
+
+      const heroEdge = createHero({ x: base.x + base.width, y: base.y + base.height, team: 'blue' })
+      expect(isHeroInBase(heroEdge)).toBe(true)
+    })
+  })
+
+  describe('processBaseRegen', () => {
+    let heroes: MapSchema<HeroSchema>
+
+    beforeEach(() => {
+      heroes = new MapSchema<HeroSchema>()
+    })
+
+    it('should regenerate HP for hero inside own base', () => {
+      const hero = createHero({ hp: 300, maxHp: 650, team: 'blue', x: 50, y: 360 })
+      heroes.set('hero-1', hero)
+
+      processBaseRegen(heroes, 1.0)
+
+      expect(hero.hp).toBe(300 + BASE_HP_REGEN_PER_SEC)
+    })
+
+    it('should clamp HP to maxHp', () => {
+      const hero = createHero({ hp: 600, maxHp: 650, team: 'blue', x: 50, y: 360 })
+      heroes.set('hero-1', hero)
+
+      processBaseRegen(heroes, 1.0)
+
+      expect(hero.hp).toBe(650)
+    })
+
+    it('should not regenerate for hero outside base', () => {
+      const hero = createHero({ hp: 300, maxHp: 650, team: 'blue', x: 500, y: 360 })
+      heroes.set('hero-1', hero)
+
+      processBaseRegen(heroes, 1.0)
+
+      expect(hero.hp).toBe(300)
+    })
+
+    it('should not regenerate for dead hero', () => {
+      const hero = createHero({ hp: 0, maxHp: 650, dead: true, team: 'blue', x: 50, y: 360 })
+      heroes.set('hero-1', hero)
+
+      processBaseRegen(heroes, 1.0)
+
+      expect(hero.hp).toBe(0)
+    })
+
+    it('should not regenerate when already at full HP', () => {
+      const hero = createHero({ hp: 650, maxHp: 650, team: 'blue', x: 50, y: 360 })
+      heroes.set('hero-1', hero)
+
+      processBaseRegen(heroes, 1.0)
+
+      expect(hero.hp).toBe(650)
+    })
+
+    it('should scale with deltaTime', () => {
+      const hero = createHero({ hp: 300, maxHp: 650, team: 'blue', x: 50, y: 360 })
+      heroes.set('hero-1', hero)
+
+      processBaseRegen(heroes, 0.5)
+
+      expect(hero.hp).toBe(300 + BASE_HP_REGEN_PER_SEC * 0.5)
+    })
+
+    it('should regenerate multiple heroes independently', () => {
+      const blueHero = createHero({ id: 'blue-1', hp: 300, maxHp: 650, team: 'blue', x: 50, y: 360 })
+      const redBase = BASES.red
+      const redHero = createHero({ id: 'red-1', hp: 200, maxHp: 400, team: 'red', x: redBase.x + 50, y: redBase.y + 50 })
+      heroes.set('blue-1', blueHero)
+      heroes.set('red-1', redHero)
+
+      processBaseRegen(heroes, 1.0)
+
+      expect(blueHero.hp).toBe(300 + BASE_HP_REGEN_PER_SEC)
+      expect(redHero.hp).toBe(200 + BASE_HP_REGEN_PER_SEC)
+    })
+
+    it('should not regenerate hero in enemy base', () => {
+      const redBase = BASES.red
+      const blueInRedBase = createHero({ hp: 300, maxHp: 650, team: 'blue', x: redBase.x + 50, y: redBase.y + 50 })
+      heroes.set('hero-1', blueInRedBase)
+
+      processBaseRegen(heroes, 1.0)
+
+      expect(blueInRedBase.hp).toBe(300)
+    })
+  })
+})

--- a/server/src/__tests__/ServerBaseRegenSystem.test.ts
+++ b/server/src/__tests__/ServerBaseRegenSystem.test.ts
@@ -48,6 +48,14 @@ describe('ServerBaseRegenSystem', () => {
       const heroEdge = createHero({ x: base.x + base.width, y: base.y + base.height, team: 'blue' })
       expect(isHeroInBase(heroEdge)).toBe(true)
     })
+
+    it('should return false just outside base boundary', () => {
+      const base = BASES.blue
+      expect(isHeroInBase(createHero({ x: base.x - 1, y: base.y, team: 'blue' }))).toBe(false)
+      expect(isHeroInBase(createHero({ x: base.x, y: base.y - 1, team: 'blue' }))).toBe(false)
+      expect(isHeroInBase(createHero({ x: base.x + base.width + 1, y: base.y, team: 'blue' }))).toBe(false)
+      expect(isHeroInBase(createHero({ x: base.x, y: base.y + base.height + 1, team: 'blue' }))).toBe(false)
+    })
   })
 
   describe('processBaseRegen', () => {

--- a/server/src/game/ServerBaseRegenSystem.ts
+++ b/server/src/game/ServerBaseRegenSystem.ts
@@ -1,0 +1,33 @@
+import { MapSchema } from '@colyseus/schema'
+import type { HeroSchema } from '../schema/HeroSchema.js'
+import { BASES, BASE_HP_REGEN_PER_SEC } from '@shared/constants'
+
+/**
+ * Check if a hero is inside their own base area.
+ */
+export function isHeroInBase(hero: HeroSchema): boolean {
+  const base = hero.team === 'blue' ? BASES.blue : BASES.red
+  return (
+    hero.x >= base.x &&
+    hero.x <= base.x + base.width &&
+    hero.y >= base.y &&
+    hero.y <= base.y + base.height
+  )
+}
+
+/**
+ * Regenerate HP for heroes standing inside their own base.
+ * Skips dead heroes. Clamps HP to maxHp.
+ */
+export function processBaseRegen(
+  heroes: MapSchema<HeroSchema>,
+  deltaTime: number,
+): void {
+  heroes.forEach((hero) => {
+    if (hero.dead) return
+    if (hero.hp >= hero.maxHp) return
+    if (!isHeroInBase(hero)) return
+
+    hero.hp = Math.min(hero.maxHp, hero.hp + BASE_HP_REGEN_PER_SEC * deltaTime)
+  })
+}

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -5,7 +5,7 @@ import { TowerSchema } from '../schema/TowerSchema.js'
 import { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import { HERO_DEFINITIONS } from '@shared/entities/Hero'
 import { DEFAULT_TOWER } from '@shared/entities/Tower'
-import { WORLD_WIDTH, WORLD_HEIGHT, MINION_WAVE_INTERVAL, BASES } from '@shared/constants'
+import { WORLD_WIDTH, WORLD_HEIGHT, MINION_WAVE_INTERVAL } from '@shared/constants'
 import type { HeroType } from '@shared/types'
 import type { InputMessage, CombatEventMessage } from '@shared/messages'
 import { processMovement } from '../game/ServerMovementSystem.js'
@@ -13,6 +13,7 @@ import { processHeroCombat, resetProjectileIdCounter } from '../game/ServerComba
 import { processProjectiles } from '../game/ServerProjectileSystem.js'
 import { processTowerCombat, resetTowerProjectileIdCounter } from '../game/ServerTowerSystem.js'
 import { processDeathAndRespawn } from '../game/ServerDeathSystem.js'
+import { isHeroInBase, processBaseRegen } from '../game/ServerBaseRegenSystem.js'
 import { checkTowerDestroyed, endMatch } from '../game/ServerMatchSystem.js'
 import { MinionSchema } from '../schema/MinionSchema.js'
 import {
@@ -91,15 +92,6 @@ function isValidUnequipSlotMessage(msg: unknown): msg is { slot: SkillSlot } {
   return VALID_SLOTS.has((msg as Record<string, unknown>).slot as string)
 }
 
-function isHeroInBase(hero: HeroSchema): boolean {
-  const base = hero.team === 'blue' ? BASES.blue : BASES.red
-  return (
-    hero.x >= base.x &&
-    hero.x <= base.x + base.width &&
-    hero.y >= base.y &&
-    hero.y <= base.y + base.height
-  )
-}
 
 export class GameRoom extends Room<GameRoomState> {
   maxClients = MAX_PLAYERS
@@ -406,6 +398,9 @@ export class GameRoom extends Room<GameRoomState> {
 
     // 5.5. Bot auto-spend talent points
     spendBotTalents(heroes, TALENT_TREES)
+
+    // 5.6. Base HP regeneration
+    processBaseRegen(heroes, deltaTime)
 
     // 6. Hero death detection and respawn
     const deathEvents = processDeathAndRespawn(heroes, getSpawnPosition, deltaTime)

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -48,6 +48,9 @@ export const DEFAULT_ENTITY_RADIUS = 20
 // Projectile
 export const DEFAULT_PROJECTILE_RADIUS = 5
 
+// Base HP regeneration
+export const BASE_HP_REGEN_PER_SEC = 200 // HP recovered per second while inside own base
+
 // Ranged attack pause — brief stop when firing a ranged attack while moving
 export const RANGED_ATTACK_PAUSE_DURATION = 0.15 // seconds
 


### PR DESCRIPTION
## Summary
- 自陣の拠点エリア内にいるヒーローのHPが200/秒で自然回復する機能を追加
- `ServerBaseRegenSystem` を新規作成し、`isHeroInBase` を GameRoom から抽出・共通化
- 死亡中・HP満タンのヒーローはスキップ
- ゲームループの死亡判定前（ステップ5.6）で実行

## Test plan
- [x] 拠点内のヒーローがHP回復する
- [x] maxHpを超えない（クランプ）
- [x] 拠点外では回復しない
- [x] 死亡中は回復しない
- [x] 満タンでは回復しない
- [x] deltaTimeでスケールする
- [x] 敵拠点では回復しない
- [x] 複数ヒーローが独立して回復する
- [x] 全690ユニットテスト + 11 E2Eテスト通過

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)