### PR TITLE
feat: add AURA Heal skill with ally targeting

### DIFF
--- a/openspec/changes/archive/2026-03-09-aura-heal/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-09-aura-heal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-09

--- a/openspec/changes/archive/2026-03-09-aura-heal/design.md
+++ b/openspec/changes/archive/2026-03-09-aura-heal/design.md
@@ -1,0 +1,78 @@
+## Context
+
+AURAの Q スキル「Heal」を実装する。現在のスキルシステムは攻撃系（dash, projectile）のみで、味方を対象とするスキルが存在しない。Heal は味方または自分のHPを回復するシンプルな仕様で、新しい `heal` effectType と `ally` ターゲティングの最初の実装となる。
+
+現在の実装:
+- `SkillEffectParams` は `DashEffectParams | ProjectileEffectParams` の共用体
+- `SkillEffectHandler` レジストリで effectType ごとにハンドラをディスパッチ
+- `SkillExecutionContext` は `hero`, `casterId`, `direction`, `targetPosition`, `projectiles` を持つ
+- `SkillTargeting` 型に `'ally'` は定義済みだが、サーバー側の ally ターゲット解決ロジックは未実装
+- `CombatEntitySchema` に `applyDamage()` はあるが回復メソッドはない
+
+## Goals / Non-Goals
+
+**Goals:**
+- `heal` effectType を追加し、ハンドラレジストリパターンを維持して拡張する
+- `ally` ターゲティングのサーバー側解決ロジックを実装する（最寄り味方 or 自己回復）
+- `SkillExecutionContext` に `heroes` MapSchema を追加し、味方検索を可能にする
+- HP 回復は maxHp を超えないようクランプする
+
+**Non-Goals:**
+- Shield（E スキル）やその他バフ/デバフの実装
+- 回復エフェクトのクライアント描画（Phase 1 では skillEvent の受信のみ）
+- 回復量のレベルスケーリング（将来タレントツリーで対応）
+
+## Decisions
+
+### D1: HealEffectParams の設計
+
+`HealEffectParams` を `{ effectType: 'heal', healAmount: number, range: number }` とする。
+
+- `healAmount`: 回復量（固定値）
+- `range`: 対象選択の射程（px）。ally ターゲティングで「クリック位置の最寄り味方」が射程内かの判定に使用。
+
+**理由**: Dash（distance, duration, damage）、Projectile（speed, range, radius, ...）と同様に、effectType 固有のパラメータを持たせるパターンを踏襲。
+
+### D2: ally ターゲット解決の実装箇所
+
+`executeSkill` 内で、`targeting === 'ally'` の場合にクリック座標から最寄りの同チーム生存ヒーローを検索する。見つからない場合は自分自身を対象とする。
+
+**理由**: ターゲット解決はスキル発動フロー（検証→ターゲット解決→エフェクト実行→CD設定）の一部であり、`executeSkill` に属する。エフェクトハンドラは「対象が確定した後の処理」に専念する。
+
+**代替案**: エフェクトハンドラ内でターゲット解決 → 責務が混在するため却下。
+
+### D3: SkillExecutionContext の拡張
+
+`heroes: MapSchema<HeroSchema>` を `SkillExecutionContext` に追加する。`targetHero` フィールドも追加し、ally ターゲティングで解決されたヒーロー参照を渡す。
+
+```typescript
+export interface SkillExecutionContext {
+  readonly hero: HeroSchema
+  readonly casterId: string
+  readonly direction: { readonly x: number; readonly y: number }
+  readonly targetPosition: { readonly x: number; readonly y: number }
+  readonly projectiles: MapSchema<ProjectileSchema>
+  readonly heroes: MapSchema<HeroSchema>
+  readonly targetHero?: HeroSchema  // ally ターゲティングで解決された対象
+}
+```
+
+**理由**: `heroes` は将来の味方対象スキル（Shield, Haste 等）でも再利用される。`targetHero` は解決済みターゲットを渡すことでハンドラの責務をシンプルに保つ。
+
+### D4: HP 回復メソッド
+
+`CombatEntitySchema` に `applyHeal(amount: number)` を追加する。`applyDamage` と対称的に、`maxHp` を超えないようクランプし、`dead` 状態では無効とする。
+
+**理由**: 回復ロジックを1箇所に集約し、将来の回復系スキル（zone heal 等）で再利用可能にする。
+
+### D5: 自己回復のフォールバック
+
+射程内に味方がいない場合、自分自身を回復対象とする。これにより「使ったのに何も起きない」ケースを防ぐ。
+
+**理由**: MOBA の一般的な Heal スキル仕様。2v2 では味方が1人しかいないため、フォールバックが重要。
+
+## Risks / Trade-offs
+
+- **[Risk] ally ターゲティングの精度** — クリック座標から最寄り味方を選ぶため、密集時に意図しない対象を選ぶ可能性がある → 射程内チェックで緩和。2v2 なので味方は1人、実質的な問題は少ない。
+- **[Risk] SkillExecutionContext の肥大化** — フィールド追加が続くと管理が難しくなる → 現時点では `heroes` と `targetHero` のみで許容範囲。大きくなりすぎた場合はコンテキストオブジェクトの分割を検討。
+- **[Trade-off] 自己回復フォールバック** — 「味方を狙ったが自分に当たった」ケースが発生しうる → 2v2 の簡素さを優先し、Phase 1 では許容。

