### PR TITLE
feat: add AURA Weaken skill with enemy targeting system

### DIFF
--- a/openspec/changes/archive/2026-03-10-aura-weaken/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-10-aura-weaken/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/archive/2026-03-10-aura-weaken/design.md
+++ b/openspec/changes/archive/2026-03-10-aura-weaken/design.md
@@ -1,0 +1,75 @@
+## Overview
+
+Weaken は AURA の初デバフスキル。敵ヒーローの攻撃力を一定時間低下させる。既存の StatusEffect システム（`isDebuff: true`）を再利用し、新たに `enemy` ターゲティングを追加する。
+
+## Design Decisions
+
+### ターゲット解決の統合（resolveHeroTarget）
+
+`resolveAllyTarget` と `resolveEnemyTarget` はチームフィルタの向きだけが異なる。重複を避けるため、共通の `resolveHeroTarget` を作りフィルタを引数で渡す。
+
+```typescript
+function resolveHeroTarget(
+  hero: HeroSchema, casterId: string,
+  target: { x: number; y: number },
+  heroes: MapSchema<HeroSchema>, range: number,
+  filter: (candidate: HeroSchema, candidateId: string) => boolean,
+): HeroSchema | null {
+  // filter を満たす最寄りヒーローを range 内で検索
+  // 該当なし → null
+}
+```
+
+- **ally**: `filter = (c, sid) => sid !== casterId && c.team === hero.team && !c.dead`、フォールバック = 自分
+- **enemy**: `filter = (c) => c.team !== hero.team && !c.dead`、フォールバック = null（不発）
+
+`executeSkill` 内で `targeting === 'enemy'` かつ `targetHero === null` なら `null` を返す（CD 未消費）。
+
+### `SkillTargeting` 拡張
+
+```typescript
+export type SkillTargeting = 'direction' | 'point' | 'self' | 'ally' | 'enemy'
+```
+
+`SkillDefinition.range` は `ally` と `enemy` の両方で使用する。
+
+### 実効ステータス計算の汎用化（getEffectiveStat）
+
+`StatusEffectSystem.ts` に汎用ヘルパーを追加し、各システムのステータス計算を統一する:
+
+```typescript
+export function getEffectiveStat(base: number, hero: HeroSchema, buffType: string): number {
+  return Math.max(0, base + getStatusEffectValue(hero, buffType))
+}
+```
+
+- `ServerMovementSystem` の speed 計算: `getEffectiveStat(hero.speed, hero, 'speed')` に置換
+- `ServerCombatManager` の attackDamage 計算: `getEffectiveStat(hero.attackDamage, hero, 'attackDamage')` に置換
+- 今後 `attackSpeed` や `defense` 等のデバフ/バフ追加時も同じパターンで一行で済む
+- `Math.max(0, ...)` のクランプ忘れを防止
+
+### buffEffectHandler の再利用
+
+既存の `buffEffectHandler` はそのまま動作する。`ctx.targetHero` に敵ヒーローが渡され、`statusEffects` にデバフが追加される。`isDebuff: true` フラグは将来の dispel 用。
+
+### スキルパラメータ
+
+| パラメータ | 値 | 備考 |
+|-----------|-----|------|
+| cooldown | 14 | 長めのCD |
+| range | 500 | 射程（攻撃よりやや長い） |
+| buffType | `'attackDamage'` | 攻撃力に影響 |
+| value | -15 | 攻撃力を15低下（固定値） |
+| duration | 4 | 4秒間 |
+| isDebuff | true | デバフフラグ |
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `shared/skills/skillDefinitions.ts` | `SkillTargeting` に `'enemy'` 追加、`aura-weaken` 定義 |
+| `server/src/game/ServerSkillExecutionSystem.ts` | `resolveHeroTarget` 統合、`resolveAllyTarget`/`resolveEnemyTarget` をフィルタ切替に、enemy 分岐追加 |
+| `server/src/game/StatusEffectSystem.ts` | `getEffectiveStat` 汎用ヘルパー追加 |
+| `server/src/game/ServerCombatManager.ts` | attackDamage 3箇所を `getEffectiveStat` に置換 |
+| `server/src/game/ServerMovementSystem.ts` | speed 計算を `getEffectiveStat` に置換 |
+| テスト | 敵ターゲティング、デバフ適用、攻撃力低下反映、getEffectiveStat |

--- a/openspec/changes/archive/2026-03-10-aura-weaken/proposal.md
+++ b/openspec/changes/archive/2026-03-10-aura-weaken/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+AURA の Weaken スキル（#214）を実装する。初のデバフスキルであり、敵ヒーローの攻撃力を一定時間低下させる。これにより `enemy` ターゲティングの基盤が整い、今後の敵対象スキル（Slow Field, Nova 等）の土台となる。StatusEffect システム（aura-haste で構築済み）の `isDebuff: true` パスを実戦投入する最初のケース。
+
+## What Changes
+
+- `SkillTargeting` に `'enemy'` を追加
+- `resolveEnemyTarget` を実装（クリック座標から最寄りの敵チーム生存ヒーローを range 内で検索）
+- `executeSkill` 内で `enemy` ターゲティング時に `resolveEnemyTarget` を呼び、結果を `targetHero` に渡す
+- `SKILL_DEFINITIONS` に `aura-weaken` エントリを追加（`effectType: 'buff'`, `isDebuff: true`, `buffType: 'attackDamage'`）
+- `ServerCombatManager` でヒーローの攻撃ダメージ計算時に `getStatusEffectValue(hero, 'attackDamage')` を加算
+- `buffEffectHandler` はそのまま再利用（既存ハンドラで敵デバフも処理可能）
+
+## Capabilities
+
+### New Capabilities
+- `aura-weaken`: Weaken スキル定義、敵ターゲティング、攻撃力デバフ反映
+
+### Modified Capabilities
+- `skill-execution`: `SkillTargeting` に `'enemy'` 追加、`resolveEnemyTarget` 実装、`executeSkill` での敵ターゲット解決
+
+## Impact
+
+- `shared/skills/skillDefinitions.ts` — `SkillTargeting` 型拡張、`aura-weaken` 定義
+- `server/src/game/ServerSkillExecutionSystem.ts` — `resolveEnemyTarget`、`executeSkill` 分岐追加
+- `server/src/game/ServerCombatManager.ts` — 攻撃ダメージに StatusEffect 反映
+- テスト: 敵ターゲティング、デバフ適用、攻撃力低下の各テスト追加

