### PR TITLE
feat: add Pierce Shot skill with projectile effectType

### DIFF
--- a/openspec/changes/archive/2026-03-08-pierce-shot/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-08-pierce-shot/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-08

--- a/openspec/changes/archive/2026-03-08-pierce-shot/design.md
+++ b/openspec/changes/archive/2026-03-08-pierce-shot/design.md
@@ -1,0 +1,106 @@
+## Context
+
+現在のプロジェクタイルシステムはホーミング専用（`targetId` で追尾対象を指定）で、通常攻撃のみが使用する。Pierce Shot は「方向指定・直進・貫通」というまったく異なる飛行モードを必要とする。既存の `ProjectileSchema` と `ServerProjectileSystem` を拡張して両方のモードをサポートする設計が必要。
+
+### 既存コード構造
+- `ProjectileSchema`: id, x, y, targetX, targetY, speed, damage, ownerId, team, targetId
+- `ServerProjectileSystem.processProjectiles()`: ホーミング移動 + 指定ターゲットのみ衝突判定
+- `skillEffectRegistry`: effectType → handler マッピング（現在 `dash` のみ）
+- `SkillEffectParams`: discriminated union（現在 `DashEffectParams` のみ）
+
+## Goals / Non-Goals
+
+**Goals:**
+- `projectile` effectType をスキルエフェクトハンドラとして追加
+- 直進（non-homing）プロジェクタイルの飛行モードをサポート
+- 貫通（pierce）: 同じプロジェクタイルが複数の敵にヒット可能
+- 射程制限: 最大飛行距離を超えたら消滅
+- 今後の projectile 系スキル（Barrage, Ricochet, Snipe）の基盤となる再利用可能な設計
+
+**Non-Goals:**
+- AoE 判定（Pierce Shot は線上の敵のみ）
+- プロジェクタイルの軌道変更（Ricochet は別スキルで対応）
+- チャージ/溜め撃ち機構
+- 既存ホーミングプロジェクタイルの変更（通常攻撃は従来通り）
+
+## Decisions
+
+### 1. ProjectileSchema に `mode` フィールドを追加
+
+```
+mode: 'homing' | 'linear'  (default: 'homing')
+```
+
+- `homing`: 既存の targetId 追尾動作（通常攻撃）
+- `linear`: dirX/dirY 方向に直進、targetId 不要
+
+**理由**: 飛行モードを明示的に分離することで、ServerProjectileSystem 内の分岐が明確になる。将来のモード追加（parabolic 等）にも対応可能。
+
+### 2. 貫通は `pierceRemaining` + `hitEntityIds` で管理
+
+```
+pierceRemaining: number   // 残り貫通回数（-1 = 無限）
+hitEntityIds: string[]    // 既にヒットしたエンティティID
+```
+
+- ヒット時に `pierceRemaining` を減算、0 になったらプロジェクタイル除去
+- `hitEntityIds` で同じ敵への二重ヒットを防止
+- `hitEntityIds` はサーバーのみで管理（Schema にはせず、Map で保持）
+
+**理由**: `hitEntityIds` を Schema に入れると ArraySchema のシリアライズコストが発生し、クライアントには不要な情報。サーバーサイドの `Map<projectileId, Set<string>>` で管理する。
+
+### 3. 射程制限は `maxRange` + `distanceTraveled` で実装
+
+```
+maxRange: number          // 最大飛行距離 (px)
+distanceTraveled: number  // 累計移動距離 (px)
+```
+
+- 毎フレーム `distanceTraveled += speed * dt` を加算
+- `distanceTraveled >= maxRange` で除去
+- ホーミングプロジェクタイルは `maxRange = 0`（無制限、targetId 到達で消滅）
+
+**理由**: フレーム単位の位置比較より正確で、高速プロジェクタイルの飛び越しにも対応。
+
+### 4. ProjectileEffectParams の設計
+
+```typescript
+interface ProjectileEffectParams {
+  effectType: 'projectile'
+  damage: number
+  speed: number           // px/sec
+  range: number           // max travel distance (px)
+  radius: number          // collision/render radius
+  pierceCount: number     // max enemies to pierce (0 = single hit)
+  homing: boolean         // true = track target, false = straight line
+}
+```
+
+**理由**: スキル定義に必要なパラメータをすべて含め、将来の projectile 系スキルで値を変えるだけで異なる挙動を実現できる。例: Snipe は `pierceCount: 0, speed: 1200, range: 800`、Barrage は `pierceCount: 0, speed: 400` を複数発射。
+
+### 5. projectileEffectHandler はプロジェクタイル生成のみ担当
+
+ハンドラは `ProjectileSchema` を生成して `GameRoomState.projectiles` に追加するだけ。移動・衝突・除去は既存の `ServerProjectileSystem.processProjectiles()` が担当。
+
+**問題**: 現在の `SkillExecutionContext` には `projectiles` MapSchema への参照がない。
+
+**解決**: `SkillExecutionContext` に `projectiles: MapSchema<ProjectileSchema>` を追加する。
+
+### 6. Pierce Shot のパラメータ
+
+| パラメータ | 値 | 備考 |
+|-----------|-----|------|
+| targeting | direction | |
+| cooldown | 5s | |
+| damage | 60 | |
+| speed | 800 | px/sec、通常攻撃(600)より速い |
+| range | 600 | px |
+| radius | 5 | px |
+| pierceCount | 3 | 最大3体貫通 |
+| homing | false | 直進 |
+
+## Risks / Trade-offs
+
+- **hitEntityIds のメモリ管理**: サーバーサイド Map にプロジェクタイルIDをキーとして保持するため、プロジェクタイル除去時に確実にクリーンアップが必要
+- **高速プロジェクタイルの衝突漏れ**: speed=800, dt=0.016 で 1フレーム12.8px 移動。radius=5 のターゲットを飛び越す可能性は低いが、極端に速いプロジェクタイルでは sweep collision が将来必要になる可能性がある（現時点では不要）
+- **Schema フィールド増加**: ProjectileSchema に 4 フィールド追加（mode, dirX, dirY, maxRange）。ホーミングプロジェクタイルにも同期されるが、サイズ影響は軽微