--- a/openspec/changes/archive/2026-03-09-aura-heal/proposal.md
+++ b/openspec/changes/archive/2026-03-09-aura-heal/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+AURAの味方支援ビルドの起点となるスキル Heal を実装する。現在のスキルシステムは攻撃系（dash, projectile）のみで、味方を対象とするスキルが存在しない。Heal は「味方または自分のHPを回復する」というシンプルな仕様で、新しい `heal` effectType と `ally` ターゲティングの最初の実装として最適。今後の Haste, Barrier 等の味方支援スキル基盤となる。
+
+## What Changes
+
+- `shared/skills/skillDefinitions.ts` に `HealEffectParams` インターフェースと `aura-heal` スキル定義を追加
+- `SkillEffectParams` 共用体に `HealEffectParams` を追加
+- サーバーに `healEffectHandler` を新規作成（スキル発動時にターゲットのHPを回復）
+- `SkillExecutionContext` に `heroes` MapSchema 参照を追加（味方ターゲット解決のため）
+- `executeSkill` で `ally` ターゲティング時にクリック座標から最寄り味方を検索するロジックを追加
+- クライアント側のターゲティングUIで `ally` モードの視覚フィードバック（既存の色変更で対応可能）
+
+## Capabilities
+
+### New Capabilities
+- `aura-heal`: Heal スキルの定義、heal effectType ハンドラ、味方ターゲット解決の実装
+
+### Modified Capabilities
+- `skill-execution`: `ally` ターゲティングのサポート追加（最寄り味方検索、射程チェック）
+
+## Impact
+
+- **shared/skills/**: `HealEffectParams` 追加、`SkillEffectParams` 共用体拡張
+- **server/src/game/skills/handlers/**: 新規 `healEffectHandler.ts`
+- **server/src/game/**: `ServerSkillExecutionSystem` に ally ターゲット解決ロジック追加
+- **server/src/game/skills/**: `SkillExecutionContext` に heroes 参照追加
+- **src/scenes/**: クライアント側ターゲティングUI（ally モード対応）

--- a/openspec/changes/archive/2026-03-09-aura-heal/specs/aura-heal/spec.md
+++ b/openspec/changes/archive/2026-03-09-aura-heal/specs/aura-heal/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: HealEffectParams 定義
+`shared/skills/skillDefinitions.ts` に `HealEffectParams` インターフェースを追加しなければならない（SHALL）。`effectType: 'heal'`、`healAmount: number`（回復量）、`range: number`（味方選択射程 px）を持たなければならない（SHALL）。`SkillEffectParams` 共用体に `HealEffectParams` を追加しなければならない（SHALL）。
+
+#### Scenario: HealEffectParams の型定義
+- **WHEN** `HealEffectParams` を定義する
+- **THEN** `effectType` が `'heal'`、`healAmount` が `number`、`range` が `number` のプロパティを持つ
+
+#### Scenario: SkillEffectParams 共用体の拡張
+- **WHEN** `SkillEffectParams` 型を参照する
+- **THEN** `DashEffectParams | ProjectileEffectParams | HealEffectParams` の共用体である
+
+### Requirement: aura-heal スキル定義
+`SKILL_DEFINITIONS` に `aura-heal` エントリを追加しなければならない（SHALL）。`targeting` は `'ally'`、`cooldown` は `10` 秒、`effect` は `HealEffectParams` で `healAmount: 120`、`range: 400` でなければならない（SHALL）。
+
+#### Scenario: aura-heal スキル定義の参照
+- **WHEN** `getSkillDefinition('aura-heal')` を呼び出す
+- **THEN** `targeting: 'ally'`、`cooldown: 10`、`effect.effectType: 'heal'`、`effect.healAmount: 120`、`effect.range: 400` のスキル定義が返される
+
+### Requirement: healEffectHandler
+サーバーに `healEffectHandler` を実装しなければならない（SHALL）。`effectType: 'heal'` として効果ハンドラレジストリに登録しなければならない（SHALL）。実行時に `ctx.targetHero` の HP を `params.healAmount` 分回復しなければならない（SHALL）。`ctx.targetHero` が存在しない場合は `ctx.hero`（自分自身）を回復しなければならない（SHALL）。
+
+#### Scenario: 味方ヒーローの回復
+- **WHEN** `targetHero` がHP 200/500 の味方で、`healAmount: 120` で実行する
+- **THEN** `targetHero` の HP が 320 になる
+
+#### Scenario: 自己回復フォールバック
+- **WHEN** `targetHero` が undefined で、自分のHPが 300/500 で `healAmount: 120` で実行する
+- **THEN** 自分の HP が 420 になる
+
+#### Scenario: maxHp を超えない回復
+- **WHEN** 対象のHPが 450/500 で `healAmount: 120` で実行する
+- **THEN** 対象の HP が 500 になる（maxHp でクランプ）
+
+### Requirement: CombatEntitySchema.applyHeal
+`CombatEntitySchema` に `applyHeal(amount: number)` メソッドを追加しなければならない（SHALL）。HP を `amount` 分増加させ、`maxHp` を超えないようクランプしなければならない（SHALL）。`dead` 状態のエンティティに対しては何もしてはならない（SHALL）。
+
+#### Scenario: 通常の回復
+- **WHEN** HP 200、maxHp 500 のエンティティに `applyHeal(100)` を呼ぶ
+- **THEN** HP が 300 になる
+
+#### Scenario: maxHp クランプ
+- **WHEN** HP 480、maxHp 500 のエンティティに `applyHeal(100)` を呼ぶ
+- **THEN** HP が 500 になる
+
+#### Scenario: 死亡エンティティへの回復は無効
+- **WHEN** `dead: true` のエンティティに `applyHeal(100)` を呼ぶ
+- **THEN** HP は変化しない

--- a/openspec/changes/archive/2026-03-09-aura-heal/specs/skill-execution/spec.md
+++ b/openspec/changes/archive/2026-03-09-aura-heal/specs/skill-execution/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: useSkill メッセージ
+クライアントは `useSkill` メッセージ（`slot: 'Q' | 'E' | 'R'`, `target: { x: number, y: number }`）をサーバーに送信しなければならない（SHALL）。サーバーは受信時に以下を検証しなければならない（SHALL）：該当スロットにスキルが装備されていること、スロットのクールダウンが 0 であること、ヒーローが生存中であること。検証失敗時はメッセージを無視しなければならない（SHALL）。
+
+`ally` ターゲティングのスキルの場合、サーバーはクリック座標から最寄りの同チーム生存ヒーローを検索しなければならない（SHALL）。最寄りヒーローがスキルの `range` 以内にいる場合、そのヒーローを対象としなければならない（SHALL）。射程内に味方がいない場合、発動者自身を対象としなければならない（SHALL）。解決されたターゲットは `SkillExecutionContext.targetHero` として渡されなければならない（SHALL）。
+
+#### Scenario: 正常なスキル発動
+- **WHEN** ヒーローが生存中で、Q スロットに `blade-charge` が装備されており、CD が 0 の状態で `useSkill { slot: 'Q', target: { x: 500, y: 300 } }` を送信する
+- **THEN** サーバーがスキル効果を実行し、Q スロットのクールダウンがスキル定義の cooldown 値にセットされる
+
+#### Scenario: クールダウン中のスキル発動拒否
+- **WHEN** Q スロットのクールダウンが 0 より大きい状態で `useSkill { slot: 'Q', ... }` を送信する
+- **THEN** サーバーはメッセージを無視し、状態は変化しない
+
+#### Scenario: 死亡中のスキル発動拒否
+- **WHEN** ヒーローが死亡中に `useSkill` を送信する
+- **THEN** サーバーはメッセージを無視し、状態は変化しない
+
+#### Scenario: 空スロットのスキル発動拒否
+- **WHEN** Q スロットが空（スキル未装備）の状態で `useSkill { slot: 'Q', ... }` を送信する
+- **THEN** サーバーはメッセージを無視し、状態は変化しない
+
+#### Scenario: ally ターゲティングで味方を回復
+- **WHEN** `aura-heal`（ally ターゲティング, range: 400）を装備し、味方ヒーローの近く（距離 300px）をクリックする
+- **THEN** 最寄りの同チーム生存ヒーローが `targetHero` としてエフェクトハンドラに渡され、回復が実行される
+
+#### Scenario: ally ターゲティングで射程外 — 自己回復
+- **WHEN** `aura-heal`（range: 400）を装備し、味方ヒーローから 500px 離れた位置をクリックする
+- **THEN** 発動者自身が `targetHero` としてセットされ、自己回復が実行される
+
+## ADDED Requirements
+
+### Requirement: SkillExecutionContext に heroes と targetHero を追加
+`SkillExecutionContext` に `heroes: MapSchema<HeroSchema>` と `targetHero?: HeroSchema` フィールドを追加しなければならない（SHALL）。`heroes` はルーム内の全ヒーロー参照で、味方ターゲット検索に使用されなければならない（SHALL）。`targetHero` は ally ターゲティングで解決された対象ヒーローでなければならない（SHALL）。
+
+#### Scenario: heroes が渡される
+- **WHEN** `executeSkill` が呼ばれる
+- **THEN** `SkillExecutionContext.heroes` にルーム内の全ヒーローの MapSchema が含まれる
+
+#### Scenario: ally ターゲティング時に targetHero が設定される
+- **WHEN** ally ターゲティングのスキルで味方が射程内にいる
+- **THEN** `SkillExecutionContext.targetHero` にその味方ヒーローが設定される
+
+### Requirement: GameRoom から executeSkill に heroes を渡す
+`GameRoom` の `useSkill` メッセージハンドラで `executeSkill` に `this.state.heroes` を渡さなければならない（SHALL）。
+
+#### Scenario: GameRoom が heroes を渡す
+- **WHEN** クライアントが `useSkill` メッセージを送信する
+- **THEN** `executeSkill` に `this.state.heroes` と `this.state.projectiles` の両方が渡される

--- a/openspec/changes/archive/2026-03-09-aura-heal/tasks.md
+++ b/openspec/changes/archive/2026-03-09-aura-heal/tasks.md
@@ -1,0 +1,22 @@
+## 1. Shared 定義（shared/）
+
+- [x] 1.1 `HealEffectParams` インターフェースを追加し、`SkillEffectParams` 共用体を拡張する（specs/aura-heal/spec.md: HealEffectParams 定義）
+- [x] 1.2 `SKILL_DEFINITIONS` に `aura-heal` エントリを追加する（specs/aura-heal/spec.md: aura-heal スキル定義）
+
+## 2. サーバー基盤（server/）
+
+- [x] 2.1 `CombatEntitySchema.applyHeal(amount)` メソッドを追加する（specs/aura-heal/spec.md: CombatEntitySchema.applyHeal）
+- [x] 2.2 `SkillExecutionContext` に `heroes` と `targetHero` フィールドを追加する（specs/skill-execution/spec.md: SkillExecutionContext 拡張）
+- [x] 2.3 `executeSkill` に ally ターゲット解決ロジックを追加する — 最寄り同チーム生存ヒーロー検索、射程チェック、自己フォールバック（specs/skill-execution/spec.md: useSkill メッセージ MODIFIED）
+- [x] 2.4 `GameRoom` から `executeSkill` に `this.state.heroes` を渡すようにする（specs/skill-execution/spec.md: GameRoom から heroes を渡す）
+
+## 3. Heal エフェクトハンドラ（server/）
+
+- [x] 3.1 `healEffectHandler` を作成し、ハンドラレジストリに登録する（specs/aura-heal/spec.md: healEffectHandler）
+
+## 4. テスト
+
+- [x] 4.1 `CombatEntitySchema.applyHeal` のユニットテスト（通常回復、maxHp クランプ、死亡エンティティ）
+- [x] 4.2 `healEffectHandler` のユニットテスト（味方回復、自己フォールバック、maxHp クランプ）
+- [x] 4.3 `executeSkill` ally ターゲティングのユニットテスト（射程内味方、射程外自己フォールバック）
+- [x] 4.4 全テスト・lint パス確認（`npm run test:unit && npm run lint`）

--- a/openspec/specs/aura-heal/spec.md
+++ b/openspec/specs/aura-heal/spec.md
@@ -1,0 +1,55 @@
+# Specification
+
+## Purpose
+
+オーラヒールスキル — 味方ヒーローまたは自分自身を回復するスキルの定義、エフェクトハンドラ、回復ロジックを担う。
+
+## Requirements
+
+### Requirement: HealEffectParams 定義
+`shared/skills/skillDefinitions.ts` に `HealEffectParams` インターフェースを追加しなければならない（SHALL）。`effectType: 'heal'`、`healAmount: number`（回復量）、`range: number`（味方選択射程 px）を持たなければならない（SHALL）。`SkillEffectParams` 共用体に `HealEffectParams` を追加しなければならない（SHALL）。
+
+#### Scenario: HealEffectParams の型定義
+- **WHEN** `HealEffectParams` を定義する
+- **THEN** `effectType` が `'heal'`、`healAmount` が `number`、`range` が `number` のプロパティを持つ
+
+#### Scenario: SkillEffectParams 共用体の拡張
+- **WHEN** `SkillEffectParams` 型を参照する
+- **THEN** `DashEffectParams | ProjectileEffectParams | HealEffectParams` の共用体である
+
+### Requirement: aura-heal スキル定義
+`SKILL_DEFINITIONS` に `aura-heal` エントリを追加しなければならない（SHALL）。`targeting` は `'ally'`、`cooldown` は `10` 秒、`effect` は `HealEffectParams` で `healAmount: 120`、`range: 400` でなければならない（SHALL）。
+
+#### Scenario: aura-heal スキル定義の参照
+- **WHEN** `getSkillDefinition('aura-heal')` を呼び出す
+- **THEN** `targeting: 'ally'`、`cooldown: 10`、`effect.effectType: 'heal'`、`effect.healAmount: 120`、`effect.range: 400` のスキル定義が返される
+
+### Requirement: healEffectHandler
+サーバーに `healEffectHandler` を実装しなければならない（SHALL）。`effectType: 'heal'` として効果ハンドラレジストリに登録しなければならない（SHALL）。実行時に `ctx.targetHero` の HP を `params.healAmount` 分回復しなければならない（SHALL）。`ctx.targetHero` が存在しない場合は `ctx.hero`（自分自身）を回復しなければならない（SHALL）。
+
+#### Scenario: 味方ヒーローの回復
+- **WHEN** `targetHero` がHP 200/500 の味方で、`healAmount: 120` で実行する
+- **THEN** `targetHero` の HP が 320 になる
+
+#### Scenario: 自己回復フォールバック
+- **WHEN** `targetHero` が undefined で、自分のHPが 300/500 で `healAmount: 120` で実行する
+- **THEN** 自分の HP が 420 になる
+
+#### Scenario: maxHp を超えない回復
+- **WHEN** 対象のHPが 450/500 で `healAmount: 120` で実行する
+- **THEN** 対象の HP が 500 になる（maxHp でクランプ）
+
+### Requirement: CombatEntitySchema.applyHeal
+`CombatEntitySchema` に `applyHeal(amount: number)` メソッドを追加しなければならない（SHALL）。HP を `amount` 分増加させ、`maxHp` を超えないようクランプしなければならない（SHALL）。`dead` 状態のエンティティに対しては何もしてはならない（SHALL）。
+
+#### Scenario: 通常の回復
+- **WHEN** HP 200、maxHp 500 のエンティティに `applyHeal(100)` を呼ぶ
+- **THEN** HP が 300 になる
+
+#### Scenario: maxHp クランプ
+- **WHEN** HP 480、maxHp 500 のエンティティに `applyHeal(100)` を呼ぶ
+- **THEN** HP が 500 になる
+
+#### Scenario: 死亡エンティティへの回復は無効
+- **WHEN** `dead: true` のエンティティに `applyHeal(100)` を呼ぶ
+- **THEN** HP は変化しない

--- a/openspec/specs/skill-execution/spec.md
+++ b/openspec/specs/skill-execution/spec.md
@@ -16,6 +16,8 @@
 ### Requirement: useSkill メッセージ
 クライアントは `useSkill` メッセージ（`slot: 'Q' | 'E' | 'R'`, `target: { x: number, y: number }`）をサーバーに送信しなければならない（SHALL）。サーバーは受信時に以下を検証しなければならない（SHALL）：該当スロットにスキルが装備されていること、スロットのクールダウンが 0 であること、ヒーローが生存中であること。検証失敗時はメッセージを無視しなければならない（SHALL）。
 
+`ally` ターゲティングのスキルの場合、サーバーはクリック座標から最寄りの同チーム生存ヒーローを検索しなければならない（SHALL）。最寄りヒーローがスキルの `range` 以内にいる場合、そのヒーローを対象としなければならない（SHALL）。射程内に味方がいない場合、発動者自身を対象としなければならない（SHALL）。解決されたターゲットは `SkillExecutionContext.targetHero` として渡されなければならない（SHALL）。
+
 #### Scenario: 正常なスキル発動
 - **WHEN** ヒーローが生存中で、Q スロットに `blade-charge` が装備されており、CD が 0 の状態で `useSkill { slot: 'Q', target: { x: 500, y: 300 } }` を送信する
 - **THEN** サーバーがスキル効果を実行し、Q スロットのクールダウンがスキル定義の cooldown 値にセットされる
@@ -31,6 +33,14 @@
 #### Scenario: 空スロットのスキル発動拒否
 - **WHEN** Q スロットが空（スキル未装備）の状態で `useSkill { slot: 'Q', ... }` を送信する
 - **THEN** サーバーはメッセージを無視し、状態は変化しない
+
+#### Scenario: ally ターゲティングで味方を回復
+- **WHEN** `aura-heal`（ally ターゲティング, range: 400）を装備し、味方ヒーローの近く（距離 300px）をクリックする
+- **THEN** 最寄りの同チーム生存ヒーローが `targetHero` としてエフェクトハンドラに渡され、回復が実行される
+
+#### Scenario: ally ターゲティングで射程外 — 自己回復
+- **WHEN** `aura-heal`（range: 400）を装備し、味方ヒーローから 500px 離れた位置をクリックする
+- **THEN** 発動者自身が `targetHero` としてセットされ、自己回復が実行される
 
 ### Requirement: クールダウン管理
 `HeroSchema` はスロット別のクールダウン残り時間（`cooldownQ`, `cooldownE`, `cooldownR`、各 `float32`）を持たなければならない（SHALL）。初期値は 0 でなければならない（SHALL）。サーバーは毎 tick、0 より大きいクールダウンを deltaSeconds 分減算しなければならない（SHALL）。0 以下になった場合は 0 にクランプしなければならない（SHALL）。クールダウンフィールドは Colyseus `@type` で全クライアントに同期されなければならない（SHALL）。
@@ -74,3 +84,21 @@ GameHud のスキルスロット表示にクールダウン残り時間を表示
 #### Scenario: クールダウン完了のスロット表示
 - **WHEN** Q スロットのクールダウンが 0 になる
 - **THEN** Q スロットが通常表示に戻り、秒数表示が消える
+
+### Requirement: SkillExecutionContext に heroes と targetHero を追加
+`SkillExecutionContext` に `heroes: MapSchema<HeroSchema>` と `targetHero?: HeroSchema` フィールドを追加しなければならない（SHALL）。`heroes` はルーム内の全ヒーロー参照で、味方ターゲット検索に使用されなければならない（SHALL）。`targetHero` は ally ターゲティングで解決された対象ヒーローでなければならない（SHALL）。
+
+#### Scenario: heroes が渡される
+- **WHEN** `executeSkill` が呼ばれる
+- **THEN** `SkillExecutionContext.heroes` にルーム内の全ヒーローの MapSchema が含まれる
+
+#### Scenario: ally ターゲティング時に targetHero が設定される
+- **WHEN** ally ターゲティングのスキルで味方が射程内にいる
+- **THEN** `SkillExecutionContext.targetHero` にその味方ヒーローが設定される
+
+### Requirement: GameRoom から executeSkill に heroes を渡す
+`GameRoom` の `useSkill` メッセージハンドラで `executeSkill` に `this.state.heroes` を渡さなければならない（SHALL）。
+
+#### Scenario: GameRoom が heroes を渡す
+- **WHEN** クライアントが `useSkill` メッセージを送信する
+- **THEN** `executeSkill` に `this.state.heroes` と `this.state.projectiles` の両方が渡される

--- a/server/src/__tests__/CombatEntitySchema.test.ts
+++ b/server/src/__tests__/CombatEntitySchema.test.ts
@@ -34,4 +34,16 @@ describe('CombatEntitySchema.applyHeal', () => {
     e.applyHeal(100)
     expect(e.hp).toBe(500)
   })
+
+  it('should do nothing when amount is zero', () => {
+    const e = createEntity(200, 500)
+    e.applyHeal(0)
+    expect(e.hp).toBe(200)
+  })
+
+  it('should do nothing when amount is negative', () => {
+    const e = createEntity(200, 500)
+    e.applyHeal(-50)
+    expect(e.hp).toBe(200)
+  })
 })

--- a/server/src/__tests__/CombatEntitySchema.test.ts
+++ b/server/src/__tests__/CombatEntitySchema.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { HeroSchema } from '../schema/HeroSchema.js'
+
+function createEntity(hp: number, maxHp: number, dead = false): HeroSchema {
+  const e = new HeroSchema()
+  e.hp = hp
+  e.maxHp = maxHp
+  e.dead = dead
+  return e
+}
+
+describe('CombatEntitySchema.applyHeal', () => {
+  it('should increase HP by healAmount', () => {
+    const e = createEntity(200, 500)
+    e.applyHeal(100)
+    expect(e.hp).toBe(300)
+  })
+
+  it('should clamp HP to maxHp', () => {
+    const e = createEntity(480, 500)
+    e.applyHeal(100)
+    expect(e.hp).toBe(500)
+  })
+
+  it('should do nothing when entity is dead', () => {
+    const e = createEntity(0, 500, true)
+    e.applyHeal(100)
+    expect(e.hp).toBe(0)
+    expect(e.dead).toBe(true)
+  })
+
+  it('should not change HP when already at maxHp', () => {
+    const e = createEntity(500, 500)
+    e.applyHeal(100)
+    expect(e.hp).toBe(500)
+  })
+})

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -211,6 +211,136 @@ describe('executeSkill — bolt-pierce-shot', () => {
   })
 })
 
+describe('executeSkill — aura-heal', () => {
+  function createAuraHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+    return createHero({
+      heroType: 'AURA',
+      team: 'blue',
+      hp: 300,
+      maxHp: 500,
+      skillSlotQ: 'aura-heal',
+      ...overrides,
+    })
+  }
+
+  it('should return valid SkillEvent for aura-heal definition', () => {
+    const def = getSkillDefinition('aura-heal')
+    expect(def).toBeDefined()
+    expect(def!.targeting).toBe('ally')
+    expect(def!.cooldown).toBe(10)
+    expect(def!.effect.effectType).toBe('heal')
+    if (def!.effect.effectType === 'heal') {
+      expect(def!.effect.healAmount).toBe(120)
+      expect(def!.effect.range).toBe(400)
+    }
+  })
+
+  it('should heal the nearest ally within range', () => {
+    const caster = createAuraHero({ x: 100, y: 100, hp: 500, maxHp: 500 })
+    const ally = createAuraHero({ x: 300, y: 100, hp: 200, maxHp: 500 })
+    ally.team = 'blue'
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    // Click near ally position (within range 400)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 300, y: 100 }, undefined, heroes)
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('aura-heal')
+    expect(ally.hp).toBe(320) // 200 + 120
+  })
+
+  it('should fall back to self-heal when no ally in range', () => {
+    const caster = createAuraHero({ x: 100, y: 100 })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    // No ally in heroes map
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 800, y: 800 }, undefined, heroes)
+    expect(event).not.toBeNull()
+    expect(caster.hp).toBe(420) // 300 + 120
+  })
+
+  it('should heal ally near click even when ally is far from caster', () => {
+    const caster = createAuraHero({ x: 100, y: 100 })
+    const ally = createAuraHero({ x: 600, y: 100, hp: 200, maxHp: 500 })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    // Click at ally position — distance from click to ally is 0, within range
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 600, y: 100 }, undefined, heroes)
+    expect(event).not.toBeNull()
+    expect(ally.hp).toBe(320)
+  })
+
+  it('should fall back to self-heal when ally is far from click', () => {
+    const caster = createAuraHero({ x: 100, y: 100 })
+    const ally = createAuraHero({ x: 100, y: 200, hp: 200, maxHp: 500 })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    // Click at (900, 900), ally at (100, 200) — distance ~922px > range 400
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 900, y: 900 }, undefined, heroes)
+    expect(event).not.toBeNull()
+    expect(ally.hp).toBe(200) // NOT healed
+    expect(caster.hp).toBe(420) // self-heal fallback
+  })
+
+  it('should clamp heal to maxHp', () => {
+    const caster = createAuraHero({ x: 100, y: 100, hp: 450, maxHp: 500 })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
+    expect(caster.hp).toBe(500) // clamped to maxHp
+  })
+
+  it('should not heal dead allies', () => {
+    const caster = createAuraHero({ x: 100, y: 100, hp: 500, maxHp: 500 })
+    const ally = createAuraHero({ x: 200, y: 100, hp: 0, maxHp: 500, dead: true })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    // Click near dead ally — dead allies are excluded from target resolution
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    expect(event).not.toBeNull()
+    expect(ally.hp).toBe(0) // not healed
+    expect(caster.hp).toBe(500) // self-heal fallback, but already full
+  })
+
+  it('should not target enemies as ally', () => {
+    const caster = createAuraHero({ x: 100, y: 100 })
+    const enemy = createAuraHero({ x: 200, y: 100, hp: 200, maxHp: 500 })
+    enemy.team = 'red'
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    expect(enemy.hp).toBe(200) // not healed
+    expect(caster.hp).toBe(420) // self-heal fallback
+  })
+
+  it('should set cooldown to 10 seconds after heal', () => {
+    const caster = createAuraHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
+    expect(caster.cooldownQ).toBe(10)
+  })
+})
+
 describe('tickCooldowns', () => {
   it('should decrement cooldowns by dt', () => {
     const hero = createHero()

--- a/server/src/game/ServerSkillExecutionSystem.ts
+++ b/server/src/game/ServerSkillExecutionSystem.ts
@@ -2,7 +2,7 @@ import { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import type { SkillEvent } from '@shared/messages'
-import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { getSkillDefinition, type SkillDefinition } from '@shared/skills/skillDefinitions'
 import { getEffectHandler } from './skills/skillEffectRegistry.js'
 import { createServerLogger } from '@shared/logging'
 
@@ -45,6 +45,48 @@ function normalizeDirection(
 }
 
 /**
+ * Resolve the target hero for ally-targeting skills.
+ * Finds the nearest same-team alive hero within range of the click position.
+ * Falls back to the caster if no ally is in range.
+ */
+function resolveAllyTarget(
+  hero: HeroSchema,
+  casterId: string,
+  target: { x: number; y: number },
+  heroes: MapSchema<HeroSchema>,
+  range: number,
+): HeroSchema {
+  let bestHero: HeroSchema | null = null
+  let bestDistSq = Infinity
+
+  heroes.forEach((candidate, sid) => {
+    if (sid === casterId) return
+    if (candidate.team !== hero.team) return
+    if (candidate.dead) return
+
+    const dx = candidate.x - target.x
+    const dy = candidate.y - target.y
+    const distSq = dx * dx + dy * dy
+    if (distSq < bestDistSq) {
+      bestDistSq = distSq
+      bestHero = candidate
+    }
+  })
+
+  if (bestHero && bestDistSq <= range * range) {
+    return bestHero
+  }
+  return hero
+}
+
+/** Extract range from skill definition for ally targeting. */
+function getAllyRange(def: SkillDefinition): number {
+  if (def.effect.effectType === 'heal') return def.effect.range
+  logger.warn('getAllyRange: no range for ally-targeting effect', { effectType: def.effect.effectType })
+  return 0
+}
+
+/**
  * Execute a skill from a hero's slot.
  * Returns a SkillEvent on success, or null if validation fails.
  */