--- a/openspec/changes/archive/2026-03-10-aura-weaken/specs/aura-weaken/spec.md
+++ b/openspec/changes/archive/2026-03-10-aura-weaken/specs/aura-weaken/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: aura-weaken スキル定義
+`SKILL_DEFINITIONS` に `aura-weaken` エントリを追加しなければならない（SHALL）。`targeting: 'enemy'`、`cooldown: 14`、`range: 500`、`effect` は `BuffEffectParams` で `buffType: 'attackDamage'`、`value: -15`、`duration: 4`、`isDebuff: true` でなければならない（SHALL）。
+
+#### Scenario: aura-weaken スキル定義の参照
+- **WHEN** `getSkillDefinition('aura-weaken')` を呼び出す
+- **THEN** `targeting: 'enemy'`、`cooldown: 14`、`range: 500`、`effect.effectType: 'buff'`、`effect.buffType: 'attackDamage'`、`effect.value: -15`、`effect.duration: 4`、`effect.isDebuff: true` のスキル定義が返される
+
+### Requirement: 攻撃力デバフの反映
+`ServerCombatManager` でヒーローの攻撃ダメージを計算する際、`hero.attackDamage + getStatusEffectValue(hero, 'attackDamage')` を実効攻撃力として使用しなければならない（SHALL）。実効攻撃力は 0 以下にクランプしなければならない（SHALL）。
+
+#### Scenario: デバフ中の攻撃力低下
+- **WHEN** `hero.attackDamage` が 50、`attackDamage` デバフの合算値が -15 の状態でメレー攻撃する
+- **THEN** 実効攻撃力が 35 でダメージ計算される
+
+#### Scenario: デバフなしの攻撃力
+- **WHEN** `attackDamage` のステータスエフェクトがない状態で攻撃する
+- **THEN** `hero.attackDamage` がそのまま使用される
+
+#### Scenario: デバフが攻撃力を超過する場合
+- **WHEN** `hero.attackDamage` が 50、デバフ合算値が -60 の状態で攻撃する
+- **THEN** 実効攻撃力は 0 にクランプされ、ダメージは 0 になる
+
+### Requirement: 敵ターゲットへのデバフ適用
+`executeSkill` で `targeting: 'enemy'` のスキルを発動した場合、`resolveEnemyTarget` で解決された敵ヒーローの `statusEffects` にデバフが適用されなければならない（SHALL）。射程内に敵がいない場合はスキルが不発（null を返す）でなければならない（SHALL）。
+
+#### Scenario: 敵にデバフを適用
+- **WHEN** `aura-weaken` を装備し、敵ヒーローから range 以内の位置をクリックする
+- **THEN** 敵ヒーローの `statusEffects` に `'aura-weaken'` エントリが追加される
+
+#### Scenario: 射程外で不発
+- **WHEN** `aura-weaken` を装備し、敵ヒーローから range 外の位置をクリックする
+- **THEN** スキルが不発（null）となり、クールダウンは消費されない

--- a/openspec/changes/archive/2026-03-10-aura-weaken/specs/skill-execution/spec.md
+++ b/openspec/changes/archive/2026-03-10-aura-weaken/specs/skill-execution/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: スキルメタデータ定義
+各スキルの共通パラメータ（`cooldown`, `range`, `targeting`）を共有定数テーブルとして定義しなければならない（SHALL）。`targeting` は `'direction' | 'point' | 'self' | 'ally' | 'enemy'` のいずれかでなければならない（SHALL）。スキル定義はサーバーとクライアントの両方から参照可能な `shared/` 配下に配置しなければならない（SHALL）。`ally` および `enemy` ターゲティングのスキルは `range` フィールド（ターゲット選択射程 px）を持たなければならない（SHALL）。
+
+#### Scenario: enemy ターゲティングスキルの range 参照
+- **WHEN** `aura-weaken` のメタデータを取得する
+- **THEN** `range: 500` がスキル定義レベルで取得できる
+
+## ADDED Requirements
+
+### Requirement: resolveEnemyTarget
+`executeSkill` 内で `targeting: 'enemy'` のスキルの場合、クリック座標から最寄りの **敵チーム** 生存ヒーローを `range` 以内で検索しなければならない（SHALL）。射程内に敵がいない場合は `null` を返さなければならない（SHALL）。`resolveEnemyTarget` で解決された敵ヒーローは `SkillExecutionContext.targetHero` として渡されなければならない（SHALL）。`targetHero` が `null`（射程外）の場合、`executeSkill` は `null` を返し、クールダウンは消費されない（SHALL NOT）。
+
+#### Scenario: 敵が射程内にいる
+- **WHEN** enemy ターゲティングで敵ヒーローがクリック位置から range 以内にいる
+- **THEN** その敵ヒーローが `targetHero` としてエフェクトハンドラに渡される
+
+#### Scenario: 敵が射程外
+- **WHEN** enemy ターゲティングで敵ヒーローがクリック位置から range 外にいる
+- **THEN** `executeSkill` は `null` を返し、クールダウンは消費されない
+
+#### Scenario: 味方を敵として選択しない
+- **WHEN** enemy ターゲティングで味方ヒーローのみがクリック位置付近にいる
+- **THEN** `resolveEnemyTarget` は `null` を返し、スキルが不発になる

