### PR TITLE
fix: eliminate cross-room projectile state contamination

### DIFF
--- a/server/src/__tests__/GameRoomIntegration.test.ts
+++ b/server/src/__tests__/GameRoomIntegration.test.ts
@@ -8,9 +8,10 @@ import { DEFAULT_TOWER } from '@shared/entities/Tower'
 import { WORLD_HEIGHT } from '@shared/constants'
 import type { InputMessage } from '@shared/messages'
 import { processMovement } from '../game/ServerMovementSystem.js'
-import { processHeroCombat, resetProjectileIdCounter } from '../game/ServerCombatManager.js'
+import { processHeroCombat } from '../game/ServerCombatManager.js'
 import { processProjectiles } from '../game/ServerProjectileSystem.js'
-import { processTowerCombat, resetTowerProjectileIdCounter } from '../game/ServerTowerSystem.js'
+import { processTowerCombat } from '../game/ServerTowerSystem.js'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
 import { processDeathAndRespawn } from '../game/ServerDeathSystem.js'
 
 const BLUE_SPAWN = { x: 320, y: 360 }
@@ -81,7 +82,8 @@ function runGameTick(
   towers: MapSchema<TowerSchema>,
   projectiles: MapSchema<ProjectileSchema>,
   playerInputs: Map<string, InputMessage>,
-  deltaTime: number
+  deltaTime: number,
+  tracker: ProjectileTracker,
 ): void {
   // 1. Movement
   heroes.forEach((hero, sessionId) => {
@@ -95,16 +97,16 @@ function runGameTick(
   // 2. Hero combat
   heroes.forEach((hero, heroId) => {
     const input = playerInputs.get(heroId)
-    processHeroCombat(hero, heroId, input, heroes, towers, projectiles, ProjectileSchema, deltaTime)
+    processHeroCombat(hero, heroId, input, heroes, towers, projectiles, ProjectileSchema, deltaTime, tracker)
   })
 
   // 3. Tower combat
   towers.forEach((tower, towerId) => {
-    processTowerCombat(tower, towerId, heroes, projectiles, ProjectileSchema, deltaTime)
+    processTowerCombat(tower, towerId, heroes, projectiles, ProjectileSchema, deltaTime, tracker)
   })
 
   // 4. Projectiles
-  processProjectiles(projectiles, heroes, towers, deltaTime)
+  processProjectiles(projectiles, heroes, towers, deltaTime, tracker)
 
   // 5. Death and respawn
   processDeathAndRespawn(heroes, getSpawnPosition, deltaTime)
@@ -119,9 +121,10 @@ describe('GameRoom integration', () => {
   let projectiles: MapSchema<ProjectileSchema>
   let playerInputs: Map<string, InputMessage>
 
+  let tracker: ProjectileTracker
+
   beforeEach(() => {
-    resetProjectileIdCounter()
-    resetTowerProjectileIdCounter()
+    tracker = new ProjectileTracker()
     heroes = new MapSchema<HeroSchema>()
     towers = new MapSchema<TowerSchema>()
     projectiles = new MapSchema<ProjectileSchema>()
@@ -143,7 +146,7 @@ describe('GameRoom integration', () => {
         facing: 0,
       })
 
-      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
 
       expect(p1.x).toBeGreaterThan(startX)
       expect(p1.lastProcessedSeq).toBe(1)
@@ -153,7 +156,7 @@ describe('GameRoom integration', () => {
       const p1 = heroes.get('p1')!
       const startX = p1.x
 
-      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
 
       expect(p1.x).toBe(startX)
     })
@@ -165,7 +168,7 @@ describe('GameRoom integration', () => {
         attackTargetId: null,
         facing: 0,
       })
-      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       expect(heroes.get('p1')!.lastProcessedSeq).toBe(5)
 
       playerInputs.set('p1', {
@@ -174,7 +177,7 @@ describe('GameRoom integration', () => {
         attackTargetId: null,
         facing: 0,
       })
-      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       expect(heroes.get('p1')!.lastProcessedSeq).toBe(10)
     })
 
@@ -190,7 +193,7 @@ describe('GameRoom integration', () => {
         facing: 0,
       })
 
-      runGameTick(heroes, towers, projectiles, playerInputs, 1)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1, tracker)
 
       expect(p1.x).toBeGreaterThanOrEqual(0)
       expect(p1.y).toBeGreaterThanOrEqual(0)
@@ -214,7 +217,7 @@ describe('GameRoom integration', () => {
         facing: 0,
       })
 
-      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
 
       // First tick sets up attack target, may not deal damage yet (cooldown starts)
       // Run a few more ticks to allow cooldown to pass and damage to be dealt
@@ -225,7 +228,7 @@ describe('GameRoom integration', () => {
           attackTargetId: 'p2',
           facing: 0,
         })
-        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       }
 
       expect(p2.hp).toBeLessThan(initialHp)
@@ -253,7 +256,7 @@ describe('GameRoom integration', () => {
           attackTargetId: 'ally',
           facing: 0,
         })
-        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       }
 
       expect(ally.hp).toBe(initialHp)
@@ -278,7 +281,7 @@ describe('GameRoom integration', () => {
           attackTargetId: 'p2',
           facing: 0,
         })
-        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
         if (p2.dead) break
       }
 
@@ -294,7 +297,7 @@ describe('GameRoom integration', () => {
 
       // Run ticks until respawn timer expires
       for (let i = 0; i < 60; i++) {
-        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       }
 
       expect(p2.dead).toBe(false)
@@ -316,7 +319,7 @@ describe('GameRoom integration', () => {
         facing: 0,
       })
 
-      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       expect(p1.x).toBe(startX)
     })
   })
@@ -333,7 +336,7 @@ describe('GameRoom integration', () => {
 
       // Run enough ticks for tower to fire
       for (let i = 0; i < 120; i++) {
-        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       }
 
       // Tower should have created a projectile or dealt damage
@@ -351,7 +354,7 @@ describe('GameRoom integration', () => {
       const initialHp = p1.hp
 
       for (let i = 0; i < 120; i++) {
-        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       }
 
       expect(p1.hp).toBe(initialHp)
@@ -367,7 +370,7 @@ describe('GameRoom integration', () => {
         facing: 0,
       })
 
-      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       expect(playerInputs.size).toBe(0)
     })
 
@@ -390,7 +393,7 @@ describe('GameRoom integration', () => {
         facing: 0,
       })
 
-      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+      runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
 
       expect(p1.x).toBeGreaterThan(startX1)
       expect(p2.x).toBeLessThan(startX2)
@@ -406,7 +409,7 @@ describe('GameRoom integration', () => {
 
       // Run ticks — tower should fire projectile, which should travel and hit
       for (let i = 0; i < 180; i++) {
-        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60)
+        runGameTick(heroes, towers, projectiles, playerInputs, 1 / 60, tracker)
       }
 
       // Projectile should have hit and dealt damage

--- a/server/src/__tests__/ProjectileTracker.test.ts
+++ b/server/src/__tests__/ProjectileTracker.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+
+describe('ProjectileTracker', () => {
+  let tracker: ProjectileTracker
+
+  beforeEach(() => {
+    tracker = new ProjectileTracker()
+  })
+
+  describe('ID generation', () => {
+    it('should generate unique combat projectile IDs', () => {
+      expect(tracker.nextCombatProjectileId()).toBe('proj-1')
+      expect(tracker.nextCombatProjectileId()).toBe('proj-2')
+      expect(tracker.nextCombatProjectileId()).toBe('proj-3')
+    })
+
+    it('should generate unique skill projectile IDs', () => {
+      expect(tracker.nextSkillProjectileId()).toBe('skill-proj-1')
+      expect(tracker.nextSkillProjectileId()).toBe('skill-proj-2')
+    })
+
+    it('should generate unique tower projectile IDs', () => {
+      expect(tracker.nextTowerProjectileId()).toBe('tower-proj-1')
+      expect(tracker.nextTowerProjectileId()).toBe('tower-proj-2')
+    })
+
+    it('should maintain independent counters per type', () => {
+      tracker.nextCombatProjectileId() // proj-1
+      tracker.nextSkillProjectileId()  // skill-proj-1
+      tracker.nextTowerProjectileId()  // tower-proj-1
+      expect(tracker.nextCombatProjectileId()).toBe('proj-2')
+      expect(tracker.nextSkillProjectileId()).toBe('skill-proj-2')
+      expect(tracker.nextTowerProjectileId()).toBe('tower-proj-2')
+    })
+  })
+
+  describe('distance tracking', () => {
+    it('should return 0 for unknown projectile', () => {
+      expect(tracker.getDistanceTraveled('unknown')).toBe(0)
+    })
+
+    it('should store and retrieve distance traveled', () => {
+      tracker.setDistanceTraveled('proj-1', 150)
+      expect(tracker.getDistanceTraveled('proj-1')).toBe(150)
+    })
+
+    it('should update distance traveled', () => {
+      tracker.setDistanceTraveled('proj-1', 100)
+      tracker.setDistanceTraveled('proj-1', 250)
+      expect(tracker.getDistanceTraveled('proj-1')).toBe(250)
+    })
+  })
+
+  describe('hit set tracking', () => {
+    it('should create empty hit set for new projectile', () => {
+      const hitSet = tracker.getHitSet('proj-1')
+      expect(hitSet.size).toBe(0)
+    })
+
+    it('should return same set on repeated access', () => {
+      const set1 = tracker.getHitSet('proj-1')
+      set1.add('enemy-1')
+      const set2 = tracker.getHitSet('proj-1')
+      expect(set2.has('enemy-1')).toBe(true)
+    })
+  })
+
+  describe('cleanup', () => {
+    it('should remove distance and hit set for projectile', () => {
+      tracker.setDistanceTraveled('proj-1', 200)
+      tracker.getHitSet('proj-1').add('enemy-1')
+
+      tracker.cleanupTracking('proj-1')
+
+      expect(tracker.getDistanceTraveled('proj-1')).toBe(0)
+      expect(tracker.getHitSet('proj-1').size).toBe(0)
+    })
+
+    it('should not affect other projectiles', () => {
+      tracker.setDistanceTraveled('proj-1', 100)
+      tracker.setDistanceTraveled('proj-2', 200)
+
+      tracker.cleanupTracking('proj-1')
+
+      expect(tracker.getDistanceTraveled('proj-2')).toBe(200)
+    })
+  })
+
+  describe('room isolation', () => {
+    it('should maintain independent state per instance', () => {
+      const tracker2 = new ProjectileTracker()
+
+      expect(tracker.nextCombatProjectileId()).toBe('proj-1')
+      expect(tracker2.nextCombatProjectileId()).toBe('proj-1')
+
+      tracker.setDistanceTraveled('proj-1', 100)
+      expect(tracker2.getDistanceTraveled('proj-1')).toBe(0)
+    })
+  })
+})

--- a/server/src/__tests__/ServerCombatManager.test.ts
+++ b/server/src/__tests__/ServerCombatManager.test.ts
@@ -4,7 +4,8 @@ import { HeroSchema } from '../schema/HeroSchema.js'
 import { TowerSchema } from '../schema/TowerSchema.js'
 import { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import { StatusEffectSchema } from '../schema/StatusEffectSchema.js'
-import { processHeroCombat, resetProjectileIdCounter } from '../game/ServerCombatManager.js'
+import { processHeroCombat } from '../game/ServerCombatManager.js'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
 import type { InputMessage } from '@shared/messages'
 
 function createHero(id: string, overrides: Partial<Record<keyof HeroSchema, unknown>> = {}): HeroSchema {
@@ -41,12 +42,13 @@ describe('ServerCombatManager', () => {
   let heroes: MapSchema<HeroSchema>
   let towers: MapSchema<TowerSchema>
   let projectiles: MapSchema<ProjectileSchema>
+  let tracker: ProjectileTracker
 
   beforeEach(() => {
     heroes = new MapSchema<HeroSchema>()
     towers = new MapSchema<TowerSchema>()
     projectiles = new MapSchema<ProjectileSchema>()
-    resetProjectileIdCounter()
+    tracker = new ProjectileTracker()
   })
 
   describe('processHeroCombat', () => {
@@ -54,7 +56,7 @@ describe('ServerCombatManager', () => {
       const hero = createHero('hero-1', { dead: true, attackTargetId: 'enemy', attackCooldown: 1 })
       heroes.set('hero-1', hero)
 
-      processHeroCombat(hero, 'hero-1', undefined, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(hero, 'hero-1', undefined, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(hero.attackTargetId).toBe('')
       expect(hero.attackCooldown).toBe(0)
@@ -64,7 +66,7 @@ describe('ServerCombatManager', () => {
       const hero = createHero('hero-1', { attackCooldown: 1.0 })
       heroes.set('hero-1', hero)
 
-      processHeroCombat(hero, 'hero-1', undefined, heroes, towers, projectiles, ProjectileSchema, 0.5)
+      processHeroCombat(hero, 'hero-1', undefined, heroes, towers, projectiles, ProjectileSchema, 0.5, tracker)
 
       expect(hero.attackCooldown).toBeCloseTo(0.5, 2)
     })
@@ -76,7 +78,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(attacker.attackTargetId).toBe('target')
     })
@@ -88,7 +90,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(attacker.attackTargetId).toBe('')
     })
@@ -100,7 +102,7 @@ describe('ServerCombatManager', () => {
       heroes.set('ally', ally)
 
       const input = createInput({ attackTargetId: 'ally' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(attacker.attackTargetId).toBe('')
     })
@@ -116,7 +118,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(target.hp).toBe(590) // 650 - 60
       expect(attacker.attackCooldown).toBeCloseTo(1 / 0.8, 2)
@@ -133,7 +135,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(projectiles.size).toBe(1)
       const proj = Array.from(projectiles.values())[0]!
@@ -156,7 +158,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(target.hp).toBe(650) // No damage
     })
@@ -166,7 +168,7 @@ describe('ServerCombatManager', () => {
       heroes.set('hero-1', hero)
 
       const input = createInput({ attackTargetId: null })
-      processHeroCombat(hero, 'hero-1', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(hero, 'hero-1', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(hero.attackTargetId).toBe('')
     })
@@ -183,7 +185,7 @@ describe('ServerCombatManager', () => {
 
       // Tick 1: first attack lands
       const input1 = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input1, heroes, towers, projectiles, ProjectileSchema, 0.016)
+      processHeroCombat(attacker, 'attacker', input1, heroes, towers, projectiles, ProjectileSchema, 0.016, tracker)
       expect(target.hp).toBe(590)
       expect(attacker.attackCooldown).toBeGreaterThan(0)
 
@@ -191,12 +193,12 @@ describe('ServerCombatManager', () => {
       // cooldown = 1/0.8 = 1.25s, need ceil(1.25/0.016) = 79 ticks to expire
       for (let i = 0; i < 78; i++) {
         const input = createInput({ attackTargetId: 'target', seq: i + 2 })
-        processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.016)
+        processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.016, tracker)
       }
 
       // Tick 80: cooldown expired, second attack lands
       const finalInput = createInput({ attackTargetId: 'target', seq: 80 })
-      processHeroCombat(attacker, 'attacker', finalInput, heroes, towers, projectiles, ProjectileSchema, 0.016)
+      processHeroCombat(attacker, 'attacker', finalInput, heroes, towers, projectiles, ProjectileSchema, 0.016, tracker)
       expect(target.hp).toBe(530) // 590 - 60
     })
 
@@ -211,12 +213,12 @@ describe('ServerCombatManager', () => {
 
       // First: set target
       const input1 = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input1, heroes, towers, projectiles, ProjectileSchema, 0.016)
+      processHeroCombat(attacker, 'attacker', input1, heroes, towers, projectiles, ProjectileSchema, 0.016, tracker)
       expect(attacker.attackTargetId).toBe('target')
 
       // Next: send null to clear
       const input2 = createInput({ attackTargetId: null, seq: 2 })
-      processHeroCombat(attacker, 'attacker', input2, heroes, towers, projectiles, ProjectileSchema, 0.016)
+      processHeroCombat(attacker, 'attacker', input2, heroes, towers, projectiles, ProjectileSchema, 0.016, tracker)
       expect(attacker.attackTargetId).toBe('')
     })
 
@@ -227,7 +229,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(attacker.attackTargetId).toBe('')
     })
@@ -237,7 +239,7 @@ describe('ServerCombatManager', () => {
       heroes.set('attacker', attacker)
 
       const input = createInput({ attackTargetId: 'nonexistent' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(attacker.attackTargetId).toBe('')
     })
@@ -260,8 +262,8 @@ describe('ServerCombatManager', () => {
       const inputB = createInput({ attackTargetId: 'heroA' })
 
       // Simulate game loop: process both heroes in sequence (same tick)
-      processHeroCombat(heroA, 'heroA', inputA, heroes, towers, projectiles, ProjectileSchema, 0.016)
-      processHeroCombat(heroB, 'heroB', inputB, heroes, towers, projectiles, ProjectileSchema, 0.016)
+      processHeroCombat(heroA, 'heroA', inputA, heroes, towers, projectiles, ProjectileSchema, 0.016, tracker)
+      processHeroCombat(heroB, 'heroB', inputB, heroes, towers, projectiles, ProjectileSchema, 0.016, tracker)
 
       // Both heroes should have taken damage
       expect(heroA.hp).toBe(590) // 650 - 60 from heroB
@@ -279,7 +281,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      const events = processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      const events = processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(events).toHaveLength(2)
       expect(events[0]).toEqual({
@@ -303,7 +305,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      const events = processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      const events = processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(events).toHaveLength(1)
       expect(events[0]).toEqual({
@@ -332,7 +334,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      const events = processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      const events = processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(target.hp).toBe(615) // 650 - (50 - 15) = 650 - 35
       expect(events[1]).toEqual({
@@ -360,7 +362,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(target.hp).toBe(650) // 0 damage
     })
@@ -384,7 +386,7 @@ describe('ServerCombatManager', () => {
       heroes.set('target', target)
 
       const input = createInput({ attackTargetId: 'target' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(projectiles.size).toBe(1)
       const proj = Array.from(projectiles.values())[0]!
@@ -395,7 +397,7 @@ describe('ServerCombatManager', () => {
       const hero = createHero('hero-1', { attackCooldown: 1.0 })
       heroes.set('hero-1', hero)
 
-      const events = processHeroCombat(hero, 'hero-1', undefined, heroes, towers, projectiles, ProjectileSchema, 0.5)
+      const events = processHeroCombat(hero, 'hero-1', undefined, heroes, towers, projectiles, ProjectileSchema, 0.5, tracker)
       expect(events).toHaveLength(0)
     })
 
@@ -419,7 +421,7 @@ describe('ServerCombatManager', () => {
       towers.set('tower-red', tower)
 
       const input = createInput({ attackTargetId: 'tower-red' })
-      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1)
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(tower.hp).toBe(1440) // 1500 - 60
     })

--- a/server/src/__tests__/ServerProjectileSystem.test.ts
+++ b/server/src/__tests__/ServerProjectileSystem.test.ts
@@ -4,7 +4,8 @@ import { HeroSchema } from '../schema/HeroSchema.js'
 import { TowerSchema } from '../schema/TowerSchema.js'
 import { MinionSchema } from '../schema/MinionSchema.js'
 import { ProjectileSchema } from '../schema/ProjectileSchema.js'
-import { processProjectiles, resetProjectileTracking } from '../game/ServerProjectileSystem.js'
+import { processProjectiles } from '../game/ServerProjectileSystem.js'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
 
 function createProjectile(overrides: Partial<Record<keyof ProjectileSchema, unknown>> = {}): ProjectileSchema {
   const proj = new ProjectileSchema()
@@ -40,12 +41,13 @@ describe('ServerProjectileSystem', () => {
   let heroes: MapSchema<HeroSchema>
   let towers: MapSchema<TowerSchema>
   let projectiles: MapSchema<ProjectileSchema>
+  let tracker: ProjectileTracker
 
   beforeEach(() => {
     heroes = new MapSchema<HeroSchema>()
     towers = new MapSchema<TowerSchema>()
     projectiles = new MapSchema<ProjectileSchema>()
-    resetProjectileTracking()
+    tracker = new ProjectileTracker()
   })
 
   describe('processProjectiles — homing', () => {
@@ -56,7 +58,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 100, y: 100, targetId: 'enemy', speed: 400 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.25)
+      processProjectiles(projectiles, heroes, towers, 0.25, tracker)
 
       expect(proj.x).toBeCloseTo(200, 0) // 100 + 400 * 0.25
       expect(proj.y).toBeCloseTo(100, 0)
@@ -71,14 +73,14 @@ describe('ServerProjectileSystem', () => {
       projectiles.set(proj.id, proj)
 
       // First tick: target at (300, 100)
-      processProjectiles(projectiles, heroes, towers, 0.1)
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker)
       const x1 = proj.x
 
       // Target moves up
       target.y = 200
 
       // Second tick: projectile should now home toward (300, 200)
-      processProjectiles(projectiles, heroes, towers, 0.1)
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker)
 
       // Projectile should have a y component now (moving toward new target position)
       expect(proj.y).toBeGreaterThan(100)
@@ -96,7 +98,7 @@ describe('ServerProjectileSystem', () => {
       target.x = 400
       target.y = 200
 
-      processProjectiles(projectiles, heroes, towers, 0.1)
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker)
 
       expect(proj.targetX).toBe(400)
       expect(proj.targetY).toBe(200)
@@ -112,7 +114,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 145, y: 100, targetId: 'enemy', team: 'blue', damage: 60 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.01)
+      processProjectiles(projectiles, heroes, towers, 0.01, tracker)
 
       expect(bystander.hp).toBe(650) // No damage to bystander
       expect(projectiles.size).toBe(1) // Projectile not consumed
@@ -125,7 +127,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 195, y: 100, targetId: 'enemy', team: 'blue', damage: 60 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.01)
+      processProjectiles(projectiles, heroes, towers, 0.01, tracker)
 
       expect(target.hp).toBe(590) // 650 - 60
       expect(projectiles.size).toBe(0) // Removed after hit
@@ -138,7 +140,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 100, y: 100, targetId: 'enemy' })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.1)
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker)
 
       expect(projectiles.size).toBe(0)
     })
@@ -148,7 +150,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 100, y: 100, targetId: 'nonexistent' })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.1)
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker)
 
       expect(projectiles.size).toBe(0)
     })
@@ -161,7 +163,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 195, y: 100, targetId: 'ally', team: 'blue', damage: 60 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.01)
+      processProjectiles(projectiles, heroes, towers, 0.01, tracker)
 
       // Friendly fire guard: no damage applied, projectile removed
       expect(ally.hp).toBe(650)
@@ -176,7 +178,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 200, y: 100, targetId: 'enemy', team: 'blue', damage: 60 })
       projectiles.set(proj.id, proj)
 
-      const events = processProjectiles(projectiles, heroes, towers, 0.01)
+      const events = processProjectiles(projectiles, heroes, towers, 0.01, tracker)
 
       expect(target.hp).toBe(590)
       expect(projectiles.size).toBe(0)
@@ -190,7 +192,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 195, y: 100, targetId: 'enemy', team: 'blue', damage: 60, ownerId: 'shooter' })
       projectiles.set(proj.id, proj)
 
-      const events = processProjectiles(projectiles, heroes, towers, 0.01)
+      const events = processProjectiles(projectiles, heroes, towers, 0.01, tracker)
 
       expect(events).toHaveLength(1)
       expect(events[0]).toEqual({
@@ -206,7 +208,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 100, y: 100, targetId: 'enemy' })
       projectiles.set(proj.id, proj)
 
-      const events = processProjectiles(projectiles, heroes, towers, 0.01)
+      const events = processProjectiles(projectiles, heroes, towers, 0.01, tracker)
       expect(events).toHaveLength(0)
     })
 
@@ -221,7 +223,7 @@ describe('ServerProjectileSystem', () => {
       projectiles.set(proj1.id, proj1)
       projectiles.set(proj2.id, proj2)
 
-      processProjectiles(projectiles, heroes, towers, 0.01)
+      processProjectiles(projectiles, heroes, towers, 0.01, tracker)
 
       expect(enemy1.hp).toBe(620) // hit by proj1
       expect(enemy2.hp).toBe(650) // proj2 still in flight
@@ -243,7 +245,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 195, y: 100, targetId: 'tower-red', team: 'blue', damage: 45 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.01)
+      processProjectiles(projectiles, heroes, towers, 0.01, tracker)
 
       expect(tower.hp).toBe(1455)
       expect(projectiles.size).toBe(0)
@@ -265,7 +267,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createProjectile({ x: 295, y: 100, targetId: 'minion-1', damage: 50 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.01, minions)
+      processProjectiles(projectiles, heroes, towers, 0.01, tracker, minions)
 
       expect(minion.hp).toBe(50)
       expect(projectiles.size).toBe(0)
@@ -295,7 +297,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createLinearProjectile()
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.016)
+      processProjectiles(projectiles, heroes, towers, 0.016, tracker)
 
       expect(proj.x).toBeCloseTo(100 + 800 * 0.016) // 112.8
       expect(proj.y).toBeCloseTo(200)
@@ -307,7 +309,7 @@ describe('ServerProjectileSystem', () => {
       projectiles.set(proj.id, proj)
 
       // One big tick that exceeds maxRange
-      processProjectiles(projectiles, heroes, towers, 0.2) // 800*0.2 = 160 > 100
+      processProjectiles(projectiles, heroes, towers, 0.2, tracker) // 800*0.2 = 160 > 100
 
       expect(projectiles.size).toBe(0)
     })
@@ -316,7 +318,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createLinearProjectile({ maxRange: 600 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.1) // 80px traveled
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker) // 80px traveled
 
       expect(projectiles.size).toBe(1)
     })
@@ -328,7 +330,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createLinearProjectile({ x: 100, y: 200 })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.016)
+      processProjectiles(projectiles, heroes, towers, 0.016, tracker)
 
       expect(enemy.hp).toBe(440) // 500 - 60
       expect(proj.pierceRemaining).toBe(2)
@@ -346,13 +348,13 @@ describe('ServerProjectileSystem', () => {
       projectiles.set(proj.id, proj)
 
       // Tick 1: proj moves to 180 — within 27px of enemy1 at 200? dist=20 < 27, hit!
-      processProjectiles(projectiles, heroes, towers, 0.1)
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker)
       expect(enemy1.hp).toBe(440)
       expect(proj.pierceRemaining).toBe(2)
 
       // Tick 2-3: proj moves further, reaches enemy2
-      processProjectiles(projectiles, heroes, towers, 0.1) // x=260
-      processProjectiles(projectiles, heroes, towers, 0.1) // x=340, dist to enemy2=10 < 27, hit!
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker) // x=260
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker) // x=340, dist to enemy2=10 < 27, hit!
       expect(enemy2.hp).toBe(440)
       expect(proj.pierceRemaining).toBe(1)
       expect(projectiles.size).toBe(1) // still alive
@@ -369,7 +371,7 @@ describe('ServerProjectileSystem', () => {
       projectiles.set(proj.id, proj)
 
       // Tick: proj moves to 180 — hits enemy1, pierceRemaining becomes 0, removed
-      processProjectiles(projectiles, heroes, towers, 0.1)
+      processProjectiles(projectiles, heroes, towers, 0.1, tracker)
 
       expect(enemy1.hp).toBe(440)
       expect(enemy2.hp).toBe(500) // not hit — projectile removed after 1st
@@ -384,11 +386,11 @@ describe('ServerProjectileSystem', () => {
       projectiles.set(proj.id, proj)
 
       // First tick — hits enemy
-      processProjectiles(projectiles, heroes, towers, 0.005)
+      processProjectiles(projectiles, heroes, towers, 0.005, tracker)
       expect(enemy.hp).toBe(440)
 
       // Second tick — still overlapping, but should NOT hit again
-      processProjectiles(projectiles, heroes, towers, 0.005)
+      processProjectiles(projectiles, heroes, towers, 0.005, tracker)
       expect(enemy.hp).toBe(440) // unchanged
     })
 
@@ -399,7 +401,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createLinearProjectile({ x: 100, y: 200, team: 'blue' })
       projectiles.set(proj.id, proj)
 
-      processProjectiles(projectiles, heroes, towers, 0.016)
+      processProjectiles(projectiles, heroes, towers, 0.016, tracker)
 
       expect(ally.hp).toBe(500)
     })
@@ -411,7 +413,7 @@ describe('ServerProjectileSystem', () => {
       const proj = createLinearProjectile({ x: 100, y: 200, ownerId: 'shooter' })
       projectiles.set(proj.id, proj)
 
-      const events = processProjectiles(projectiles, heroes, towers, 0.016)
+      const events = processProjectiles(projectiles, heroes, towers, 0.016, tracker)
 
       expect(events).toHaveLength(1)
       expect(events[0]).toEqual({
@@ -430,7 +432,7 @@ describe('ServerProjectileSystem', () => {
       projectiles.set(homing.id, homing)
       projectiles.set(linear.id, linear)
 
-      const events = processProjectiles(projectiles, heroes, towers, 0.01)
+      const events = processProjectiles(projectiles, heroes, towers, 0.01, tracker)
 
       // Homing should hit its target
       expect(target.hp).toBe(600)

--- a/server/src/__tests__/ServerTowerSystem.test.ts
+++ b/server/src/__tests__/ServerTowerSystem.test.ts
@@ -3,7 +3,8 @@ import { MapSchema } from '@colyseus/schema'
 import { HeroSchema } from '../schema/HeroSchema.js'
 import { TowerSchema } from '../schema/TowerSchema.js'
 import { ProjectileSchema } from '../schema/ProjectileSchema.js'
-import { processTowerCombat, resetTowerProjectileIdCounter } from '../game/ServerTowerSystem.js'
+import { processTowerCombat } from '../game/ServerTowerSystem.js'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
 
 function createTower(id: string, overrides: Partial<Record<keyof TowerSchema, unknown>> = {}): TowerSchema {
   const tower = new TowerSchema()
@@ -43,11 +44,12 @@ function createHero(id: string, overrides: Partial<Record<keyof HeroSchema, unkn
 describe('ServerTowerSystem', () => {
   let heroes: MapSchema<HeroSchema>
   let projectiles: MapSchema<ProjectileSchema>
+  let tracker: ProjectileTracker
 
   beforeEach(() => {
     heroes = new MapSchema<HeroSchema>()
     projectiles = new MapSchema<ProjectileSchema>()
-    resetTowerProjectileIdCounter()
+    tracker = new ProjectileTracker()
   })
 
   describe('processTowerCombat', () => {
@@ -56,7 +58,7 @@ describe('ServerTowerSystem', () => {
       const enemy = createHero('enemy', { team: 'red' })
       heroes.set('enemy', enemy)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(tower.attackTargetId).toBe('')
       expect(projectiles.size).toBe(0)
@@ -67,7 +69,7 @@ describe('ServerTowerSystem', () => {
       const enemy = createHero('enemy-1', { x: 700, y: 360, team: 'red' })
       heroes.set('enemy-1', enemy)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(tower.attackTargetId).toBe('enemy-1')
     })
@@ -77,7 +79,7 @@ describe('ServerTowerSystem', () => {
       const ally = createHero('ally', { x: 700, y: 360, team: 'blue' })
       heroes.set('ally', ally)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(tower.attackTargetId).toBe('')
     })
@@ -87,7 +89,7 @@ describe('ServerTowerSystem', () => {
       const enemy = createHero('enemy', { x: 2000, y: 360, team: 'red' })
       heroes.set('enemy', enemy)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(tower.attackTargetId).toBe('')
     })
@@ -97,7 +99,7 @@ describe('ServerTowerSystem', () => {
       const enemy = createHero('enemy', { x: 700, y: 360, team: 'red' })
       heroes.set('enemy', enemy)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(projectiles.size).toBe(1)
       const proj = Array.from(projectiles.values())[0]!
@@ -116,7 +118,7 @@ describe('ServerTowerSystem', () => {
       const enemy = createHero('enemy', { x: 700, y: 360, team: 'red' })
       heroes.set('enemy', enemy)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(projectiles.size).toBe(0)
     })
@@ -125,7 +127,7 @@ describe('ServerTowerSystem', () => {
       const tower = createTower('tower-1', { attackCooldown: 1.0 })
       heroes.set('enemy', createHero('enemy', { team: 'red' }))
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.5)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.5, tracker)
 
       expect(tower.attackCooldown).toBeCloseTo(0.5, 2)
     })
@@ -135,7 +137,7 @@ describe('ServerTowerSystem', () => {
       const enemy = createHero('enemy', { x: 700, y: 360, team: 'red' })
       heroes.set('enemy', enemy)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(tower.attackCooldown).toBeCloseTo(1 / 0.8, 2)
     })
@@ -145,7 +147,7 @@ describe('ServerTowerSystem', () => {
       const enemy = createHero('enemy', { x: 700, y: 360, team: 'red', dead: true, hp: 0 })
       heroes.set('enemy', enemy)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(tower.attackTargetId).toBe('')
     })
@@ -157,7 +159,7 @@ describe('ServerTowerSystem', () => {
       heroes.set('far', farEnemy)
       heroes.set('close', closeEnemy)
 
-      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1)
+      processTowerCombat(tower, 'tower-1', heroes, projectiles, ProjectileSchema, 0.1, tracker)
 
       expect(tower.attackTargetId).toBe('close')
     })

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -5,11 +5,15 @@ import { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import { executeSkill, tickCooldowns, resolveHeroTarget } from '../game/ServerSkillExecutionSystem.js'
 import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
 import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+
+let tracker: ProjectileTracker
 
 // Register handlers once before tests run
 beforeEach(() => {
   // registerAllEffectHandlers is idempotent — safe to call multiple times
   registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
 })
 
 function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
@@ -75,7 +79,7 @@ describe('getSkillDefinition', () => {
 describe('executeSkill', () => {
   it('should execute blade-charge and return SkillEvent', () => {
     const hero = createHero()
-    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 })
+    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(event).not.toBeNull()
     expect(event!.casterId).toBe('player-1')
     expect(event!.skillId).toBe('blade-charge')
@@ -86,13 +90,13 @@ describe('executeSkill', () => {
 
   it('should set cooldown after successful execution', () => {
     const hero = createHero()
-    executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 })
+    executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(hero.cooldownQ).toBe(8)
   })
 
   it('should set dash state on hero after Charge', () => {
     const hero = createHero()
-    executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 })
+    executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(hero.dashTimer).toBeCloseTo(0.3)
     expect(hero.dashDirX).toBeCloseTo(1)
     expect(hero.dashDirY).toBeCloseTo(0)
@@ -103,20 +107,20 @@ describe('executeSkill', () => {
   it('should reject when hero is dead', () => {
     const hero = createHero()
     hero.dead = true
-    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 })
+    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(event).toBeNull()
   })
 
   it('should reject when slot is empty', () => {
     const hero = createHero()
-    const event = executeSkill(hero, 'player-1', 'E', { x: 400, y: 200 })
+    const event = executeSkill(hero, 'player-1', 'E', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(event).toBeNull()
   })
 
   it('should reject when cooldown is active', () => {
     const hero = createHero()
     hero.cooldownQ = 5
-    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 })
+    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(event).toBeNull()
     expect(hero.cooldownQ).toBe(5) // unchanged
   })
@@ -124,14 +128,14 @@ describe('executeSkill', () => {
   it('should reject unknown skill ID', () => {
     const hero = createHero()
     hero.skillSlotQ = 'unknown-skill'
-    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 })
+    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(event).toBeNull()
   })
 
   it('should reject when dashing', () => {
     const hero = createHero()
     hero.dashTimer = 0.2
-    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 })
+    const event = executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(event).toBeNull()
   })
 })
@@ -139,14 +143,14 @@ describe('executeSkill', () => {
 describe('executeSkill — bolt-dash', () => {
   it('should return valid SkillEvent for bolt-dash', () => {
     const hero = createHero({ hp: 500, maxHp: 500, heroType: 'BOLT', skillSlotQ: 'bolt-dash' })
-    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 })
+    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(event).not.toBeNull()
     expect(event!.skillId).toBe('bolt-dash')
   })
 
   it('should set dash state with zero damage', () => {
     const hero = createHero({ hp: 500, maxHp: 500, heroType: 'BOLT', skillSlotQ: 'bolt-dash' })
-    executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 })
+    executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(hero.dashTimer).toBeCloseTo(0.05)
     expect(hero.dashDirX).toBeCloseTo(1)
     expect(hero.dashDirY).toBeCloseTo(0)
@@ -156,7 +160,7 @@ describe('executeSkill — bolt-dash', () => {
 
   it('should set cooldown to 6 seconds', () => {
     const hero = createHero({ hp: 500, maxHp: 500, heroType: 'BOLT', skillSlotQ: 'bolt-dash' })
-    executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 })
+    executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(hero.cooldownQ).toBe(6)
   })
 })
@@ -165,7 +169,7 @@ describe('executeSkill — bolt-pierce-shot', () => {
   it('should return valid SkillEvent and spawn projectile', () => {
     const hero = createHero({ heroType: 'BOLT', skillSlotQ: 'bolt-pierce-shot' })
     const projectiles = new MapSchema<ProjectileSchema>()
-    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles)
+    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles, new MapSchema<HeroSchema>(), tracker)
     expect(event).not.toBeNull()
     expect(event!.skillId).toBe('bolt-pierce-shot')
     expect(event!.direction.x).toBeCloseTo(1)
@@ -190,14 +194,14 @@ describe('executeSkill — bolt-pierce-shot', () => {
   it('should set cooldown to 5 seconds', () => {
     const hero = createHero({ heroType: 'BOLT', skillSlotQ: 'bolt-pierce-shot' })
     const projectiles = new MapSchema<ProjectileSchema>()
-    executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles)
+    executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles, new MapSchema<HeroSchema>(), tracker)
     expect(hero.cooldownQ).toBe(5)
   })
 
   it('should reject when dead', () => {
     const hero = createHero({ heroType: 'BOLT', skillSlotQ: 'bolt-pierce-shot', dead: true })
     const projectiles = new MapSchema<ProjectileSchema>()
-    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles)
+    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles, new MapSchema<HeroSchema>(), tracker)
     expect(event).toBeNull()
     expect(projectiles.size).toBe(0)
   })
@@ -205,7 +209,7 @@ describe('executeSkill — bolt-pierce-shot', () => {
   it('should reject when cooldown is active', () => {
     const hero = createHero({ heroType: 'BOLT', skillSlotQ: 'bolt-pierce-shot', cooldownQ: 3 })
     const projectiles = new MapSchema<ProjectileSchema>()
-    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles)
+    const event = executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, projectiles, new MapSchema<HeroSchema>(), tracker)
     expect(event).toBeNull()
     expect(projectiles.size).toBe(0)
   })
@@ -245,7 +249,7 @@ describe('executeSkill — aura-heal', () => {
     heroes.set('ally-1', ally)
 
     // Click near ally position (within range 400)
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 300, y: 100 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 300, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).not.toBeNull()
     expect(event!.skillId).toBe('aura-heal')
     expect(ally.hp).toBe(320) // 200 + 120
@@ -258,7 +262,7 @@ describe('executeSkill — aura-heal', () => {
     heroes.set('caster-1', caster)
     // No ally in heroes map
 
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 800, y: 800 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 800, y: 800 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).not.toBeNull()
     expect(caster.hp).toBe(420) // 300 + 120
   })
@@ -272,7 +276,7 @@ describe('executeSkill — aura-heal', () => {
     heroes.set('ally-1', ally)
 
     // Click at ally position — distance from click to ally is 0, within range
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 600, y: 100 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 600, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).not.toBeNull()
     expect(ally.hp).toBe(320)
   })
@@ -286,7 +290,7 @@ describe('executeSkill — aura-heal', () => {
     heroes.set('ally-1', ally)
 
     // Click at (900, 900), ally at (100, 200) — distance ~922px > range 400
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 900, y: 900 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 900, y: 900 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).not.toBeNull()
     expect(ally.hp).toBe(200) // NOT healed
     expect(caster.hp).toBe(420) // self-heal fallback
@@ -298,7 +302,7 @@ describe('executeSkill — aura-heal', () => {
     const heroes = new MapSchema<HeroSchema>()
     heroes.set('caster-1', caster)
 
-    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(caster.hp).toBe(500) // clamped to maxHp
   })
 
@@ -311,7 +315,7 @@ describe('executeSkill — aura-heal', () => {
     heroes.set('ally-1', ally)
 
     // Click near dead ally — dead allies are excluded from target resolution
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).not.toBeNull()
     expect(ally.hp).toBe(0) // not healed
     expect(caster.hp).toBe(500) // self-heal fallback, but already full
@@ -326,7 +330,7 @@ describe('executeSkill — aura-heal', () => {
     heroes.set('caster-1', caster)
     heroes.set('enemy-1', enemy)
 
-    executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(enemy.hp).toBe(200) // not healed
     expect(caster.hp).toBe(420) // self-heal fallback
   })
@@ -336,7 +340,7 @@ describe('executeSkill — aura-heal', () => {
     const heroes = new MapSchema<HeroSchema>()
     heroes.set('caster-1', caster)
 
-    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(caster.cooldownQ).toBe(10)
   })
 })
@@ -376,7 +380,7 @@ describe('executeSkill — aura-haste', () => {
     heroes.set('caster-1', caster)
     heroes.set('ally-1', ally)
 
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 300, y: 100 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 300, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).not.toBeNull()
     expect(event!.skillId).toBe('aura-haste')
 
@@ -392,7 +396,7 @@ describe('executeSkill — aura-haste', () => {
     const heroes = new MapSchema<HeroSchema>()
     heroes.set('caster-1', caster)
 
-    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
 
     const effect = caster.statusEffects.get('aura-haste')
     expect(effect).toBeDefined()
@@ -404,7 +408,7 @@ describe('executeSkill — aura-haste', () => {
     const heroes = new MapSchema<HeroSchema>()
     heroes.set('caster-1', caster)
 
-    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(caster.cooldownQ).toBe(12)
   })
 })
@@ -530,7 +534,7 @@ describe('executeSkill — aura-weaken', () => {
     heroes.set('caster-1', caster)
     heroes.set('enemy-1', enemy)
 
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 300, y: 100 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 300, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).not.toBeNull()
     expect(event!.skillId).toBe('aura-weaken')
 
@@ -551,7 +555,7 @@ describe('executeSkill — aura-weaken', () => {
     heroes.set('enemy-1', enemy)
 
     // Click near caster — distance from click (100,100) to enemy (800,100) = 700 > range 500
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).toBeNull()
     expect(caster.cooldownQ).toBe(0) // CD not consumed
   })
@@ -564,7 +568,7 @@ describe('executeSkill — aura-weaken', () => {
     heroes.set('caster-1', caster)
     heroes.set('ally-1', ally)
 
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).toBeNull()
     expect(caster.cooldownQ).toBe(0)
   })
@@ -577,7 +581,7 @@ describe('executeSkill — aura-weaken', () => {
     heroes.set('caster-1', caster)
     heroes.set('enemy-1', enemy)
 
-    executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(caster.cooldownQ).toBe(14)
   })
 
@@ -589,7 +593,7 @@ describe('executeSkill — aura-weaken', () => {
     heroes.set('caster-1', caster)
     heroes.set('enemy-1', enemy)
 
-    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, undefined, heroes)
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 200, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
     expect(event).toBeNull()
     expect(caster.cooldownQ).toBe(0)
   })

--- a/server/src/game/ProjectileTracker.ts
+++ b/server/src/game/ProjectileTracker.ts
@@ -1,0 +1,47 @@
+/**
+ * Per-room projectile state tracker.
+ * Encapsulates all mutable state that was previously module-level singletons.
+ * Each GameRoom creates its own instance to prevent cross-room contamination.
+ */
+export class ProjectileTracker {
+  private combatCounter = 0
+  private skillCounter = 0
+  private towerCounter = 0
+
+  private readonly distanceTraveled = new Map<string, number>()
+  private readonly hitEntityIds = new Map<string, Set<string>>()
+
+  nextCombatProjectileId(): string {
+    return `proj-${++this.combatCounter}`
+  }
+
+  nextSkillProjectileId(): string {
+    return `skill-proj-${++this.skillCounter}`
+  }
+
+  nextTowerProjectileId(): string {
+    return `tower-proj-${++this.towerCounter}`
+  }
+
+  getDistanceTraveled(projId: string): number {
+    return this.distanceTraveled.get(projId) ?? 0
+  }
+
+  setDistanceTraveled(projId: string, value: number): void {
+    this.distanceTraveled.set(projId, value)
+  }
+
+  getHitSet(projId: string): Set<string> {
+    let set = this.hitEntityIds.get(projId)
+    if (!set) {
+      set = new Set()
+      this.hitEntityIds.set(projId, set)
+    }
+    return set
+  }
+
+  cleanupTracking(projId: string): void {
+    this.distanceTraveled.delete(projId)
+    this.hitEntityIds.delete(projId)
+  }
+}

--- a/server/src/game/ServerCombatManager.ts
+++ b/server/src/game/ServerCombatManager.ts
@@ -10,12 +10,7 @@ import type { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import type { InputMessage, CombatEventMessage } from '@shared/messages'
 import { applyDamageToTarget } from './combatUtils.js'
 import { getEffectiveStat } from './StatusEffectSystem.js'
-
-let projectileIdCounter = 0
-
-export function resetProjectileIdCounter(): void {
-  projectileIdCounter = 0
-}
+import type { ProjectileTracker } from './ProjectileTracker.js'
 
 interface CombatTarget {
   id: string
@@ -58,6 +53,7 @@ export function processHeroCombat(
   projectiles: MapSchema<ProjectileSchema>,
   ProjectileSchemaClass: new () => ProjectileSchema,
   deltaTime: number,
+  tracker: ProjectileTracker,
   minions?: MapSchema<MinionSchema>,
 ): CombatEventMessage[] {
   const events: CombatEventMessage[] = []
@@ -150,7 +146,7 @@ export function processHeroCombat(
     } else {
       // Ranged: spawn projectile
       const proj = new ProjectileSchemaClass()
-      proj.id = `proj-${++projectileIdCounter}`
+      proj.id = tracker.nextCombatProjectileId()
       proj.x = hero.x
       proj.y = hero.y
       proj.targetX = target.x

--- a/server/src/game/ServerProjectileSystem.ts
+++ b/server/src/game/ServerProjectileSystem.ts
@@ -5,6 +5,7 @@ import type { TowerSchema } from '../schema/TowerSchema.js'
 import type { MinionSchema } from '../schema/MinionSchema.js'
 import type { CombatEventMessage } from '@shared/messages'
 import { applyDamageToTarget } from './combatUtils.js'
+import type { ProjectileTracker } from './ProjectileTracker.js'
 
 interface TargetPosition {
   readonly x: number
@@ -35,28 +36,6 @@ function distanceSq(x1: number, y1: number, x2: number, y2: number): number {
   const dx = x2 - x1
   const dy = y2 - y1
   return dx * dx + dy * dy
-}
-
-// ── Server-side tracking for linear projectiles ────────────
-/** Cumulative distance traveled by each linear projectile */
-const distanceTraveled = new Map<string, number>()
-/** Set of entity IDs already hit by each piercing projectile */
-const hitEntityIds = new Map<string, Set<string>>()
-
-/** Clean up tracking data for a removed projectile */
-function cleanupProjectileTracking(projId: string): void {
-  distanceTraveled.delete(projId)
-  hitEntityIds.delete(projId)
-}
-
-/** Get or create the hit set for a piercing projectile */
-function getHitSet(projId: string): Set<string> {
-  let set = hitEntityIds.get(projId)
-  if (!set) {
-    set = new Set()
-    hitEntityIds.set(projId, set)
-  }
-  return set
 }
 
 // ── Homing projectile logic (existing behavior) ────────────
@@ -159,6 +138,7 @@ function processLinearProjectile(
   minions: MapSchema<MinionSchema> | undefined,
   events: CombatEventMessage[],
   toRemove: string[],
+  tracker: ProjectileTracker,
 ): void {
   // Move in direction
   const moveDistance = proj.speed * deltaTime
@@ -166,8 +146,8 @@ function processLinearProjectile(
   proj.y = proj.y + proj.dirY * moveDistance
 
   // Track cumulative distance
-  const traveled = (distanceTraveled.get(projId) ?? 0) + moveDistance
-  distanceTraveled.set(projId, traveled)
+  const traveled = tracker.getDistanceTraveled(projId) + moveDistance
+  tracker.setDistanceTraveled(projId, traveled)
 
   // Range check
   if (proj.maxRange > 0 && traveled >= proj.maxRange) {
@@ -176,7 +156,7 @@ function processLinearProjectile(
   }
 
   // Collision with all enemy entities
-  const hitSet = getHitSet(projId)
+  const hitSet = tracker.getHitSet(projId)
   const enemies = collectEnemyEntities(proj.team, heroes, towers, minions)
 
   for (const enemy of enemies) {
@@ -216,6 +196,7 @@ export function processProjectiles(
   heroes: MapSchema<HeroSchema>,
   towers: MapSchema<TowerSchema>,
   deltaTime: number,
+  tracker: ProjectileTracker,
   minions?: MapSchema<MinionSchema>,
 ): CombatEventMessage[] {
   const events: CombatEventMessage[] = []
@@ -223,7 +204,7 @@ export function processProjectiles(
 
   projectiles.forEach((proj, projId) => {
     if (proj.mode === 'linear') {
-      processLinearProjectile(proj, projId, heroes, towers, deltaTime, minions, events, toRemove)
+      processLinearProjectile(proj, projId, heroes, towers, deltaTime, minions, events, toRemove, tracker)
     } else {
       processHomingProjectile(proj, projId, heroes, towers, deltaTime, minions, events, toRemove)
     }
@@ -231,14 +212,8 @@ export function processProjectiles(
 
   for (const id of toRemove) {
     projectiles.delete(id)
-    cleanupProjectileTracking(id)
+    tracker.cleanupTracking(id)
   }
 
   return events
-}
-
-/** Reset server-side tracking maps. For testing only. */
-export function resetProjectileTracking(): void {
-  distanceTraveled.clear()
-  hitEntityIds.clear()
 }

--- a/server/src/game/ServerSkillExecutionSystem.ts
+++ b/server/src/game/ServerSkillExecutionSystem.ts
@@ -5,6 +5,7 @@ import type { SkillEvent } from '@shared/messages'
 import { getSkillDefinition } from '@shared/skills/skillDefinitions'
 import { getEffectHandler } from './skills/skillEffectRegistry.js'
 import { createServerLogger } from '@shared/logging'
+import type { ProjectileTracker } from './ProjectileTracker.js'
 
 const logger = createServerLogger('skill')
 
@@ -85,8 +86,9 @@ export function executeSkill(
   sessionId: string,
   slot: SkillSlot,
   target: { x: number; y: number },
-  projectiles?: MapSchema<ProjectileSchema>,
-  heroes?: MapSchema<HeroSchema>,
+  projectiles: MapSchema<ProjectileSchema>,
+  heroes: MapSchema<HeroSchema>,
+  tracker: ProjectileTracker,
 ): SkillEvent | null {
   // Validation: hero must be alive
   if (hero.dead) return null
@@ -135,8 +137,9 @@ export function executeSkill(
       skillId,
       direction,
       targetPosition: target,
-      projectiles: projectiles ?? new MapSchema(),
-      heroes: heroes ?? new MapSchema(),
+      projectiles,
+      heroes,
+      projectileTracker: tracker,
       targetHero,
     },
     def.effect,

--- a/server/src/game/ServerTowerSystem.ts
+++ b/server/src/game/ServerTowerSystem.ts
@@ -5,12 +5,7 @@ import type { TowerSchema } from '../schema/TowerSchema.js'
 import type { MinionSchema } from '../schema/MinionSchema.js'
 import type { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import type { CombatEventMessage } from '@shared/messages'
-
-let towerProjectileIdCounter = 0
-
-export function resetTowerProjectileIdCounter(): void {
-  towerProjectileIdCounter = 0
-}
+import type { ProjectileTracker } from './ProjectileTracker.js'
 
 /**
  * Select the nearest alive enemy (minion or hero) within the tower's attack range.
@@ -104,6 +99,7 @@ export function processTowerCombat(
   projectiles: MapSchema<ProjectileSchema>,
   ProjectileSchemaClass: new () => ProjectileSchema,
   deltaTime: number,
+  tracker: ProjectileTracker,
   minions?: MapSchema<MinionSchema>,
 ): CombatEventMessage[] {
   const events: CombatEventMessage[] = []
@@ -134,7 +130,7 @@ export function processTowerCombat(
 
     // Towers always use projectiles
     const proj = new ProjectileSchemaClass()
-    proj.id = `tower-proj-${++towerProjectileIdCounter}`
+    proj.id = tracker.nextTowerProjectileId()
     proj.x = tower.x
     proj.y = tower.y
     proj.targetX = target.x

--- a/server/src/game/skills/SkillEffectHandler.ts
+++ b/server/src/game/skills/SkillEffectHandler.ts
@@ -2,6 +2,7 @@ import type { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../../schema/HeroSchema.js'
 import type { ProjectileSchema } from '../../schema/ProjectileSchema.js'
 import type { SkillEffectParams } from '@shared/skills/skillDefinitions'
+import type { ProjectileTracker } from '../../game/ProjectileTracker.js'
 
 /** Context passed to every effect handler at execution time. */
 export interface SkillExecutionContext {
@@ -12,6 +13,7 @@ export interface SkillExecutionContext {
   readonly targetPosition: { readonly x: number; readonly y: number }
   readonly projectiles: MapSchema<ProjectileSchema>
   readonly heroes: MapSchema<HeroSchema>
+  readonly projectileTracker: ProjectileTracker
   /** Resolved target for ally/enemy-targeting skills. */
   readonly targetHero?: HeroSchema
 }

--- a/server/src/game/skills/handlers/projectileEffectHandler.ts
+++ b/server/src/game/skills/handlers/projectileEffectHandler.ts
@@ -2,19 +2,13 @@ import { ProjectileSchema } from '../../../schema/ProjectileSchema.js'
 import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
 import type { ProjectileEffectParams } from '@shared/skills/skillDefinitions'
 
-let skillProjectileIdCounter = 0
-
-export function resetSkillProjectileIdCounter(): void {
-  skillProjectileIdCounter = 0
-}
-
 export const projectileEffectHandler: SkillEffectHandler<ProjectileEffectParams> = {
   effectType: 'projectile',
   execute(ctx: SkillExecutionContext, params: ProjectileEffectParams): void {
-    const { hero, casterId, direction, projectiles } = ctx
+    const { hero, casterId, direction, projectiles, projectileTracker } = ctx
 
     const proj = new ProjectileSchema()
-    proj.id = `skill-proj-${++skillProjectileIdCounter}`
+    proj.id = projectileTracker.nextSkillProjectileId()
     proj.x = hero.x
     proj.y = hero.y
     proj.speed = params.speed

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -9,9 +9,10 @@ import { WORLD_WIDTH, WORLD_HEIGHT, MINION_WAVE_INTERVAL } from '@shared/constan
 import type { HeroType } from '@shared/types'
 import type { InputMessage, CombatEventMessage } from '@shared/messages'
 import { processMovement } from '../game/ServerMovementSystem.js'
-import { processHeroCombat, resetProjectileIdCounter } from '../game/ServerCombatManager.js'
+import { processHeroCombat } from '../game/ServerCombatManager.js'
 import { processProjectiles } from '../game/ServerProjectileSystem.js'
-import { processTowerCombat, resetTowerProjectileIdCounter } from '../game/ServerTowerSystem.js'
+import { processTowerCombat } from '../game/ServerTowerSystem.js'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
 import { processDeathAndRespawn } from '../game/ServerDeathSystem.js'
 import { isHeroInBase, processBaseRegen } from '../game/ServerBaseRegenSystem.js'
 import { checkTowerDestroyed, endMatch, endMatchByDisconnect } from '../game/ServerMatchSystem.js'
@@ -113,6 +114,7 @@ export class GameRoom extends Room<GameRoomState> {
   private playerInputs = new Map<string, InputMessage>()
   private nextWaveTime = MINION_WAVE_INTERVAL
   private minionCtx = createMinionSystemContext()
+  private projectileTracker = new ProjectileTracker()
   private isSoloMode = false
   private dashHitSets = new Map<string, Set<string>>()
 
@@ -178,7 +180,7 @@ export class GameRoom extends Room<GameRoomState> {
       if (!isValidUseSkillMessage(message)) return
       const hero = this.state.heroes.get(client.sessionId)
       if (!hero) return
-      const event = executeSkill(hero, client.sessionId, message.slot, message.target, this.state.projectiles, this.state.heroes)
+      const event = executeSkill(hero, client.sessionId, message.slot, message.target, this.state.projectiles, this.state.heroes, this.projectileTracker)
       if (event) {
         this.broadcast('skill', event)
       }
@@ -301,9 +303,6 @@ export class GameRoom extends Room<GameRoomState> {
 
   onDispose(): void {
     logger.info('Room disposed', { roomId: this.roomId })
-    resetProjectileIdCounter()
-    resetTowerProjectileIdCounter()
-    this.minionCtx = createMinionSystemContext()
   }
 
   private setupTowers(): void {
@@ -381,6 +380,7 @@ export class GameRoom extends Room<GameRoomState> {
         projectiles,
         ProjectileSchema,
         deltaTime,
+        this.projectileTracker,
         minions,
       )
       events.push(...heroEvents)
@@ -434,13 +434,14 @@ export class GameRoom extends Room<GameRoomState> {
         projectiles,
         ProjectileSchema,
         deltaTime,
+        this.projectileTracker,
         minions,
       )
       events.push(...towerEvents)
     })
 
     // 4. Process projectiles
-    const projectileEvents = processProjectiles(projectiles, heroes, towers, deltaTime, minions)
+    const projectileEvents = processProjectiles(projectiles, heroes, towers, deltaTime, this.projectileTracker, minions)
     events.push(...projectileEvents)
 
     // 5. Minion death + XP distribution


### PR DESCRIPTION
## Summary
- Replace module-level projectile counters and tracking maps with per-room `ProjectileTracker` class (#221)
- Each `GameRoom` creates its own instance, preventing shared mutable state across Colyseus rooms
- Thread tracker through all system call chains (`ServerCombatManager`, `ServerTowerSystem`, `ServerProjectileSystem`, `ServerSkillExecutionSystem`, `projectileEffectHandler`)

## Test plan
- [x] 818 unit tests passing (12 new `ProjectileTracker` tests)
- [x] TypeScript compilation clean
- [x] Lint clean
- [x] Verified independent counter/tracking state per `ProjectileTracker` instance

Closes #221