@@ -54,6 +96,7 @@ export function executeSkill(
   slot: SkillSlot,
   target: { x: number; y: number },
   projectiles?: MapSchema<ProjectileSchema>,
+  heroes?: MapSchema<HeroSchema>,
 ): SkillEvent | null {
   // Validation: hero must be alive
   if (hero.dead) return null
@@ -75,6 +118,12 @@ export function executeSkill(
   // Calculate direction from hero to target
   const direction = normalizeDirection(hero.x, hero.y, target.x, target.y)
 
+  // Resolve ally target if targeting type is 'ally'
+  let targetHero: HeroSchema | undefined
+  if (def.targeting === 'ally' && heroes) {
+    targetHero = resolveAllyTarget(hero, sessionId, target, heroes, getAllyRange(def))
+  }
+
   // Dispatch to registered effect handler by effectType
   const handler = getEffectHandler(def.effect.effectType)
   if (!handler) {
@@ -89,6 +138,8 @@ export function executeSkill(
       direction,
       targetPosition: target,
       projectiles: projectiles ?? new MapSchema(),
+      heroes: heroes ?? new MapSchema(),
+      targetHero,
     },
     def.effect,
   )

--- a/server/src/game/skills/SkillEffectHandler.ts
+++ b/server/src/game/skills/SkillEffectHandler.ts
@@ -10,6 +10,9 @@ export interface SkillExecutionContext {
   readonly direction: { readonly x: number; readonly y: number }
   readonly targetPosition: { readonly x: number; readonly y: number }
   readonly projectiles: MapSchema<ProjectileSchema>
+  readonly heroes: MapSchema<HeroSchema>
+  /** Resolved target for ally-targeting skills (falls back to caster if no ally in range). */
+  readonly targetHero?: HeroSchema
 }
 
 /** Every effect type implements this interface. */

--- a/server/src/game/skills/handlers/healEffectHandler.ts
+++ b/server/src/game/skills/handlers/healEffectHandler.ts
@@ -1,0 +1,11 @@
+import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
+import type { HealEffectParams } from '@shared/skills/skillDefinitions'
+
+export const healEffectHandler: SkillEffectHandler<HealEffectParams> = {
+  effectType: 'heal',
+
+  execute(ctx: SkillExecutionContext, params: HealEffectParams): void {
+    const target = ctx.targetHero ?? ctx.hero
+    target.applyHeal(params.healAmount)
+  },
+}

--- a/server/src/game/skills/handlers/index.ts
+++ b/server/src/game/skills/handlers/index.ts
@@ -1,6 +1,7 @@
 import { registerEffectHandler, clearEffectRegistry } from '../skillEffectRegistry.js'
 import { dashEffectHandler } from './dashEffectHandler.js'
 import { projectileEffectHandler } from './projectileEffectHandler.js'
+import { healEffectHandler } from './healEffectHandler.js'
 
 let registered = false
 
@@ -10,6 +11,7 @@ export function registerAllEffectHandlers(): void {
   registered = true
   registerEffectHandler(dashEffectHandler)
   registerEffectHandler(projectileEffectHandler)
+  registerEffectHandler(healEffectHandler)
 }
 
 /** Reset registration state and clear registry. For testing only. */

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -177,7 +177,7 @@ export class GameRoom extends Room<GameRoomState> {
       if (!isValidUseSkillMessage(message)) return
       const hero = this.state.heroes.get(client.sessionId)
       if (!hero) return
-      const event = executeSkill(hero, client.sessionId, message.slot, message.target, this.state.projectiles)
+      const event = executeSkill(hero, client.sessionId, message.slot, message.target, this.state.projectiles, this.state.heroes)
       if (event) {
         this.broadcast('skill', event)
       }

--- a/server/src/schema/CombatEntitySchema.ts
+++ b/server/src/schema/CombatEntitySchema.ts
@@ -26,4 +26,11 @@ export abstract class CombatEntitySchema extends Schema {
       this.dead = true
     }
   }
+
+  /** Restore HP, clamped to maxHp. Does nothing if dead or amount <= 0. */
+  applyHeal(amount: number): void {
+    if (this.dead) return
+    if (amount <= 0) return
+    this.hp = Math.min(this.maxHp, this.hp + amount)
+  }
 }

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -18,11 +18,17 @@ export interface ProjectileEffectParams {
   readonly visualType: string       // key into PROJECTILE_VISUALS (e.g. 'circle', 'diamond')
 }
 
+export interface HealEffectParams {
+  readonly effectType: 'heal'
+  readonly healAmount: number    // HP restored
+  readonly range: number         // ally selection range (px)
+}
+
 // Future effect types:
 // export interface AoeEffectParams { effectType: 'aoe'; ... }
 // export interface BuffEffectParams { effectType: 'buff'; ... }
 
-export type SkillEffectParams = DashEffectParams | ProjectileEffectParams
+export type SkillEffectParams = DashEffectParams | ProjectileEffectParams | HealEffectParams
 
 // ── Common fields shared by ALL skills ────────────────────────
 
@@ -73,6 +79,16 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       pierceCount: 3,
       homing: false,
       visualType: 'diamond',
+    },
+  },
+  'aura-heal': {
+    id: 'aura-heal',
+    targeting: 'ally',
+    cooldown: 10,
+    effect: {
+      effectType: 'heal',
+      healAmount: 120,
+      range: 400,
     },
   },
 }