--- a/openspec/changes/archive/2026-03-10-aura-weaken/tasks.md
+++ b/openspec/changes/archive/2026-03-10-aura-weaken/tasks.md
@@ -1,0 +1,27 @@
+## Tasks
+
+### 1. Shared 定義
+
+- [x] 1.1 `SkillTargeting` に `'enemy'` を追加する
+- [x] 1.2 `SKILL_DEFINITIONS` に `aura-weaken` エントリを追加する
+
+### 2. ターゲット解決の統合
+
+- [x] 2.1 `resolveHeroTarget` を実装する（フィルタ引数で ally/enemy を切り替え）
+- [x] 2.2 既存の `resolveAllyTarget` を `resolveHeroTarget` + ally フィルタに置換する
+- [x] 2.3 `executeSkill` に `enemy` ターゲティング分岐を追加する（`targetHero` が null なら不発）
+
+### 3. 実効ステータス計算の汎用化
+
+- [x] 3.1 `StatusEffectSystem.ts` に `getEffectiveStat(base, hero, buffType)` を追加する
+- [x] 3.2 `ServerMovementSystem` の speed 計算を `getEffectiveStat` に置換する
+- [x] 3.3 `ServerCombatManager` の `hero.attackDamage` 3箇所を `getEffectiveStat` に置換する
+
+### 4. テスト
+
+- [x] 4.1 `aura-weaken` スキル定義のユニットテスト
+- [x] 4.2 `resolveHeroTarget` のユニットテスト（敵選択、味方選択、射程外、味方除外、死亡除外）
+- [x] 4.3 `executeSkill` aura-weaken のユニットテスト（敵デバフ適用、射程外不発でCD未消費、CD設定）
+- [x] 4.4 `getEffectiveStat` のユニットテスト（デバフ反映、バフ反映、エフェクトなし、0 クランプ）
+- [x] 4.5 攻撃力デバフ反映のユニットテスト（メレー攻撃時のダメージ低下）
+- [x] 4.6 全テスト・lint パス確認（`npm run test:unit && npm run lint`）

--- a/openspec/specs/aura-weaken/spec.md
+++ b/openspec/specs/aura-weaken/spec.md
@@ -1,0 +1,40 @@
+# Specification
+
+## Purpose
+
+AURA Weaken スキル — 敵ヒーローに攻撃力デバフを付与するオーラスキル。
+
+## Requirements
+
+### Requirement: aura-weaken スキル定義
+`SKILL_DEFINITIONS` に `aura-weaken` エントリを追加しなければならない（SHALL）。`targeting: 'enemy'`、`cooldown: 14`、`range: 500`、`effect` は `BuffEffectParams` で `buffType: 'attackDamage'`、`value: -15`、`duration: 4`、`isDebuff: true` でなければならない（SHALL）。
+
+#### Scenario: aura-weaken スキル定義の参照
+- **WHEN** `getSkillDefinition('aura-weaken')` を呼び出す
+- **THEN** `targeting: 'enemy'`、`cooldown: 14`、`range: 500`、`effect.effectType: 'buff'`、`effect.buffType: 'attackDamage'`、`effect.value: -15`、`effect.duration: 4`、`effect.isDebuff: true` のスキル定義が返される
+
+### Requirement: 攻撃力デバフの反映
+`ServerCombatManager` でヒーローの攻撃ダメージを計算する際、`hero.attackDamage + getStatusEffectValue(hero, 'attackDamage')` を実効攻撃力として使用しなければならない（SHALL）。実効攻撃力は 0 以下にクランプしなければならない（SHALL）。
+
+#### Scenario: デバフ中の攻撃力低下
+- **WHEN** `hero.attackDamage` が 50、`attackDamage` デバフの合算値が -15 の状態でメレー攻撃する
+- **THEN** 実効攻撃力が 35 でダメージ計算される
+
+#### Scenario: デバフなしの攻撃力
+- **WHEN** `attackDamage` のステータスエフェクトがない状態で攻撃する
+- **THEN** `hero.attackDamage` がそのまま使用される
+
+#### Scenario: デバフが攻撃力を超過する場合
+- **WHEN** `hero.attackDamage` が 50、デバフ合算値が -60 の状態で攻撃する
+- **THEN** 実効攻撃力は 0 にクランプされ、ダメージは 0 になる
+
+### Requirement: 敵ターゲットへのデバフ適用
+`executeSkill` で `targeting: 'enemy'` のスキルを発動した場合、`resolveEnemyTarget` で解決された敵ヒーローの `statusEffects` にデバフが適用されなければならない（SHALL）。射程内に敵がいない場合はスキルが不発（null を返す）でなければならない（SHALL）。
+
+#### Scenario: 敵にデバフを適用
+- **WHEN** `aura-weaken` を装備し、敵ヒーローから range 以内の位置をクリックする
+- **THEN** 敵ヒーローの `statusEffects` に `'aura-weaken'` エントリが追加される
+
+#### Scenario: 射程外で不発
+- **WHEN** `aura-weaken` を装備し、敵ヒーローから range 外の位置をクリックする
+- **THEN** スキルが不発（null）となり、クールダウンは消費されない

--- a/openspec/specs/skill-execution/spec.md
+++ b/openspec/specs/skill-execution/spec.md
@@ -7,7 +7,7 @@
 ## Requirements
 
 ### Requirement: スキルメタデータ定義
-各スキルの共通パラメータ（`cooldown`, `range`, `targeting`）を共有定数テーブルとして定義しなければならない（SHALL）。`targeting` は `'direction' | 'point' | 'self' | 'ally'` のいずれかでなければならない（SHALL）。スキル定義はサーバーとクライアントの両方から参照可能な `shared/` 配下に配置しなければならない（SHALL）。`ally` ターゲティングのスキルは `range` フィールド（味方選択射程 px）を持たなければならない（SHALL）。
+各スキルの共通パラメータ（`cooldown`, `range`, `targeting`）を共有定数テーブルとして定義しなければならない（SHALL）。`targeting` は `'direction' | 'point' | 'self' | 'ally' | 'enemy'` のいずれかでなければならない（SHALL）。スキル定義はサーバーとクライアントの両方から参照可能な `shared/` 配下に配置しなければならない（SHALL）。`ally` および `enemy` ターゲティングのスキルは `range` フィールド（ターゲット選択射程 px）を持たなければならない（SHALL）。
 
 #### Scenario: スキル定義の参照
 - **WHEN** サーバーまたはクライアントがスキルID `blade-charge` のメタデータを取得する