--- a/openspec/changes/archive/2026-03-08-pierce-shot/proposal.md
+++ b/openspec/changes/archive/2026-03-08-pierce-shot/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+BOLTの火力ビルドの起点となるスキル Pierce Shot を実装する。現在のスキルシステムは `dash` effectType のみ対応しており、`projectile` effectType を追加することで今後のスキル（Barrage, Ricochet, Snipe 等）の基盤となる。Pierce Shot は Depth 1 / Cost 1 で最も取得しやすく、「方向指定で貫通弾を発射し複数の敵にヒットする」というシンプルな仕様のため、projectile effectType の最初の実装として最適。
+
+## What Changes
+
+- `shared/skills/skillDefinitions.ts` に `ProjectileEffectParams` インターフェースと `pierce-shot` スキル定義を追加
+- `SkillEffectParams` 共用体に `ProjectileEffectParams` を追加
+- サーバーに `projectileEffectHandler` を新規作成（スキル発動時にプロジェクタイルを生成）
+- 既存のホーミングプロジェクタイルシステムを拡張し、「直進 + 貫通」タイプのプロジェクタイルをサポート
+- `ProjectileSchema` に貫通関連フィールド（`pierceCount`, `hitEntityIds`）を追加
+- クライアント側でスキル由来プロジェクタイルの描画を既存 `ProjectileRenderer` で対応
+- `shared/talents/boltTalents.ts` の既存 `pierce-shot` タレントノードと連携確認
+
+## Capabilities
+
+### New Capabilities
+- `pierce-shot`: Pierce Shot スキルの定義、projectile effectType ハンドラ、直進貫通プロジェクタイルの実装
+
+### Modified Capabilities
+- `projectile-system`: 既存のホーミングプロジェクタイルに加え、直進（non-homing）・貫通（pierce）タイプをサポート
+
+## Impact
+
+- **shared/skills/**: `ProjectileEffectParams` 追加、`SkillEffectParams` 共用体拡張
+- **server/src/game/skills/handlers/**: 新規 `projectileEffectHandler.ts`
+- **server/src/schema/**: `ProjectileSchema` に pierceCount, hitEntityIds 等を追加
+- **server/src/game/**: `ServerProjectileSystem` に直進移動・貫通判定ロジック追加
+- **src/scenes/effects/**: 既存 `ProjectileRenderer` でスキル由来プロジェクタイルも描画（変更最小限）

--- a/openspec/changes/archive/2026-03-08-pierce-shot/specs/pierce-shot/spec.md
+++ b/openspec/changes/archive/2026-03-08-pierce-shot/specs/pierce-shot/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Pierce Shot スキル定義
+`shared/skills/skillDefinitions.ts` に `ProjectileEffectParams` インターフェースと `pierce-shot` スキル定義を追加しなければならない（SHALL）。`ProjectileEffectParams` は `effectType: 'projectile'`, `damage`, `speed`, `range`, `radius`, `pierceCount`, `homing` フィールドを持たなければならない（SHALL）。`SkillEffectParams` 共用体に `ProjectileEffectParams` を追加しなければならない（SHALL）。
+
+#### Scenario: Pierce Shot 定義の参照
+- **WHEN** `getSkillDefinition('pierce-shot')` を呼び出す
+- **THEN** `{ id: 'pierce-shot', targeting: 'direction', cooldown: 5, effect: { effectType: 'projectile', damage: 60, speed: 800, range: 600, radius: 5, pierceCount: 3, homing: false } }` が返される
+
+#### Scenario: SkillEffectParams 共用体
+- **WHEN** `SkillEffectParams` 型を参照する
+- **THEN** `DashEffectParams | ProjectileEffectParams` の共用体型である
+
+### Requirement: projectile エフェクトハンドラ
+`projectileEffectHandler` は effectType `'projectile'` のスキル発動時にプロジェクタイルを生成しなければならない（SHALL）。生成されるプロジェクタイルは `SkillExecutionContext` の `direction` 方向に直進し、`ProjectileEffectParams` のパラメータ（damage, speed, range, radius, pierceCount）を持たなければならない（SHALL）。
+
+#### Scenario: Pierce Shot 発動でプロジェクタイルが生成される
+- **WHEN** ヒーローが Pierce Shot を direction (1, 0) で発動する
+- **THEN** ヒーローの位置から direction (1, 0) に直進するプロジェクタイルが生成され、damage=60, speed=800, range=600, pierceCount=3 のパラメータを持つ
+
+#### Scenario: SkillExecutionContext にプロジェクタイル参照が提供される
+- **WHEN** projectile effectType のスキルが発動される
+- **THEN** `SkillExecutionContext.projectiles` を通じて `MapSchema<ProjectileSchema>` にアクセスでき、新しいプロジェクタイルを追加できる
+
+### Requirement: Pierce Shot のクールダウン設定
+Pierce Shot 発動後、使用したスロットのクールダウンが 5 秒にセットされなければならない（SHALL）。これは既存の `executeSkill` のクールダウン設定ロジックで自動的に処理される。
+
+#### Scenario: 発動後のクールダウン
+- **WHEN** ヒーローが Q スロットの Pierce Shot を発動する
+- **THEN** `cooldownQ` が 5 にセットされる
+
+### Requirement: 貫通による複数ヒット
+Pierce Shot のプロジェクタイルは最大 `pierceCount` 体の敵を貫通しなければならない（SHALL）。同じ敵には1回のみヒットしなければならない（SHALL）。`pierceCount` 体にヒットした後、プロジェクタイルは除去されなければならない（SHALL）。
+
+#### Scenario: 3体の敵を貫通する
+- **WHEN** pierceCount=3 のプロジェクタイルが一直線上の敵3体を通過する
+- **THEN** 3体すべてにダメージが適用され、3体目ヒット後にプロジェクタイルが除去される
+
+#### Scenario: 同じ敵に2回ヒットしない
+- **WHEN** プロジェクタイルが敵Aにヒットした後、敵Aの判定範囲内に留まる
+- **THEN** 敵Aへの追加ダメージは発生しない
+
+### Requirement: 射程制限
+直進プロジェクタイルは `maxRange` で指定された距離を超えて飛行してはならない（SHALL）。累計移動距離が `maxRange` 以上になった時点でプロジェクタイルを除去しなければならない（SHALL）。
+
+#### Scenario: 最大射程で消滅する
+- **WHEN** range=600 のプロジェクタイルが 600px 以上移動した
+- **THEN** プロジェクタイルが除去される
+
+#### Scenario: 射程内では飛行を継続する
+- **WHEN** range=600 のプロジェクタイルが 300px 移動した時点
+- **THEN** プロジェクタイルは飛行を継続する

--- a/openspec/changes/archive/2026-03-08-pierce-shot/specs/projectile-system/spec.md
+++ b/openspec/changes/archive/2026-03-08-pierce-shot/specs/projectile-system/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: 直進（linear）プロジェクタイルモード
+`ProjectileSchema` に飛行モードを示す `mode` フィールド（`'homing' | 'linear'`、デフォルト `'homing'`）を追加しなければならない（SHALL）。`mode: 'linear'` のプロジェクタイルは `dirX`, `dirY` 方向に毎フレーム `speed * deltaTime` 分だけ直進しなければならない（SHALL）。`targetId` による追尾は行わない。
+
+#### Scenario: linear モードのプロジェクタイルが直進する
+- **WHEN** mode='linear', dirX=1, dirY=0, speed=800 のプロジェクタイルが deltaTime=0.016 で更新される
+- **THEN** x が 12.8px 増加し、y は変化しない
+
+#### Scenario: homing モードは従来通り動作する
+- **WHEN** mode='homing' のプロジェクタイルが更新される
+- **THEN** targetId の現在位置に向かって追尾移動する（既存動作と同一）
+
+### Requirement: ProjectileSchema の拡張フィールド
+`ProjectileSchema` に以下のフィールドを追加しなければならない（SHALL）：`mode: string`（'homing' | 'linear'）、`dirX: float32`（直進方向X）、`dirY: float32`（直進方向Y）、`maxRange: float32`（最大飛行距離、0=無制限）、`pierceRemaining: int16`（残り貫通回数）。
+
+#### Scenario: linear プロジェクタイルのフィールド
+- **WHEN** Pierce Shot でプロジェクタイルが生成される
+- **THEN** mode='linear', dirX/dirY に正規化方向ベクトル, maxRange=600, pierceRemaining=3 がセットされる
+
+#### Scenario: homing プロジェクタイルのデフォルト値
+- **WHEN** 通常攻撃でプロジェクタイルが生成される
+- **THEN** mode='homing', dirX=0, dirY=0, maxRange=0, pierceRemaining=0 のデフォルト値を持つ
+
+### Requirement: 射程による自動除去
+`mode: 'linear'` のプロジェクタイルは累計移動距離を追跡し、`maxRange` を超えた時点で除去しなければならない（SHALL）。累計移動距離はサーバーサイドで管理し、Schema には含めない。
+
+#### Scenario: 最大射程で除去される
+- **WHEN** maxRange=600 の linear プロジェクタイルが合計 600px 以上移動した
+- **THEN** プロジェクタイルが MapSchema から除去される
+
+### Requirement: 貫通ヒット判定
+`pierceRemaining > 0` のプロジェクタイルは、敵エンティティ（ヒーロー・タワー・ミニオン）との衝突時にダメージを与えた後も飛行を継続しなければならない（SHALL）。同じエンティティへの二重ヒットを防止するため、ヒット済みエンティティIDをサーバーサイドで追跡しなければならない（SHALL）。`pierceRemaining` をヒットごとに減算し、0 になった時点でプロジェクタイルを除去しなければならない（SHALL）。
+
+#### Scenario: 貫通してダメージを与え続ける
+- **WHEN** pierceRemaining=3 のプロジェクタイルが敵Aにヒットする
+- **THEN** 敵Aにダメージが適用され、pierceRemaining が 2 に減算され、プロジェクタイルは飛行を継続する
+
+#### Scenario: 貫通回数上限で除去される
+- **WHEN** pierceRemaining=1 のプロジェクタイルが敵にヒットする
+- **THEN** ダメージ適用後、pierceRemaining が 0 になりプロジェクタイルが除去される
+
+#### Scenario: ヒット済みエンティティをスキップする
+- **WHEN** プロジェクタイルが既にヒットしたエンティティの判定範囲内を通過する
+- **THEN** 追加ダメージは発生せず、pierceRemaining は変化しない
+
+### Requirement: linear プロジェクタイルの全敵衝突判定
+`mode: 'linear'` のプロジェクタイルは `targetId` ではなく、飛行経路上のすべての敵チームエンティティに対して衝突判定を行わなければならない（SHALL）。味方エンティティには衝突しない（SHALL）。
+
+#### Scenario: 経路上の敵すべてに判定される
+- **WHEN** linear プロジェクタイルが飛行中に、経路上に敵ヒーロー2体と味方ヒーロー1体がいる
+- **THEN** 敵ヒーロー2体に対して衝突判定が行われ、味方ヒーローはスキップされる

--- a/openspec/changes/archive/2026-03-08-pierce-shot/tasks.md
+++ b/openspec/changes/archive/2026-03-08-pierce-shot/tasks.md
@@ -1,0 +1,26 @@
+## Tasks
+
+### Backend
+
+- [x] `shared/skills/skillDefinitions.ts` に `ProjectileEffectParams` インターフェースを追加し、`SkillEffectParams` 共用体を拡張する
+- [x] `shared/skills/skillDefinitions.ts` に `pierce-shot` スキル定義を `SKILL_DEFINITIONS` に追加する
+- [x] `ProjectileSchema` に新フィールドを追加する（`mode`, `dirX`, `dirY`, `maxRange`, `pierceRemaining`）
+- [x] `ServerProjectileSystem` に linear モードの直進移動ロジックを追加する（射程制限 + 累計移動距離追跡）
+- [x] `ServerProjectileSystem` に貫通ヒット判定ロジックを追加する（全敵衝突判定、hitEntityIds 管理、pierceRemaining 減算）
+- [x] `SkillExecutionContext` に `projectiles: MapSchema<ProjectileSchema>` 参照を追加する
+- [x] `projectileEffectHandler` を新規作成し、エフェクトハンドラレジストリに登録する
+- [x] `GameRoom` の `executeSkill` 呼び出し時に `SkillExecutionContext` へ projectiles を渡す
+
+### Backend Tests
+
+- [x] `skillDefinitions` テスト: Pierce Shot 定義の参照、ProjectileEffectParams の型チェック
+- [x] `ServerProjectileSystem` テスト: linear モード直進移動、射程制限での除去、貫通ヒット（複数敵）、同一敵二重ヒット防止、homing モード既存動作の非破壊確認
+- [x] `skillExecution` テスト: Pierce Shot 発動でプロジェクタイル生成、クールダウン設定、死亡時・CD中の拒否
+
+### Frontend
+
+- [x] `ProjectileRenderer` が linear モードのプロジェクタイルも正しく描画できることを確認する（既存の drawServer で対応可能 — 変更不要）
+
+### Integration
+
+- [x] 全テスト実行（`npm run test:unit`）で既存テストが壊れていないことを確認する

--- a/openspec/specs/pierce-shot/spec.md
+++ b/openspec/specs/pierce-shot/spec.md
@@ -1,0 +1,57 @@
+# Specification
+
+## Purpose
+Pierce Shot スキルの定義、エフェクトハンドラ、貫通ヒット、射程制限に関する仕様
+
+## Requirements
+
+### Requirement: Pierce Shot スキル定義
+`shared/skills/skillDefinitions.ts` に `ProjectileEffectParams` インターフェースと `pierce-shot` スキル定義を追加しなければならない（SHALL）。`ProjectileEffectParams` は `effectType: 'projectile'`, `damage`, `speed`, `range`, `radius`, `pierceCount`, `homing` フィールドを持たなければならない（SHALL）。`SkillEffectParams` 共用体に `ProjectileEffectParams` を追加しなければならない（SHALL）。
+
+#### Scenario: Pierce Shot 定義の参照
+- **WHEN** `getSkillDefinition('pierce-shot')` を呼び出す
+- **THEN** `{ id: 'pierce-shot', targeting: 'direction', cooldown: 5, effect: { effectType: 'projectile', damage: 60, speed: 800, range: 600, radius: 5, pierceCount: 3, homing: false } }` が返される
+
+#### Scenario: SkillEffectParams 共用体
+- **WHEN** `SkillEffectParams` 型を参照する
+- **THEN** `DashEffectParams | ProjectileEffectParams` の共用体型である
+
+### Requirement: projectile エフェクトハンドラ
+`projectileEffectHandler` は effectType `'projectile'` のスキル発動時にプロジェクタイルを生成しなければならない（SHALL）。生成されるプロジェクタイルは `SkillExecutionContext` の `direction` 方向に直進し、`ProjectileEffectParams` のパラメータ（damage, speed, range, radius, pierceCount）を持たなければならない（SHALL）。
+
+#### Scenario: Pierce Shot 発動でプロジェクタイルが生成される
+- **WHEN** ヒーローが Pierce Shot を direction (1, 0) で発動する
+- **THEN** ヒーローの位置から direction (1, 0) に直進するプロジェクタイルが生成され、damage=60, speed=800, range=600, pierceCount=3 のパラメータを持つ
+
+#### Scenario: SkillExecutionContext にプロジェクタイル参照が提供される
+- **WHEN** projectile effectType のスキルが発動される
+- **THEN** `SkillExecutionContext.projectiles` を通じて `MapSchema<ProjectileSchema>` にアクセスでき、新しいプロジェクタイルを追加できる
+
+### Requirement: Pierce Shot のクールダウン設定
+Pierce Shot 発動後、使用したスロットのクールダウンが 5 秒にセットされなければならない（SHALL）。これは既存の `executeSkill` のクールダウン設定ロジックで自動的に処理される。
+
+#### Scenario: 発動後のクールダウン
+- **WHEN** ヒーローが Q スロットの Pierce Shot を発動する
+- **THEN** `cooldownQ` が 5 にセットされる
+
+### Requirement: 貫通による複数ヒット
+Pierce Shot のプロジェクタイルは最大 `pierceCount` 体の敵を貫通しなければならない（SHALL）。同じ敵には1回のみヒットしなければならない（SHALL）。`pierceCount` 体にヒットした後、プロジェクタイルは除去されなければならない（SHALL）。
+
+#### Scenario: 3体の敵を貫通する
+- **WHEN** pierceCount=3 のプロジェクタイルが一直線上の敵3体を通過する
+- **THEN** 3体すべてにダメージが適用され、3体目ヒット後にプロジェクタイルが除去される
+
+#### Scenario: 同じ敵に2回ヒットしない
+- **WHEN** プロジェクタイルが敵Aにヒットした後、敵Aの判定範囲内に留まる
+- **THEN** 敵Aへの追加ダメージは発生しない
+
+### Requirement: 射程制限
+直進プロジェクタイルは `maxRange` で指定された距離を超えて飛行してはならない（SHALL）。累計移動距離が `maxRange` 以上になった時点でプロジェクタイルを除去しなければならない（SHALL）。
+
+#### Scenario: 最大射程で消滅する
+- **WHEN** range=600 のプロジェクタイルが 600px 以上移動した
+- **THEN** プロジェクタイルが除去される
+
+#### Scenario: 射程内では飛行を継続する
+- **WHEN** range=600 のプロジェクタイルが 300px 移動した時点
+- **THEN** プロジェクタイルは飛行を継続する

--- a/openspec/specs/projectile-system/spec.md
+++ b/openspec/specs/projectile-system/spec.md
@@ -85,3 +85,54 @@ GameScene の update ループにプロジェクタイルの更新・描画を�
 #### Scenario: プロジェクタイル命中時にダメージが適用される
 - **WHEN** プロジェクタイルがターゲットに命中する
 - **THEN** `applyDamage` でターゲットの HP が減少し、ヒットフラッシュが再生される
+
+### Requirement: 直進（linear）プロジェクタイルモード
+`ProjectileSchema` に飛行モードを示す `mode` フィールド（`'homing' | 'linear'`、デフォルト `'homing'`）を追加しなければならない（SHALL）。`mode: 'linear'` のプロジェクタイルは `dirX`, `dirY` 方向に毎フレーム `speed * deltaTime` 分だけ直進しなければならない（SHALL）。`targetId` による追尾は行わない。
+
+#### Scenario: linear モードのプロジェクタイルが直進する
+- **WHEN** mode='linear', dirX=1, dirY=0, speed=800 のプロジェクタイルが deltaTime=0.016 で更新される
+- **THEN** x が 12.8px 増加し、y は変化しない
+
+#### Scenario: homing モードは従来通り動作する
+- **WHEN** mode='homing' のプロジェクタイルが更新される
+- **THEN** targetId の現在位置に向かって追尾移動する（既存動作と同一）
+
+### Requirement: ProjectileSchema の拡張フィールド
+`ProjectileSchema` に以下のフィールドを追加しなければならない（SHALL）：`mode: string`（'homing' | 'linear'）、`dirX: float32`（直進方向X）、`dirY: float32`（直進方向Y）、`maxRange: float32`（最大飛行距離、0=無制限）、`pierceRemaining: int16`（残り貫通回数）。
+
+#### Scenario: linear プロジェクタイルのフィールド
+- **WHEN** Pierce Shot でプロジェクタイルが生成される
+- **THEN** mode='linear', dirX/dirY に正規化方向ベクトル, maxRange=600, pierceRemaining=3 がセットされる
+
+#### Scenario: homing プロジェクタイルのデフォルト値
+- **WHEN** 通常攻撃でプロジェクタイルが生成される
+- **THEN** mode='homing', dirX=0, dirY=0, maxRange=0, pierceRemaining=0 のデフォルト値を持つ
+
+### Requirement: 射程による自動除去
+`mode: 'linear'` のプロジェクタイルは累計移動距離を追跡し、`maxRange` を超えた時点で除去しなければならない（SHALL）。累計移動距離はサーバーサイドで管理し、Schema には含めない。
+
+#### Scenario: 最大射程で除去される
+- **WHEN** maxRange=600 の linear プロジェクタイルが合計 600px 以上移動した
+- **THEN** プロジェクタイルが MapSchema から除去される
+
+### Requirement: 貫通ヒット判定
+`pierceRemaining > 0` のプロジェクタイルは、敵エンティティ（ヒーロー・タワー・ミニオン）との衝突時にダメージを与えた後も飛行を継続しなければならない（SHALL）。同じエンティティへの二重ヒットを防止するため、ヒット済みエンティティIDをサーバーサイドで追跡しなければならない（SHALL）。`pierceRemaining` をヒットごとに減算し、0 になった時点でプロジェクタイルを除去しなければならない（SHALL）。
+
+#### Scenario: 貫通してダメージを与え続ける
+- **WHEN** pierceRemaining=3 のプロジェクタイルが敵Aにヒットする
+- **THEN** 敵Aにダメージが適用され、pierceRemaining が 2 に減算され、プロジェクタイルは飛行を継続する
+
+#### Scenario: 貫通回数上限で除去される
+- **WHEN** pierceRemaining=1 のプロジェクタイルが敵にヒットする
+- **THEN** ダメージ適用後、pierceRemaining が 0 になりプロジェクタイルが除去される
+
+#### Scenario: ヒット済みエンティティをスキップする
+- **WHEN** プロジェクタイルが既にヒットしたエンティティの判定範囲内を通過する
+- **THEN** 追加ダメージは発生せず、pierceRemaining は変化しない
+
+### Requirement: linear プロジェクタイルの全敵衝突判定
+`mode: 'linear'` のプロジェクタイルは `targetId` ではなく、飛行経路上のすべての敵チームエンティティに対して衝突判定を行わなければならない（SHALL）。味方エンティティには衝突しない（SHALL）。
+
+#### Scenario: 経路上の敵すべてに判定される
+- **WHEN** linear プロジェクタイルが飛行中に、経路上に敵ヒーロー2体と味方ヒーロー1体がいる
+- **THEN** 敵ヒーロー2体に対して衝突判定が行われ、味方ヒーローはスキップされる

--- a/server/src/__tests__/ServerProjectileSystem.test.ts
+++ b/server/src/__tests__/ServerProjectileSystem.test.ts
@@ -4,7 +4,7 @@ import { HeroSchema } from '../schema/HeroSchema.js'
 import { TowerSchema } from '../schema/TowerSchema.js'
 import { MinionSchema } from '../schema/MinionSchema.js'
 import { ProjectileSchema } from '../schema/ProjectileSchema.js'
-import { processProjectiles } from '../game/ServerProjectileSystem.js'
+import { processProjectiles, resetProjectileTracking } from '../game/ServerProjectileSystem.js'
 
 function createProjectile(overrides: Partial<Record<keyof ProjectileSchema, unknown>> = {}): ProjectileSchema {
   const proj = new ProjectileSchema()
@@ -45,6 +45,7 @@ describe('ServerProjectileSystem', () => {
     heroes = new MapSchema<HeroSchema>()
     towers = new MapSchema<TowerSchema>()
     projectiles = new MapSchema<ProjectileSchema>()
+    resetProjectileTracking()
   })
 
   describe('processProjectiles — homing', () => {
@@ -268,6 +269,174 @@ describe('ServerProjectileSystem', () => {
 
       expect(minion.hp).toBe(50)
       expect(projectiles.size).toBe(0)
+    })
+  })
+
+  describe('processProjectiles — linear', () => {
+    function createLinearProjectile(overrides: Partial<Record<string, unknown>> = {}): ProjectileSchema {
+      const proj = new ProjectileSchema()
+      proj.id = 'linear-1'
+      proj.x = 100
+      proj.y = 200
+      proj.speed = 800
+      proj.damage = 60
+      proj.ownerId = 'shooter'
+      proj.team = 'blue'
+      proj.mode = 'linear'
+      proj.dirX = 1
+      proj.dirY = 0
+      proj.maxRange = 600
+      proj.pierceRemaining = 3
+      Object.assign(proj, overrides)
+      return proj
+    }
+
+    it('should move in a straight line based on dirX/dirY', () => {
+      const proj = createLinearProjectile()
+      projectiles.set(proj.id, proj)
+
+      processProjectiles(projectiles, heroes, towers, 0.016)
+
+      expect(proj.x).toBeCloseTo(100 + 800 * 0.016) // 112.8
+      expect(proj.y).toBeCloseTo(200)
+      expect(projectiles.size).toBe(1)
+    })
+
+    it('should remove when maxRange exceeded', () => {
+      const proj = createLinearProjectile({ speed: 800, maxRange: 100 })
+      projectiles.set(proj.id, proj)
+
+      // One big tick that exceeds maxRange
+      processProjectiles(projectiles, heroes, towers, 0.2) // 800*0.2 = 160 > 100
+
+      expect(projectiles.size).toBe(0)
+    })
+
+    it('should continue within range', () => {
+      const proj = createLinearProjectile({ maxRange: 600 })
+      projectiles.set(proj.id, proj)
+
+      processProjectiles(projectiles, heroes, towers, 0.1) // 80px traveled
+
+      expect(projectiles.size).toBe(1)
+    })
+
+    it('should hit enemy in path', () => {
+      const enemy = createHero('enemy-a', { x: 120, y: 200, team: 'red', radius: 22, hp: 500 })
+      heroes.set('enemy-a', enemy)
+
+      const proj = createLinearProjectile({ x: 100, y: 200 })
+      projectiles.set(proj.id, proj)
+
+      processProjectiles(projectiles, heroes, towers, 0.016)
+
+      expect(enemy.hp).toBe(440) // 500 - 60
+      expect(proj.pierceRemaining).toBe(2)
+      expect(projectiles.size).toBe(1) // still alive (pierce)
+    })
+
+    it('should pierce through multiple enemies', () => {
+      // Place enemies far apart so projectile reaches each on separate ticks
+      const enemy1 = createHero('e1', { x: 200, y: 200, team: 'red', radius: 22, hp: 500 })
+      const enemy2 = createHero('e2', { x: 350, y: 200, team: 'red', radius: 22, hp: 500 })
+      heroes.set('e1', enemy1)
+      heroes.set('e2', enemy2)
+
+      const proj = createLinearProjectile({ x: 100, y: 200, pierceRemaining: 3 })
+      projectiles.set(proj.id, proj)
+
+      // Tick 1: proj moves to 180 — within 27px of enemy1 at 200? dist=20 < 27, hit!
+      processProjectiles(projectiles, heroes, towers, 0.1)
+      expect(enemy1.hp).toBe(440)
+      expect(proj.pierceRemaining).toBe(2)
+
+      // Tick 2-3: proj moves further, reaches enemy2
+      processProjectiles(projectiles, heroes, towers, 0.1) // x=260
+      processProjectiles(projectiles, heroes, towers, 0.1) // x=340, dist to enemy2=10 < 27, hit!
+      expect(enemy2.hp).toBe(440)
+      expect(proj.pierceRemaining).toBe(1)
+      expect(projectiles.size).toBe(1) // still alive
+    })
+
+    it('should remove after exhausting pierce count', () => {
+      const enemy1 = createHero('e1', { x: 200, y: 200, team: 'red', radius: 22, hp: 500 })
+      const enemy2 = createHero('e2', { x: 350, y: 200, team: 'red', radius: 22, hp: 500 })
+      heroes.set('e1', enemy1)
+      heroes.set('e2', enemy2)
+
+      // pierceRemaining=1 means remove after 1st hit
+      const proj = createLinearProjectile({ x: 100, y: 200, pierceRemaining: 1 })
+      projectiles.set(proj.id, proj)
+
+      // Tick: proj moves to 180 — hits enemy1, pierceRemaining becomes 0, removed
+      processProjectiles(projectiles, heroes, towers, 0.1)
+
+      expect(enemy1.hp).toBe(440)
+      expect(enemy2.hp).toBe(500) // not hit — projectile removed after 1st
+      expect(projectiles.size).toBe(0)
+    })
+
+    it('should not hit same enemy twice', () => {
+      const enemy = createHero('e1', { x: 115, y: 200, team: 'red', radius: 22, hp: 500 })
+      heroes.set('e1', enemy)
+
+      const proj = createLinearProjectile({ x: 100, y: 200, pierceRemaining: 3 })
+      projectiles.set(proj.id, proj)
+
+      // First tick — hits enemy
+      processProjectiles(projectiles, heroes, towers, 0.005)
+      expect(enemy.hp).toBe(440)
+
+      // Second tick — still overlapping, but should NOT hit again
+      processProjectiles(projectiles, heroes, towers, 0.005)
+      expect(enemy.hp).toBe(440) // unchanged
+    })
+
+    it('should not hit allies', () => {
+      const ally = createHero('ally', { x: 120, y: 200, team: 'blue', radius: 22, hp: 500 })
+      heroes.set('ally', ally)
+
+      const proj = createLinearProjectile({ x: 100, y: 200, team: 'blue' })
+      projectiles.set(proj.id, proj)
+
+      processProjectiles(projectiles, heroes, towers, 0.016)
+
+      expect(ally.hp).toBe(500)
+    })
+
+    it('should return damage events for each hit', () => {
+      const enemy = createHero('e1', { x: 115, y: 200, team: 'red', radius: 22, hp: 500 })
+      heroes.set('e1', enemy)
+
+      const proj = createLinearProjectile({ x: 100, y: 200, ownerId: 'shooter' })
+      projectiles.set(proj.id, proj)
+
+      const events = processProjectiles(projectiles, heroes, towers, 0.016)
+
+      expect(events).toHaveLength(1)
+      expect(events[0]).toEqual({
+        kind: 'damage',
+        event: { targetId: 'e1', amount: 60, sourceId: 'shooter' },
+      })
+    })
+
+    it('should not break existing homing projectiles', () => {
+      // Homing projectile alongside linear
+      const target = createHero('enemy', { x: 300, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('enemy', target)
+
+      const homing = createProjectile({ id: 'homing-1', x: 295, y: 100, targetId: 'enemy', team: 'blue', damage: 50 })
+      const linear = createLinearProjectile({ id: 'linear-1', x: 100, y: 500 }) // far from any enemy
+      projectiles.set(homing.id, homing)
+      projectiles.set(linear.id, linear)
+
+      const events = processProjectiles(projectiles, heroes, towers, 0.01)
+
+      // Homing should hit its target
+      expect(target.hp).toBe(600)
+      expect(events).toHaveLength(1)
+      // Linear should still be flying
+      expect(projectiles.has('linear-1')).toBe(true)
     })
   })
 })

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
 import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import { executeSkill, tickCooldowns } from '../game/ServerSkillExecutionSystem.js'
 import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
 import { getSkillDefinition } from '@shared/skills/skillDefinitions'
@@ -49,6 +51,24 @@ describe('getSkillDefinition', () => {
 
   it('should return undefined for unknown skill', () => {
     expect(getSkillDefinition('nonexistent')).toBeUndefined()
+  })
+
+  it('should return bolt-pierce-shot definition with projectile params', () => {
+    const def = getSkillDefinition('bolt-pierce-shot')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('bolt-pierce-shot')
+    expect(def!.targeting).toBe('direction')
+    expect(def!.cooldown).toBe(5)
+    expect(def!.effect.effectType).toBe('projectile')
+    if (def!.effect.effectType === 'projectile') {
+      expect(def!.effect.damage).toBe(60)
+      expect(def!.effect.speed).toBe(800)
+      expect(def!.effect.range).toBe(600)
+      expect(def!.effect.radius).toBe(5)
+      expect(def!.effect.pierceCount).toBe(3)
+      expect(def!.effect.homing).toBe(false)
+      expect(def!.effect.visualType).toBe('diamond')
+    }
   })
 })
 
@@ -138,6 +158,55 @@ describe('executeSkill — bolt-dash', () => {
     const hero = createHero({ hp: 500, maxHp: 500, heroType: 'BOLT', skillSlotQ: 'bolt-dash' })
     executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 })
     expect(hero.cooldownQ).toBe(6)
+  })
+})
+
+describe('executeSkill — bolt-pierce-shot', () => {
+  it('should return valid SkillEvent and spawn projectile', () => {
+    const hero = createHero({ heroType: 'BOLT', skillSlotQ: 'bolt-pierce-shot' })
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles)
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('bolt-pierce-shot')
+    expect(event!.direction.x).toBeCloseTo(1)
+    expect(event!.direction.y).toBeCloseTo(0)
+
+    // Projectile should be created in the map
+    expect(projectiles.size).toBe(1)
+    const proj = [...projectiles.values()][0]
+    expect(proj.mode).toBe('linear')
+    expect(proj.dirX).toBeCloseTo(1)
+    expect(proj.dirY).toBeCloseTo(0)
+    expect(proj.speed).toBe(800)
+    expect(proj.damage).toBe(60)
+    expect(proj.maxRange).toBe(600)
+    expect(proj.pierceRemaining).toBe(3)
+    expect(proj.team).toBe(hero.team)
+    expect(proj.ownerId).toBe('bolt-1')
+    expect(proj.visualType).toBe('diamond')
+  })
+
+  it('should set cooldown to 5 seconds', () => {
+    const hero = createHero({ heroType: 'BOLT', skillSlotQ: 'bolt-pierce-shot' })
+    const projectiles = new MapSchema<ProjectileSchema>()
+    executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles)
+    expect(hero.cooldownQ).toBe(5)
+  })
+
+  it('should reject when dead', () => {
+    const hero = createHero({ heroType: 'BOLT', skillSlotQ: 'bolt-pierce-shot', dead: true })
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles)
+    expect(event).toBeNull()
+    expect(projectiles.size).toBe(0)
+  })
+
+  it('should reject when cooldown is active', () => {
+    const hero = createHero({ heroType: 'BOLT', skillSlotQ: 'bolt-pierce-shot', cooldownQ: 3 })
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles)
+    expect(event).toBeNull()
+    expect(projectiles.size).toBe(0)
   })
 })
 

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -183,6 +183,7 @@ describe('executeSkill — bolt-pierce-shot', () => {
     expect(proj.pierceRemaining).toBe(3)
     expect(proj.team).toBe(hero.team)
     expect(proj.ownerId).toBe('bolt-1')
+    expect(proj.radius).toBe(5)
     expect(proj.visualType).toBe('diamond')
   })
 

--- a/server/src/game/ServerProjectileSystem.ts
+++ b/server/src/game/ServerProjectileSystem.ts
@@ -38,11 +38,179 @@ function distanceSq(x1: number, y1: number, x2: number, y2: number): number {
   return dx * dx + dy * dy
 }
 
+// ── Server-side tracking for linear projectiles ────────────
+/** Cumulative distance traveled by each linear projectile */
+const distanceTraveled = new Map<string, number>()
+/** Set of entity IDs already hit by each piercing projectile */
+const hitEntityIds = new Map<string, Set<string>>()
+
+/** Clean up tracking data for a removed projectile */
+function cleanupProjectileTracking(projId: string): void {
+  distanceTraveled.delete(projId)
+  hitEntityIds.delete(projId)
+}
+
+/** Get or create the hit set for a piercing projectile */
+function getHitSet(projId: string): Set<string> {
+  let set = hitEntityIds.get(projId)
+  if (!set) {
+    set = new Set()
+    hitEntityIds.set(projId, set)
+  }
+  return set
+}
+
+// ── Homing projectile logic (existing behavior) ────────────
+
+function processHomingProjectile(
+  proj: ProjectileSchema,
+  projId: string,
+  heroes: MapSchema<HeroSchema>,
+  towers: MapSchema<TowerSchema>,
+  deltaTime: number,
+  minions: MapSchema<MinionSchema> | undefined,
+  events: CombatEventMessage[],
+  toRemove: string[],
+): void {
+  const target = findTargetPosition(proj.targetId, heroes, towers, minions)
+
+  if (!target || target.dead || target.team === proj.team) {
+    toRemove.push(projId)
+    return
+  }
+
+  const dx = target.x - proj.x
+  const dy = target.y - proj.y
+  const distToTarget = Math.sqrt(dx * dx + dy * dy)
+
+  proj.targetX = target.x
+  proj.targetY = target.y
+
+  if (distToTarget === 0) {
+    applyDamageToTarget(proj.targetId, proj.damage, heroes, towers, minions, proj.ownerId)
+    events.push({ kind: 'damage', event: { targetId: proj.targetId, amount: proj.damage, sourceId: proj.ownerId } })
+    toRemove.push(projId)
+    return
+  }
+
+  const moveDistance = proj.speed * deltaTime
+  const nx = dx / distToTarget
+  const ny = dy / distToTarget
+
+  if (moveDistance >= distToTarget) {
+    proj.x = target.x
+    proj.y = target.y
+  } else {
+    proj.x = proj.x + nx * moveDistance
+    proj.y = proj.y + ny * moveDistance
+  }
+
+  const collisionDist = target.radius + DEFAULT_PROJECTILE_RADIUS
+  if (distanceSq(proj.x, proj.y, target.x, target.y) <= collisionDist * collisionDist) {
+    applyDamageToTarget(proj.targetId, proj.damage, heroes, towers, minions, proj.ownerId)
+    events.push({ kind: 'damage', event: { targetId: proj.targetId, amount: proj.damage, sourceId: proj.ownerId } })
+    toRemove.push(projId)
+  }
+}
+
+// ── Linear projectile logic (new: straight-line + pierce) ──
+
+interface EntityCandidate {
+  readonly id: string
+  readonly x: number
+  readonly y: number
+  readonly radius: number
+  readonly dead: boolean
+  readonly team: string
+}
+
+function collectEnemyEntities(
+  projTeam: string,
+  heroes: MapSchema<HeroSchema>,
+  towers: MapSchema<TowerSchema>,
+  minions: MapSchema<MinionSchema> | undefined,
+): EntityCandidate[] {
+  const candidates: EntityCandidate[] = []
+  heroes.forEach((h, id) => {
+    if (h.team !== projTeam && !h.dead) {
+      candidates.push({ id, x: h.x, y: h.y, radius: h.radius, dead: h.dead, team: h.team })
+    }
+  })
+  towers.forEach((t, id) => {
+    if (t.team !== projTeam && !t.dead) {
+      candidates.push({ id, x: t.x, y: t.y, radius: t.radius, dead: t.dead, team: t.team })
+    }
+  })
+  if (minions) {
+    minions.forEach((m, id) => {
+      if (m.team !== projTeam && !m.dead) {
+        candidates.push({ id, x: m.x, y: m.y, radius: m.radius, dead: m.dead, team: m.team })
+      }
+    })
+  }
+  return candidates
+}
+
+function processLinearProjectile(
+  proj: ProjectileSchema,
+  projId: string,
+  heroes: MapSchema<HeroSchema>,
+  towers: MapSchema<TowerSchema>,
+  deltaTime: number,
+  minions: MapSchema<MinionSchema> | undefined,
+  events: CombatEventMessage[],
+  toRemove: string[],
+): void {
+  // Move in direction
+  const moveDistance = proj.speed * deltaTime
+  proj.x = proj.x + proj.dirX * moveDistance
+  proj.y = proj.y + proj.dirY * moveDistance
+
+  // Track cumulative distance
+  const traveled = (distanceTraveled.get(projId) ?? 0) + moveDistance
+  distanceTraveled.set(projId, traveled)
+
+  // Range check
+  if (proj.maxRange > 0 && traveled >= proj.maxRange) {
+    toRemove.push(projId)
+    return
+  }
+
+  // Collision with all enemy entities
+  const hitSet = getHitSet(projId)
+  const enemies = collectEnemyEntities(proj.team, heroes, towers, minions)
+
+  for (const enemy of enemies) {
+    if (hitSet.has(enemy.id)) continue
+
+    const collisionDist = enemy.radius + DEFAULT_PROJECTILE_RADIUS
+    if (distanceSq(proj.x, proj.y, enemy.x, enemy.y) <= collisionDist * collisionDist) {
+      // Hit!
+      hitSet.add(enemy.id)
+      applyDamageToTarget(enemy.id, proj.damage, heroes, towers, minions, proj.ownerId)
+      events.push({ kind: 'damage', event: { targetId: enemy.id, amount: proj.damage, sourceId: proj.ownerId } })
+
+      // Decrement pierce
+      if (proj.pierceRemaining > 0) {
+        proj.pierceRemaining = proj.pierceRemaining - 1
+        if (proj.pierceRemaining <= 0) {
+          toRemove.push(projId)
+          return
+        }
+      } else {
+        // pierceCount=0 means single hit
+        toRemove.push(projId)
+        return
+      }
+    }
+  }
+}
+
+// ── Main entry point ───────────────────────────────────────
+
 /**
  * Process all projectiles for one tick.
- * Each projectile homes toward its designated target entity.
- * Damage is only applied to the designated target (not any entity on the path).
- * Projectiles are removed when they reach the target, the target dies, or the target disappears.
+ * Supports both homing (track targetId) and linear (straight-line + pierce) modes.
  */
 export function processProjectiles(
   projectiles: MapSchema<ProjectileSchema>,
@@ -55,70 +223,23 @@ export function processProjectiles(
   const toRemove: string[] = []
 
   projectiles.forEach((proj, projId) => {
-    // Look up current target position
-    const target = findTargetPosition(proj.targetId, heroes, towers, minions)
-
-    // Remove projectile if target is gone, dead, or same team (friendly fire guard)
-    if (!target || target.dead || target.team === proj.team) {
-      toRemove.push(projId)
-      return
-    }
-
-    // Update homing direction — always fly toward current target position
-    const dx = target.x - proj.x
-    const dy = target.y - proj.y
-    const distToTarget = Math.sqrt(dx * dx + dy * dy)
-
-    // Also update targetX/targetY for client-side interpolation
-    proj.targetX = target.x
-    proj.targetY = target.y
-
-    // Already at target position — apply damage immediately
-    if (distToTarget === 0) {
-      applyDamageToTarget(proj.targetId, proj.damage, heroes, towers, minions, proj.ownerId)
-      events.push({
-        kind: 'damage',
-        event: {
-          targetId: proj.targetId,
-          amount: proj.damage,
-          sourceId: proj.ownerId,
-        },
-      })
-      toRemove.push(projId)
-      return
-    }
-
-    const moveDistance = proj.speed * deltaTime
-    const nx = dx / distToTarget
-    const ny = dy / distToTarget
-
-    if (moveDistance >= distToTarget) {
-      proj.x = target.x
-      proj.y = target.y
+    if (proj.mode === 'linear') {
+      processLinearProjectile(proj, projId, heroes, towers, deltaTime, minions, events, toRemove)
     } else {
-      proj.x = proj.x + nx * moveDistance
-      proj.y = proj.y + ny * moveDistance
-    }
-
-    // Check collision with designated target only
-    const collisionDist = target.radius + DEFAULT_PROJECTILE_RADIUS
-    if (distanceSq(proj.x, proj.y, target.x, target.y) <= collisionDist * collisionDist) {
-      applyDamageToTarget(proj.targetId, proj.damage, heroes, towers, minions, proj.ownerId)
-      events.push({
-        kind: 'damage',
-        event: {
-          targetId: proj.targetId,
-          amount: proj.damage,
-          sourceId: proj.ownerId,
-        },
-      })
-      toRemove.push(projId)
+      processHomingProjectile(proj, projId, heroes, towers, deltaTime, minions, events, toRemove)
     }
   })
 
   for (const id of toRemove) {
     projectiles.delete(id)
+    cleanupProjectileTracking(id)
   }
 
   return events
+}
+
+/** Reset server-side tracking maps. For testing only. */
+export function resetProjectileTracking(): void {
+  distanceTraveled.clear()
+  hitEntityIds.clear()
 }

--- a/server/src/game/ServerProjectileSystem.ts
+++ b/server/src/game/ServerProjectileSystem.ts
@@ -5,7 +5,6 @@ import type { TowerSchema } from '../schema/TowerSchema.js'
 import type { MinionSchema } from '../schema/MinionSchema.js'
 import type { CombatEventMessage } from '@shared/messages'
 import { applyDamageToTarget } from './combatUtils.js'
-import { DEFAULT_PROJECTILE_RADIUS } from '@shared/constants'
 
 interface TargetPosition {
   readonly x: number
@@ -105,7 +104,7 @@ function processHomingProjectile(
     proj.y = proj.y + ny * moveDistance
   }
 
-  const collisionDist = target.radius + DEFAULT_PROJECTILE_RADIUS
+  const collisionDist = target.radius + proj.radius
   if (distanceSq(proj.x, proj.y, target.x, target.y) <= collisionDist * collisionDist) {
     applyDamageToTarget(proj.targetId, proj.damage, heroes, towers, minions, proj.ownerId)
     events.push({ kind: 'damage', event: { targetId: proj.targetId, amount: proj.damage, sourceId: proj.ownerId } })
@@ -183,7 +182,7 @@ function processLinearProjectile(
   for (const enemy of enemies) {
     if (hitSet.has(enemy.id)) continue
 
-    const collisionDist = enemy.radius + DEFAULT_PROJECTILE_RADIUS
+    const collisionDist = enemy.radius + proj.radius
     if (distanceSq(proj.x, proj.y, enemy.x, enemy.y) <= collisionDist * collisionDist) {
       // Hit!
       hitSet.add(enemy.id)

--- a/server/src/game/ServerSkillExecutionSystem.ts
+++ b/server/src/game/ServerSkillExecutionSystem.ts
@@ -1,4 +1,6 @@
+import { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../schema/HeroSchema.js'
+import type { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import type { SkillEvent } from '@shared/messages'
 import { getSkillDefinition } from '@shared/skills/skillDefinitions'
 import { getEffectHandler } from './skills/skillEffectRegistry.js'
@@ -51,6 +53,7 @@ export function executeSkill(
   sessionId: string,
   slot: SkillSlot,
   target: { x: number; y: number },
+  projectiles?: MapSchema<ProjectileSchema>,
 ): SkillEvent | null {
   // Validation: hero must be alive
   if (hero.dead) return null
@@ -80,7 +83,13 @@ export function executeSkill(
   }
 
   handler.execute(
-    { hero, casterId: sessionId, direction, targetPosition: target },
+    {
+      hero,
+      casterId: sessionId,
+      direction,
+      targetPosition: target,
+      projectiles: projectiles ?? new MapSchema(),
+    },
     def.effect,
   )
 

--- a/server/src/game/skills/SkillEffectHandler.ts
+++ b/server/src/game/skills/SkillEffectHandler.ts
@@ -1,4 +1,6 @@
+import type { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../../schema/HeroSchema.js'
+import type { ProjectileSchema } from '../../schema/ProjectileSchema.js'
 import type { SkillEffectParams } from '@shared/skills/skillDefinitions'
 
 /** Context passed to every effect handler at execution time. */
@@ -7,6 +9,7 @@ export interface SkillExecutionContext {
   readonly casterId: string
   readonly direction: { readonly x: number; readonly y: number }
   readonly targetPosition: { readonly x: number; readonly y: number }
+  readonly projectiles: MapSchema<ProjectileSchema>
 }
 
 /** Every effect type implements this interface. */

--- a/server/src/game/skills/handlers/index.ts
+++ b/server/src/game/skills/handlers/index.ts
@@ -1,5 +1,6 @@
 import { registerEffectHandler, clearEffectRegistry } from '../skillEffectRegistry.js'
 import { dashEffectHandler } from './dashEffectHandler.js'
+import { projectileEffectHandler } from './projectileEffectHandler.js'
 
 let registered = false
 
@@ -8,6 +9,7 @@ export function registerAllEffectHandlers(): void {
   if (registered) return
   registered = true
   registerEffectHandler(dashEffectHandler)
+  registerEffectHandler(projectileEffectHandler)
 }
 
 /** Reset registration state and clear registry. For testing only. */

--- a/server/src/game/skills/handlers/projectileEffectHandler.ts
+++ b/server/src/game/skills/handlers/projectileEffectHandler.ts
@@ -1,0 +1,41 @@
+import { ProjectileSchema } from '../../../schema/ProjectileSchema.js'
+import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
+import type { ProjectileEffectParams } from '@shared/skills/skillDefinitions'
+
+let skillProjectileIdCounter = 0
+
+export function resetSkillProjectileIdCounter(): void {
+  skillProjectileIdCounter = 0
+}
+
+export const projectileEffectHandler: SkillEffectHandler<ProjectileEffectParams> = {
+  effectType: 'projectile',
+  execute(ctx: SkillExecutionContext, params: ProjectileEffectParams): void {
+    const { hero, casterId, direction, projectiles } = ctx
+
+    const proj = new ProjectileSchema()
+    proj.id = `skill-proj-${++skillProjectileIdCounter}`
+    proj.x = hero.x
+    proj.y = hero.y
+    proj.speed = params.speed
+    proj.damage = params.damage
+    proj.ownerId = casterId
+    proj.team = hero.team
+
+    if (params.homing) {
+      proj.mode = 'homing'
+      // For homing skill projectiles, targetId would need to be set separately
+      // (not used by pierce-shot, but ready for future homing skill projectiles)
+    } else {
+      proj.mode = 'linear'
+      proj.dirX = direction.x
+      proj.dirY = direction.y
+    }
+
+    proj.maxRange = params.range
+    proj.pierceRemaining = params.pierceCount
+    proj.visualType = params.visualType
+
+    projectiles.set(proj.id, proj)
+  },
+}

--- a/server/src/game/skills/handlers/projectileEffectHandler.ts
+++ b/server/src/game/skills/handlers/projectileEffectHandler.ts
@@ -23,15 +23,14 @@ export const projectileEffectHandler: SkillEffectHandler<ProjectileEffectParams>
     proj.team = hero.team
 
     if (params.homing) {
-      proj.mode = 'homing'
-      // For homing skill projectiles, targetId would need to be set separately
-      // (not used by pierce-shot, but ready for future homing skill projectiles)
+      throw new Error('Homing skill projectiles are not yet implemented — targetId resolution is required')
     } else {
       proj.mode = 'linear'
       proj.dirX = direction.x
       proj.dirY = direction.y
     }
 
+    proj.radius = params.radius
     proj.maxRange = params.range
     proj.pierceRemaining = params.pierceCount
     proj.visualType = params.visualType

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -177,7 +177,7 @@ export class GameRoom extends Room<GameRoomState> {
       if (!isValidUseSkillMessage(message)) return
       const hero = this.state.heroes.get(client.sessionId)
       if (!hero) return
-      const event = executeSkill(hero, client.sessionId, message.slot, message.target)
+      const event = executeSkill(hero, client.sessionId, message.slot, message.target, this.state.projectiles)
       if (event) {
         this.broadcast('skill', event)
       }

--- a/server/src/schema/ProjectileSchema.ts
+++ b/server/src/schema/ProjectileSchema.ts
@@ -1,4 +1,5 @@
 import { Schema, type } from '@colyseus/schema'
+import { DEFAULT_PROJECTILE_RADIUS } from '@shared/constants'
 
 /**
  * Colyseus state schema for a projectile entity.
@@ -15,6 +16,8 @@ export class ProjectileSchema extends Schema {
   @type('string') team: string = 'blue'
   /** The entity this projectile homes toward. Damage only applies to this target. */
   @type('string') targetId: string = ''
+  /** Collision & rendering radius (px) */
+  @type('float32') radius: number = DEFAULT_PROJECTILE_RADIUS
 
   // ── Linear / pierce fields ──────────────────────────────
   /** Flight mode: 'homing' = track targetId, 'linear' = straight line */

--- a/server/src/schema/ProjectileSchema.ts
+++ b/server/src/schema/ProjectileSchema.ts
@@ -15,4 +15,17 @@ export class ProjectileSchema extends Schema {
   @type('string') team: string = 'blue'
   /** The entity this projectile homes toward. Damage only applies to this target. */
   @type('string') targetId: string = ''
+
+  // ── Linear / pierce fields ──────────────────────────────
+  /** Flight mode: 'homing' = track targetId, 'linear' = straight line */
+  @type('string') mode: string = 'homing'
+  /** Visual style key — see shared/projectile/projectileVisuals.ts */
+  @type('string') visualType: string = 'circle'
+  /** Direction for linear mode (normalized) */
+  @type('float32') dirX: number = 0
+  @type('float32') dirY: number = 0
+  /** Max flight distance in px (0 = unlimited, used by homing) */
+  @type('float32') maxRange: number = 0
+  /** Remaining pierce count (0 = remove on first hit) */
+  @type('int16') pierceRemaining: number = 0
 }

--- a/shared/projectile/projectileVisuals.ts
+++ b/shared/projectile/projectileVisuals.ts
@@ -1,0 +1,40 @@
+// ── Projectile visual types ─────────────────────────────────
+// Separates "how it looks" from "how it flies" (mode).
+// Add new entries here when introducing new projectile visuals.
+
+export type ProjectileVisualType = 'circle' | 'diamond'
+
+export interface ProjectileVisualDef {
+  readonly type: ProjectileVisualType
+  /** Whether this shape needs direction info (dirX/dirY) for rendering */
+  readonly directional: boolean
+}
+
+/** Circle: small filled dot (auto-attack projectiles) */
+export interface CircleVisualDef extends ProjectileVisualDef {
+  readonly type: 'circle'
+}
+
+/** Diamond: elongated rhombus aligned to travel direction (skill projectiles) */
+export interface DiamondVisualDef extends ProjectileVisualDef {
+  readonly type: 'diamond'
+  readonly halfLength: number   // px along travel direction
+  readonly halfWidth: number    // px perpendicular
+}
+
+export type ProjectileVisual = CircleVisualDef | DiamondVisualDef
+
+// ── Registry ────────────────────────────────────────────────
+
+export const PROJECTILE_VISUALS: Record<ProjectileVisualType, ProjectileVisual> = {
+  circle: {
+    type: 'circle',
+    directional: false,
+  },
+  diamond: {
+    type: 'diamond',
+    directional: true,
+    halfLength: 10,
+    halfWidth: 4,
+  },
+}

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -7,14 +7,22 @@ export interface DashEffectParams {
   readonly damage: number         // contact damage during dash
 }
 
+export interface ProjectileEffectParams {
+  readonly effectType: 'projectile'
+  readonly damage: number           // hit damage per target
+  readonly speed: number            // px/sec
+  readonly range: number            // max travel distance (px)
+  readonly radius: number           // collision/render radius (px)
+  readonly pierceCount: number      // max enemies to pierce (0 = single hit)
+  readonly homing: boolean          // true = track target, false = straight line
+  readonly visualType: string       // key into PROJECTILE_VISUALS (e.g. 'circle', 'diamond')
+}
+
 // Future effect types:
-// export interface ProjectileEffectParams { effectType: 'projectile'; ... }
 // export interface AoeEffectParams { effectType: 'aoe'; ... }
 // export interface BuffEffectParams { effectType: 'buff'; ... }
 
-export type SkillEffectParams = DashEffectParams
-// Union expands as new effect types are added:
-// export type SkillEffectParams = DashEffectParams | ProjectileEffectParams | AoeEffectParams | ...
+export type SkillEffectParams = DashEffectParams | ProjectileEffectParams
 
 // ── Common fields shared by ALL skills ────────────────────────
 
@@ -50,6 +58,21 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       distance: 180,
       duration: 0.05,
       damage: 0,
+    },
+  },
+  'bolt-pierce-shot': {
+    id: 'bolt-pierce-shot',
+    targeting: 'direction',
+    cooldown: 5,
+    effect: {
+      effectType: 'projectile',
+      damage: 60,
+      speed: 800,
+      range: 600,
+      radius: 5,
+      pierceCount: 3,
+      homing: false,
+      visualType: 'diamond',
     },
   },
 }

--- a/src/network/GameMode.ts
+++ b/src/network/GameMode.ts
@@ -37,6 +37,9 @@ export interface ServerProjectileState {
   readonly y: number
   readonly team: string
   readonly radius: number
+  readonly visualType: string  // key into PROJECTILE_VISUALS
+  readonly dirX: number        // direction for directional visuals
+  readonly dirY: number
 }
 
 /** Server-synced minion state */

--- a/src/network/OnlineGameMode.ts
+++ b/src/network/OnlineGameMode.ts
@@ -313,6 +313,9 @@ export class OnlineGameMode implements GameMode {
         y: proj.y as number,
         team: proj.team as string,
         radius: DEFAULT_PROJECTILE_RADIUS,
+        visualType: (proj.visualType as string) ?? 'circle',
+        dirX: (proj.dirX as number) ?? 0,
+        dirY: (proj.dirY as number) ?? 0,
       })
     })
     for (const cb of this.serverProjectileUpdateCallbacks) cb(projectiles)

--- a/src/network/OnlineGameMode.ts
+++ b/src/network/OnlineGameMode.ts
@@ -312,7 +312,7 @@ export class OnlineGameMode implements GameMode {
         x: proj.x as number,
         y: proj.y as number,
         team: proj.team as string,
-        radius: DEFAULT_PROJECTILE_RADIUS,
+        radius: (proj.radius as number) ?? DEFAULT_PROJECTILE_RADIUS,
         visualType: (proj.visualType as string) ?? 'circle',
         dirX: (proj.dirX as number) ?? 0,
         dirY: (proj.dirY as number) ?? 0,

--- a/src/scenes/effects/ProjectileRenderer.ts
+++ b/src/scenes/effects/ProjectileRenderer.ts
@@ -2,6 +2,11 @@ import Phaser from 'phaser'
 import type { ProjectileState } from '@/domain/projectile/ProjectileState'
 import type { ServerProjectileState } from '@/network/GameMode'
 import type { Team } from '@/domain/types'
+import {
+  PROJECTILE_VISUALS,
+  type ProjectileVisualType,
+  type DiamondVisualDef,
+} from '@shared/projectile/projectileVisuals'
 
 const PROJECTILE_COLORS: Record<Team, number> = {
   blue: 0x3498db,
@@ -12,8 +17,9 @@ const PROJECTILE_COLORS: Record<Team, number> = {
 const PROJECTILE_DEPTH = 8
 
 /**
- * Renders all active projectiles as filled circles each frame.
- * Uses a single shared Graphics object — clears and redraws every update.
+ * Renders all active projectiles each frame.
+ * Visual style is determined by `visualType` (from PROJECTILE_VISUALS table),
+ * keeping rendering logic separate from flight mode.
  */
 export class ProjectileRenderer {
   private readonly graphics: Phaser.GameObjects.Graphics
@@ -39,9 +45,43 @@ export class ProjectileRenderer {
 
     for (const p of projectiles) {
       const color = PROJECTILE_COLORS[p.team as Team]
-      this.graphics.fillStyle(color, 1)
-      this.graphics.fillCircle(p.x, p.y, p.radius)
+      const visual = PROJECTILE_VISUALS[p.visualType as ProjectileVisualType]
+
+      if (!visual || visual.type === 'circle') {
+        this.graphics.fillStyle(color, 1)
+        this.graphics.fillCircle(p.x, p.y, p.radius)
+      } else if (visual.type === 'diamond') {
+        this.drawDiamond(p.x, p.y, p.dirX, p.dirY, color, visual)
+      }
     }
+  }
+
+  private drawDiamond(
+    x: number, y: number,
+    dirX: number, dirY: number,
+    color: number,
+    def: DiamondVisualDef,
+  ): void {
+    const perpX = -dirY
+    const perpY = dirX
+
+    const fx = x + dirX * def.halfLength
+    const fy = y + dirY * def.halfLength
+    const bx = x - dirX * def.halfLength
+    const by = y - dirY * def.halfLength
+    const rx = x + perpX * def.halfWidth
+    const ry = y + perpY * def.halfWidth
+    const lx = x - perpX * def.halfWidth
+    const ly = y - perpY * def.halfWidth
+
+    this.graphics.fillStyle(color, 1)
+    this.graphics.beginPath()
+    this.graphics.moveTo(fx, fy)
+    this.graphics.lineTo(rx, ry)
+    this.graphics.lineTo(bx, by)
+    this.graphics.lineTo(lx, ly)
+    this.graphics.closePath()
+    this.graphics.fillPath()
   }
 
   destroy(): void {


### PR DESCRIPTION
## Summary
- BOLTの火力スキル Pierce Shot を実装（Depth 1, Cost 1 — 方向指定で貫通弾を発射）
- 新しい `projectile` effectType をスキルエフェクトハンドラに追加（dash に続く2つ目の effectType）
- 既存ホーミングプロジェクタイルシステムを拡張し、直進（linear）+ 貫通（pierce）モードをサポート
- `visualType` フィールドで飛行ロジック（mode）と描画（visualType）を分離し、見た目の一括管理を実現

## Changes
### Backend
- `ProjectileEffectParams` interface + `bolt-pierce-shot` skill definition (damage=60, speed=800, range=600, pierceCount=3)
- `ProjectileSchema` extended: mode, visualType, dirX, dirY, maxRange, pierceRemaining
- `ServerProjectileSystem`: linear mode (straight-line movement, range limit, pierce hit detection with hitEntityIds tracking)
- `projectileEffectHandler`: spawns projectile on skill cast
- `SkillExecutionContext`: now includes `projectiles` MapSchema reference

### Frontend
- `ProjectileRenderer`: table-driven rendering via `PROJECTILE_VISUALS` registry
- Linear projectiles render as elongated diamonds aligned to travel direction
- Homing projectiles unchanged (filled circles)

### Shared
- `shared/projectile/projectileVisuals.ts`: centralized visual definitions (circle, diamond)

## Test plan
- [x] Pierce Shot definition test (params, visualType)
- [x] Pierce Shot execution tests (projectile spawn, cooldown, rejection on dead/CD)
- [x] Linear projectile tests (straight-line movement, range removal, pierce through multiple enemies, no double-hit, ally skip, damage events)
- [x] Homing projectile non-regression (existing 14 tests unchanged)
- [x] All 749 unit tests pass
- [x] Lint clean