### PR DESCRIPTION
## Summary

- AURA の Q スキル「Heal」を実装。味方または自分の HP を回復する
- 新しい `heal` effectType と `ally` ターゲティングシステムを追加
- `CombatEntitySchema.applyHeal()` で回復ロジックを共通化
- `executeSkill` に ally ターゲット解決（最寄り同チーム生存ヒーロー、射程チェック、自己フォールバック）

## Changes

### Shared
- `HealEffectParams` インターフェース追加、`SkillEffectParams` 共用体拡張
- `aura-heal` スキル定義（heal 120, range 400, CD 10s, ally targeting）

### Server
- `CombatEntitySchema.applyHeal(amount)` — maxHp クランプ、dead/負値ガード
- `healEffectHandler` — targetHero を回復、未設定時は自己回復
- `resolveAllyTarget` — クリック座標から最寄り同チーム生存ヒーローを検索
- `SkillExecutionContext` に `heroes` と `targetHero` 追加
- `GameRoom` から `executeSkill` に `this.state.heroes` を渡す

### Specs
- `openspec/specs/aura-heal/` 新規作成（4 requirements）
- `openspec/specs/skill-execution/` 更新（ally ターゲティング追加）

## Test plan

- [x] `CombatEntitySchema.applyHeal` テスト（通常回復、maxHp クランプ、死亡エンティティ、満HP）
- [x] `healEffectHandler` テスト（味方回復、自己フォールバック、maxHp クランプ）
- [x] `executeSkill` ally ターゲティングテスト（射程内味方、射程外自己フォールバック、dead ally 除外、敵除外）
- [x] 全 762 テスト PASS、lint PASS

Closes #211