@@ -16,6 +16,10 @@
 #### Scenario: ally ターゲティングスキルの range 参照
 - **WHEN** `aura-heal` のメタデータを取得する
 - **THEN** `range: 400` がスキル定義レベルで取得できる
+
+#### Scenario: enemy ターゲティングスキルの range 参照
+- **WHEN** `aura-weaken` のメタデータを取得する
+- **THEN** `range: 500` がスキル定義レベルで取得できる
 
 ### Requirement: useSkill メッセージ
 クライアントは `useSkill` メッセージ（`slot: 'Q' | 'E' | 'R'`, `target: { x: number, y: number }`）をサーバーに送信しなければならない（SHALL）。サーバーは受信時に以下を検証しなければならない（SHALL）：該当スロットにスキルが装備されていること、スロットのクールダウンが 0 であること、ヒーローが生存中であること。検証失敗時はメッセージを無視しなければならない（SHALL）。
@@ -90,7 +94,7 @@ GameHud のスキルスロット表示にクールダウン残り時間を表示
 - **THEN** Q スロットが通常表示に戻り、秒数表示が消える
 
 ### Requirement: SkillExecutionContext に heroes と targetHero を追加
-`SkillExecutionContext` に `heroes: MapSchema<HeroSchema>` と `targetHero?: HeroSchema` フィールドを追加しなければならない（SHALL）。`heroes` はルーム内の全ヒーロー参照で、味方ターゲット検索に使用されなければならない（SHALL）。`targetHero` は ally ターゲティングで解決された対象ヒーローでなければならない（SHALL）。
+`SkillExecutionContext` に `heroes: MapSchema<HeroSchema>` と `targetHero?: HeroSchema` フィールドを追加しなければならない（SHALL）。`heroes` はルーム内の全ヒーロー参照で、味方・敵ターゲット検索に使用されなければならない（SHALL）。`targetHero` は ally または enemy ターゲティングで解決された対象ヒーローでなければならない（SHALL）。
 
 #### Scenario: heroes が渡される
 - **WHEN** `executeSkill` が呼ばれる
@@ -117,3 +121,18 @@ GameHud のスキルスロット表示にクールダウン残り時間を表示
 #### Scenario: buff スキルの射程取得
 - **WHEN** ally ターゲティングで `aura-haste`（range: 400）のターゲット解決を行う
 - **THEN** `def.range` から 400 が取得される
+
+### Requirement: resolveEnemyTarget
+`executeSkill` 内で `targeting: 'enemy'` のスキルの場合、クリック座標から最寄りの **敵チーム** 生存ヒーローを `range` 以内で検索しなければならない（SHALL）。射程内に敵がいない場合は `null` を返さなければならない（SHALL）。`resolveEnemyTarget` で解決された敵ヒーローは `SkillExecutionContext.targetHero` として渡されなければならない（SHALL）。`targetHero` が `null`（射程外）の場合、`executeSkill` は `null` を返し、クールダウンは消費されない（SHALL NOT）。
+
+#### Scenario: 敵が射程内にいる
+- **WHEN** enemy ターゲティングで敵ヒーローがクリック位置から range 以内にいる
+- **THEN** その敵ヒーローが `targetHero` としてエフェクトハンドラに渡される
+
+#### Scenario: 敵が射程外
+- **WHEN** enemy ターゲティングで敵ヒーローがクリック位置から range 外にいる
+- **THEN** `executeSkill` は `null` を返し、クールダウンは消費されない
+
+#### Scenario: 味方を敵として選択しない
+- **WHEN** enemy ターゲティングで味方ヒーローのみがクリック位置付近にいる
+- **THEN** `resolveEnemyTarget` は `null` を返し、スキルが不発になる

--- a/server/src/__tests__/ServerCombatManager.test.ts
+++ b/server/src/__tests__/ServerCombatManager.test.ts
@@ -3,6 +3,7 @@ import { MapSchema } from '@colyseus/schema'
 import { HeroSchema } from '../schema/HeroSchema.js'
 import { TowerSchema } from '../schema/TowerSchema.js'
 import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { StatusEffectSchema } from '../schema/StatusEffectSchema.js'
 import { processHeroCombat, resetProjectileIdCounter } from '../game/ServerCombatManager.js'
 import type { InputMessage } from '@shared/messages'
 
@@ -309,6 +310,85 @@ describe('ServerCombatManager', () => {
         kind: 'attack',
         event: { attackerId: 'attacker', targetId: 'target', attackType: 'ranged', position: { x: 100, y: 100 }, facing: 0.5 },
       })
+    })
+
+    it('should use effective attackDamage with debuff applied (melee)', () => {
+      const attacker = createHero('attacker', {
+        x: 100, y: 100, team: 'blue', radius: 22,
+        attackRange: 60, attackDamage: 50, attackSpeed: 0.8, attackCooldown: 0,
+        heroType: 'BLADE',
+      })
+      // Apply attackDamage debuff
+      const debuff = new StatusEffectSchema()
+      debuff.id = 'aura-weaken'
+      debuff.buffType = 'attackDamage'
+      debuff.value = -15
+      debuff.remainingDuration = 4
+      debuff.isDebuff = true
+      attacker.statusEffects.set('aura-weaken', debuff)
+
+      const target = createHero('target', { x: 160, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('attacker', attacker)
+      heroes.set('target', target)
+
+      const input = createInput({ attackTargetId: 'target' })
+      const events = processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+
+      expect(target.hp).toBe(615) // 650 - (50 - 15) = 650 - 35
+      expect(events[1]).toEqual({
+        kind: 'damage',
+        event: { targetId: 'target', amount: 35, sourceId: 'attacker' },
+      })
+    })
+
+    it('should clamp effective attackDamage to 0 when debuff exceeds base', () => {
+      const attacker = createHero('attacker', {
+        x: 100, y: 100, team: 'blue', radius: 22,
+        attackRange: 60, attackDamage: 10, attackSpeed: 0.8, attackCooldown: 0,
+        heroType: 'BLADE',
+      })
+      const debuff = new StatusEffectSchema()
+      debuff.id = 'aura-weaken'
+      debuff.buffType = 'attackDamage'
+      debuff.value = -30
+      debuff.remainingDuration = 4
+      debuff.isDebuff = true
+      attacker.statusEffects.set('aura-weaken', debuff)
+
+      const target = createHero('target', { x: 160, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('attacker', attacker)
+      heroes.set('target', target)
+
+      const input = createInput({ attackTargetId: 'target' })
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+
+      expect(target.hp).toBe(650) // 0 damage
+    })
+
+    it('should use effective attackDamage for ranged projectile damage', () => {
+      const attacker = createHero('attacker', {
+        x: 100, y: 100, team: 'blue', radius: 18,
+        attackRange: 300, attackDamage: 45, attackSpeed: 1.0, attackCooldown: 0,
+        heroType: 'BOLT',
+      })
+      const debuff = new StatusEffectSchema()
+      debuff.id = 'aura-weaken'
+      debuff.buffType = 'attackDamage'
+      debuff.value = -10
+      debuff.remainingDuration = 4
+      debuff.isDebuff = true
+      attacker.statusEffects.set('aura-weaken', debuff)
+
+      const target = createHero('target', { x: 350, y: 100, team: 'red', radius: 22 })
+      heroes.set('attacker', attacker)
+      heroes.set('target', target)
+
+      const input = createInput({ attackTargetId: 'target' })
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+
+      expect(projectiles.size).toBe(1)
+      const proj = Array.from(projectiles.values())[0]!
+      expect(proj.damage).toBe(35) // 45 - 10
     })
 
     it('should return empty events when no attack fires', () => {

--- a/server/src/__tests__/StatusEffectSystem.test.ts
+++ b/server/src/__tests__/StatusEffectSystem.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { HeroSchema } from '../schema/HeroSchema.js'
 import { StatusEffectSchema } from '../schema/StatusEffectSchema.js'
-import { getStatusEffectValue, tickBuffs } from '../game/StatusEffectSystem.js'
+import { getStatusEffectValue, getEffectiveStat, tickBuffs } from '../game/StatusEffectSystem.js'
 
 function createHero(): HeroSchema {
   const hero = new HeroSchema()
@@ -70,6 +70,37 @@ describe('getStatusEffectValue', () => {
     const hero = createHero()
     addEffect(hero, 'aura-haste', 'speed', 80, 3)
     expect(getStatusEffectValue(hero, 'attackSpeed')).toBe(0)
+  })
+})
+
+describe('getEffectiveStat', () => {
+  it('should return base value when no effects exist', () => {
+    const hero = createHero()
+    expect(getEffectiveStat(200, hero, 'speed')).toBe(200)
+  })
+
+  it('should apply buff to base value', () => {
+    const hero = createHero()
+    addEffect(hero, 'aura-haste', 'speed', 80, 3)
+    expect(getEffectiveStat(200, hero, 'speed')).toBe(280)
+  })
+
+  it('should apply debuff to base value', () => {
+    const hero = createHero()
+    addEffect(hero, 'aura-weaken', 'attackDamage', -15, 4, true)
+    expect(getEffectiveStat(50, hero, 'attackDamage')).toBe(35)
+  })
+
+  it('should clamp to 0 when debuff exceeds base', () => {
+    const hero = createHero()
+    addEffect(hero, 'aura-weaken', 'attackDamage', -60, 4, true)
+    expect(getEffectiveStat(50, hero, 'attackDamage')).toBe(0)
+  })
+
+  it('should not return negative values', () => {
+    const hero = createHero()
+    addEffect(hero, 'massive-debuff', 'speed', -300, 2, true)
+    expect(getEffectiveStat(200, hero, 'speed')).toBe(0)
   })
 })
 

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { MapSchema } from '@colyseus/schema'
 import { HeroSchema } from '../schema/HeroSchema.js'
 import { ProjectileSchema } from '../schema/ProjectileSchema.js'
-import { executeSkill, tickCooldowns } from '../game/ServerSkillExecutionSystem.js'
+import { executeSkill, tickCooldowns, resolveHeroTarget } from '../game/ServerSkillExecutionSystem.js'
 import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
 import { getSkillDefinition } from '@shared/skills/skillDefinitions'
 
@@ -406,6 +406,192 @@ describe('executeSkill — aura-haste', () => {
 
     executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
     expect(caster.cooldownQ).toBe(12)
+  })
+})
+
+describe('getSkillDefinition — aura-weaken', () => {
+  it('should return aura-weaken definition with correct params', () => {
+    const def = getSkillDefinition('aura-weaken')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('aura-weaken')
+    expect(def!.targeting).toBe('enemy')
+    expect(def!.cooldown).toBe(14)
+    expect(def!.range).toBe(500)
+    expect(def!.effect.effectType).toBe('buff')
+    if (def!.effect.effectType === 'buff') {
+      expect(def!.effect.buffType).toBe('attackDamage')
+      expect(def!.effect.value).toBe(-15)
+      expect(def!.effect.duration).toBe(4)
+      expect(def!.effect.isDebuff).toBe(true)
+    }
+  })
+})
+
+describe('resolveHeroTarget', () => {
+  it('should find nearest enemy within range', () => {
+    const caster = createHero({ x: 100, y: 100, team: 'blue' })
+    const enemy = createHero({ x: 300, y: 100, team: 'red' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
+    const result = resolveHeroTarget(caster, 'caster-1', { x: 300, y: 100 }, heroes, 500, filter)
+    expect(result).toBe(enemy)
+  })
+
+  it('should find nearest ally (not self) within range', () => {
+    const caster = createHero({ x: 100, y: 100, team: 'blue' })
+    const ally = createHero({ x: 200, y: 100, team: 'blue' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const filter = (c: HeroSchema, sid: string) => sid !== 'caster-1' && c.team === caster.team && !c.dead
+    const result = resolveHeroTarget(caster, 'caster-1', { x: 200, y: 100 }, heroes, 400, filter)
+    expect(result).toBe(ally)
+  })
+
+  it('should return null when target is out of range', () => {
+    const caster = createHero({ x: 100, y: 100, team: 'blue' })
+    const enemy = createHero({ x: 800, y: 100, team: 'red' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    // Click near caster — distance from click (100,100) to enemy (800,100) = 700 > range 500
+    const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
+    const result = resolveHeroTarget(caster, 'caster-1', { x: 100, y: 100 }, heroes, 500, filter)
+    expect(result).toBeNull()
+  })
+
+  it('should not select allies when filtering for enemies', () => {
+    const caster = createHero({ x: 100, y: 100, team: 'blue' })
+    const ally = createHero({ x: 200, y: 100, team: 'blue' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
+    const result = resolveHeroTarget(caster, 'caster-1', { x: 200, y: 100 }, heroes, 500, filter)
+    expect(result).toBeNull()
+  })
+
+  it('should exclude dead heroes', () => {
+    const caster = createHero({ x: 100, y: 100, team: 'blue' })
+    const enemy = createHero({ x: 200, y: 100, team: 'red', dead: true })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
+    const result = resolveHeroTarget(caster, 'caster-1', { x: 200, y: 100 }, heroes, 500, filter)
+    expect(result).toBeNull()
+  })
+
+  it('should pick nearest when multiple candidates exist', () => {
+    const caster = createHero({ x: 100, y: 100, team: 'blue' })
+    const farEnemy = createHero({ x: 400, y: 100, team: 'red' })
+    const nearEnemy = createHero({ x: 250, y: 100, team: 'red' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('far-1', farEnemy)
+    heroes.set('near-1', nearEnemy)
+
+    const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
+    const result = resolveHeroTarget(caster, 'caster-1', { x: 300, y: 100 }, heroes, 500, filter)
+    expect(result).toBe(nearEnemy)
+  })
+})
+
+describe('executeSkill — aura-weaken', () => {
+  function createAuraWeakenHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+    return createHero({
+      heroType: 'AURA',
+      team: 'blue',
+      hp: 500,
+      maxHp: 500,
+      skillSlotQ: 'aura-weaken',
+      ...overrides,
+    })
+  }
+
+  it('should apply debuff to enemy within range', () => {
+    const caster = createAuraWeakenHero({ x: 100, y: 100 })
+    const enemy = createHero({ x: 300, y: 100, team: 'red' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 300, y: 100 }, undefined, heroes)
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('aura-weaken')
+
+    const effect = enemy.statusEffects.get('aura-weaken')
+    expect(effect).toBeDefined()
+    expect(effect!.buffType).toBe('attackDamage')
+    expect(effect!.value).toBe(-15)
+    expect(effect!.remainingDuration).toBe(4)
+    expect(effect!.isDebuff).toBe(true)
+  })
+
+  it('should fail and not consume CD when enemy is out of range', () => {
+    const caster = createAuraWeakenHero({ x: 100, y: 100 })
+    const enemy = createHero({ x: 800, y: 100, team: 'red' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    // Click near caster — distance from click (100,100) to enemy (800,100) = 700 > range 500
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
+    expect(event).toBeNull()
+    expect(caster.cooldownQ).toBe(0) // CD not consumed
+  })
+
+  it('should fail when only allies are nearby', () => {
+    const caster = createAuraWeakenHero({ x: 100, y: 100 })
+    const ally = createHero({ x: 200, y: 100, team: 'blue' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    expect(event).toBeNull()
+    expect(caster.cooldownQ).toBe(0)
+  })
+
+  it('should set cooldown to 14 seconds on success', () => {
+    const caster = createAuraWeakenHero({ x: 100, y: 100 })
+    const enemy = createHero({ x: 200, y: 100, team: 'red' })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    expect(caster.cooldownQ).toBe(14)
+  })
+
+  it('should not target dead enemies', () => {
+    const caster = createAuraWeakenHero({ x: 100, y: 100 })
+    const enemy = createHero({ x: 200, y: 100, team: 'red', dead: true })
+
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    expect(event).toBeNull()
+    expect(caster.cooldownQ).toBe(0)
   })
 })
 

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -437,7 +437,7 @@ describe('resolveHeroTarget', () => {
     heroes.set('enemy-1', enemy)
 
     const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
-    const result = resolveHeroTarget(caster, 'caster-1', { x: 300, y: 100 }, heroes, 500, filter)
+    const result = resolveHeroTarget({ x: 300, y: 100 }, heroes, 500, filter)
     expect(result).toBe(enemy)
   })
 
@@ -450,7 +450,7 @@ describe('resolveHeroTarget', () => {
     heroes.set('ally-1', ally)
 
     const filter = (c: HeroSchema, sid: string) => sid !== 'caster-1' && c.team === caster.team && !c.dead
-    const result = resolveHeroTarget(caster, 'caster-1', { x: 200, y: 100 }, heroes, 400, filter)
+    const result = resolveHeroTarget({ x: 200, y: 100 }, heroes, 400, filter)
     expect(result).toBe(ally)
   })
 
@@ -464,7 +464,7 @@ describe('resolveHeroTarget', () => {
 
     // Click near caster — distance from click (100,100) to enemy (800,100) = 700 > range 500
     const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
-    const result = resolveHeroTarget(caster, 'caster-1', { x: 100, y: 100 }, heroes, 500, filter)
+    const result = resolveHeroTarget({ x: 100, y: 100 }, heroes, 500, filter)
     expect(result).toBeNull()
   })
 
@@ -477,7 +477,7 @@ describe('resolveHeroTarget', () => {
     heroes.set('ally-1', ally)
 
     const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
-    const result = resolveHeroTarget(caster, 'caster-1', { x: 200, y: 100 }, heroes, 500, filter)
+    const result = resolveHeroTarget({ x: 200, y: 100 }, heroes, 500, filter)
     expect(result).toBeNull()
   })
 
@@ -490,7 +490,7 @@ describe('resolveHeroTarget', () => {
     heroes.set('enemy-1', enemy)
 
     const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
-    const result = resolveHeroTarget(caster, 'caster-1', { x: 200, y: 100 }, heroes, 500, filter)
+    const result = resolveHeroTarget({ x: 200, y: 100 }, heroes, 500, filter)
     expect(result).toBeNull()
   })
 
@@ -505,7 +505,7 @@ describe('resolveHeroTarget', () => {
     heroes.set('near-1', nearEnemy)
 
     const filter = (c: HeroSchema) => c.team !== caster.team && !c.dead
-    const result = resolveHeroTarget(caster, 'caster-1', { x: 300, y: 100 }, heroes, 500, filter)
+    const result = resolveHeroTarget({ x: 300, y: 100 }, heroes, 500, filter)
     expect(result).toBe(nearEnemy)
   })
 })

--- a/server/src/game/ServerCombatManager.ts
+++ b/server/src/game/ServerCombatManager.ts
@@ -9,6 +9,7 @@ import type { MinionSchema } from '../schema/MinionSchema.js'
 import type { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import type { InputMessage, CombatEventMessage } from '@shared/messages'
 import { applyDamageToTarget } from './combatUtils.js'
+import { getEffectiveStat } from './StatusEffectSystem.js'
 
 let projectileIdCounter = 0
 
@@ -122,9 +123,11 @@ export function processHeroCombat(
     const heroType = hero.heroType as HeroType
     const def = HERO_DEFINITIONS[heroType]
 
+    const effectiveAttack = getEffectiveStat(hero.attackDamage, hero, 'attackDamage')
+
     if (def.projectileSpeed === 0) {
       // Melee: immediate damage
-      applyDamageToTarget(hero.attackTargetId, hero.attackDamage, heroes, towers, minions, heroId)
+      applyDamageToTarget(hero.attackTargetId, effectiveAttack, heroes, towers, minions, heroId)
 
       events.push({
         kind: 'attack',
@@ -140,7 +143,7 @@ export function processHeroCombat(
         kind: 'damage',
         event: {
           targetId: hero.attackTargetId,
-          amount: hero.attackDamage,
+          amount: effectiveAttack,
           sourceId: heroId,
         },
       })
@@ -154,7 +157,7 @@ export function processHeroCombat(
       proj.targetY = target.y
       proj.targetId = hero.attackTargetId
       proj.speed = def.projectileSpeed
-      proj.damage = hero.attackDamage
+      proj.damage = effectiveAttack
       proj.ownerId = heroId
       proj.team = hero.team
       projectiles.set(proj.id, proj)

--- a/server/src/game/ServerMovementSystem.ts
+++ b/server/src/game/ServerMovementSystem.ts
@@ -1,7 +1,7 @@
 import { WORLD_WIDTH, WORLD_HEIGHT } from '@shared/constants'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { InputMessage } from '@shared/messages'
-import { getStatusEffectValue } from './StatusEffectSystem.js'
+import { getEffectiveStat } from './StatusEffectSystem.js'
 
 /**
  * Server-side movement system.
@@ -43,7 +43,7 @@ export function processMovement(
   const nx = moveDir.x / len
   const ny = moveDir.y / len
 
-  const effectiveSpeed = Math.max(0, hero.speed + getStatusEffectValue(hero, 'speed'))
+  const effectiveSpeed = getEffectiveStat(hero.speed, hero, 'speed')
   hero.x = clamp(hero.x + nx * effectiveSpeed * deltaTime, 0, WORLD_WIDTH)
   hero.y = clamp(hero.y + ny * effectiveSpeed * deltaTime, 0, WORLD_HEIGHT)
 }

--- a/server/src/game/ServerSkillExecutionSystem.ts
+++ b/server/src/game/ServerSkillExecutionSystem.ts
@@ -2,7 +2,7 @@ import { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import type { SkillEvent } from '@shared/messages'
-import { getSkillDefinition, type SkillDefinition } from '@shared/skills/skillDefinitions'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
 import { getEffectHandler } from './skills/skillEffectRegistry.js'
 import { createServerLogger } from '@shared/logging'
 
@@ -45,24 +45,23 @@ function normalizeDirection(
 }
 
 /**
- * Resolve the target hero for ally-targeting skills.
- * Finds the nearest same-team alive hero within range of the click position.
- * Falls back to the caster if no ally is in range.
+ * Resolve the target hero for ally/enemy-targeting skills.
+ * Finds the nearest hero matching `filter` within `range` of the click position.
+ * Returns null if no matching hero is in range.
  */
-function resolveAllyTarget(
+export function resolveHeroTarget(
   hero: HeroSchema,
   casterId: string,
   target: { x: number; y: number },
   heroes: MapSchema<HeroSchema>,
   range: number,
-): HeroSchema {
+  filter: (candidate: HeroSchema, candidateId: string) => boolean,
+): HeroSchema | null {
   let bestHero: HeroSchema | null = null
   let bestDistSq = Infinity
 
   heroes.forEach((candidate, sid) => {
-    if (sid === casterId) return
-    if (candidate.team !== hero.team) return
-    if (candidate.dead) return
+    if (!filter(candidate, sid)) return
 
     const dx = candidate.x - target.x
     const dy = candidate.y - target.y
@@ -76,12 +75,7 @@ function resolveAllyTarget(
   if (bestHero && bestDistSq <= range * range) {
     return bestHero
   }
-  return hero
-}
-
-/** Extract range from skill definition for ally targeting. */
-function getAllyRange(def: SkillDefinition): number {
-  return def.range ?? 0
+  return null
 }
 
 /**
@@ -116,10 +110,17 @@ export function executeSkill(
   // Calculate direction from hero to target
   const direction = normalizeDirection(hero.x, hero.y, target.x, target.y)
 
-  // Resolve ally target if targeting type is 'ally'
+  // Resolve target hero for ally/enemy targeting
   let targetHero: HeroSchema | undefined
+  const range = def.range ?? 0
   if (def.targeting === 'ally' && heroes) {
-    targetHero = resolveAllyTarget(hero, sessionId, target, heroes, getAllyRange(def))
+    const allyFilter = (c: HeroSchema, sid: string) => sid !== sessionId && c.team === hero.team && !c.dead
+    targetHero = resolveHeroTarget(hero, sessionId, target, heroes, range, allyFilter) ?? hero
+  } else if (def.targeting === 'enemy' && heroes) {
+    const enemyFilter = (c: HeroSchema) => c.team !== hero.team && !c.dead
+    const resolved = resolveHeroTarget(hero, sessionId, target, heroes, range, enemyFilter)
+    if (!resolved) return null // No enemy in range — skill fails, no CD consumed
+    targetHero = resolved
   }
 
   // Dispatch to registered effect handler by effectType

--- a/server/src/game/ServerSkillExecutionSystem.ts
+++ b/server/src/game/ServerSkillExecutionSystem.ts
@@ -50,8 +50,6 @@ function normalizeDirection(
  * Returns null if no matching hero is in range.
  */
 export function resolveHeroTarget(
-  hero: HeroSchema,
-  casterId: string,
   target: { x: number; y: number },
   heroes: MapSchema<HeroSchema>,
   range: number,
@@ -115,10 +113,10 @@ export function executeSkill(
   const range = def.range ?? 0
   if (def.targeting === 'ally' && heroes) {
     const allyFilter = (c: HeroSchema, sid: string) => sid !== sessionId && c.team === hero.team && !c.dead
-    targetHero = resolveHeroTarget(hero, sessionId, target, heroes, range, allyFilter) ?? hero
+    targetHero = resolveHeroTarget(target, heroes, range, allyFilter) ?? hero
   } else if (def.targeting === 'enemy' && heroes) {
     const enemyFilter = (c: HeroSchema) => c.team !== hero.team && !c.dead
-    const resolved = resolveHeroTarget(hero, sessionId, target, heroes, range, enemyFilter)
+    const resolved = resolveHeroTarget(target, heroes, range, enemyFilter)
     if (!resolved) return null // No enemy in range — skill fails, no CD consumed
     targetHero = resolved
   }

--- a/server/src/game/StatusEffectSystem.ts
+++ b/server/src/game/StatusEffectSystem.ts
@@ -15,6 +15,14 @@ export function getStatusEffectValue(hero: HeroSchema, buffType: string): number
 }
 
 /**
+ * Calculate the effective stat value after applying all matching status effects.
+ * Clamps to 0 to prevent negative stats.
+ */
+export function getEffectiveStat(base: number, hero: HeroSchema, buffType: string): number {
+  return Math.max(0, base + getStatusEffectValue(hero, buffType))
+}
+
+/**
  * Tick down all status effect durations for a hero.
  * Removes expired effects (remainingDuration <= 0).
  */

--- a/server/src/game/skills/SkillEffectHandler.ts
+++ b/server/src/game/skills/SkillEffectHandler.ts
@@ -12,7 +12,7 @@ export interface SkillExecutionContext {
   readonly targetPosition: { readonly x: number; readonly y: number }
   readonly projectiles: MapSchema<ProjectileSchema>
   readonly heroes: MapSchema<HeroSchema>
-  /** Resolved target for ally-targeting skills (falls back to caster if no ally in range). */
+  /** Resolved target for ally/enemy-targeting skills. */
   readonly targetHero?: HeroSchema
 }
 

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -38,13 +38,13 @@ export type SkillEffectParams = DashEffectParams | ProjectileEffectParams | Heal
 
 // ── Common fields shared by ALL skills ────────────────────────
 
-export type SkillTargeting = 'direction' | 'point' | 'self' | 'ally'
+export type SkillTargeting = 'direction' | 'point' | 'self' | 'ally' | 'enemy'
 
 export interface SkillDefinition {
   readonly id: string
   readonly targeting: SkillTargeting
   readonly cooldown: number       // seconds
-  readonly range?: number         // ally targeting range (px) — used by ally-targeting skills
+  readonly range?: number         // target selection range (px) — used by ally/enemy-targeting skills
   readonly effect: SkillEffectParams
 }
 
@@ -109,6 +109,19 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       value: 80,
       duration: 3,
       isDebuff: false,
+    },
+  },
+  'aura-weaken': {
+    id: 'aura-weaken',
+    targeting: 'enemy',
+    cooldown: 14,
+    range: 500,
+    effect: {
+      effectType: 'buff',
+      buffType: 'attackDamage',
+      value: -15,
+      duration: 4,
+      isDebuff: true,
     },
   },
 }


### PR DESCRIPTION
## Summary
- Add `aura-weaken` skill: enemy-targeting debuff that reduces attackDamage by 15 for 4s (CD 14s, range 500px)
- Unify `resolveAllyTarget` into generic `resolveHeroTarget` with filter parameter for ally/enemy reuse
- Add `getEffectiveStat` helper to centralize stat + status effect calculation with 0 clamping
- Apply `getEffectiveStat` to both `ServerCombatManager` (attackDamage) and `ServerMovementSystem` (speed)

## Test plan
- [x] aura-weaken skill definition test (targeting, cooldown, range, effect params)
- [x] resolveHeroTarget tests (enemy select, ally select, out-of-range, team exclusion, dead exclusion, nearest pick)
- [x] executeSkill aura-weaken tests (debuff applied, out-of-range no CD, allies-only fail, CD set, dead enemy)
- [x] getEffectiveStat tests (buff, debuff, no effect, 0 clamp)
- [x] attackDamage debuff integration tests (melee damage, over-debuff clamp, ranged projectile)
- [x] All existing tests pass (806 unit + 11 E2E)

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)