### PR TITLE
refactor: extract distanceSq to shared/math utility

### DIFF
--- a/server/src/game/ServerBotSystem.ts
+++ b/server/src/game/ServerBotSystem.ts
@@ -3,6 +3,7 @@ import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { TowerSchema } from '../schema/TowerSchema.js'
 import type { MinionSchema } from '../schema/MinionSchema.js'
 import type { InputMessage } from '@shared/messages'
+import { distanceSq } from '@shared/math/distanceSq'
 
 interface PositionEntity {
   readonly id: string
@@ -11,12 +12,6 @@ interface PositionEntity {
   readonly dead: boolean
   readonly team: string
   readonly radius: number
-}
-
-function distanceSq(ax: number, ay: number, bx: number, by: number): number {
-  const dx = ax - bx
-  const dy = ay - by
-  return dx * dx + dy * dy
 }
 
 /**

--- a/server/src/game/ServerProjectileSystem.ts
+++ b/server/src/game/ServerProjectileSystem.ts
@@ -6,6 +6,7 @@ import type { MinionSchema } from '../schema/MinionSchema.js'
 import type { CombatEventMessage } from '@shared/messages'
 import { applyDamageToTarget } from './combatUtils.js'
 import type { ProjectileTracker } from './ProjectileTracker.js'
+import { distanceSq } from '@shared/math/distanceSq'
 
 interface TargetPosition {
   readonly x: number
@@ -30,12 +31,6 @@ function findTargetPosition(
     if (minion) return { x: minion.x, y: minion.y, radius: minion.radius, dead: minion.dead, team: minion.team }
   }
   return null
-}
-
-function distanceSq(x1: number, y1: number, x2: number, y2: number): number {
-  const dx = x2 - x1
-  const dy = y2 - y1
-  return dx * dx + dy * dy
 }
 
 // ── Homing projectile logic (existing behavior) ────────────

--- a/server/src/game/ServerZoneSystem.ts
+++ b/server/src/game/ServerZoneSystem.ts
@@ -2,15 +2,10 @@ import type { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { ZoneSchema } from '../schema/ZoneSchema.js'
 import { StatusEffectSchema } from '../schema/StatusEffectSchema.js'
+import { distanceSq } from '@shared/math/distanceSq'
 
 /** Duration set on zone-applied status effects. Short so they expire quickly when leaving the zone. */
 export const ZONE_EFFECT_DURATION = 0.1
-
-function distanceSq(x1: number, y1: number, x2: number, y2: number): number {
-  const dx = x2 - x1
-  const dy = y2 - y1
-  return dx * dx + dy * dy
-}
 
 function shouldAffect(zone: ZoneSchema, hero: HeroSchema): boolean {
   if (zone.target === 'enemy') return hero.team !== zone.team

--- a/server/src/game/skills/handlers/aoeEffectHandler.ts
+++ b/server/src/game/skills/handlers/aoeEffectHandler.ts
@@ -1,11 +1,6 @@
 import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
 import type { AoEEffectParams } from '@shared/skills/skillDefinitions'
-
-function distanceSq(x1: number, y1: number, x2: number, y2: number): number {
-  const dx = x2 - x1
-  const dy = y2 - y1
-  return dx * dx + dy * dy
-}
+import { distanceSq } from '@shared/math/distanceSq'
 
 export const aoeEffectHandler: SkillEffectHandler<AoEEffectParams> = {
   effectType: 'aoe',

--- a/shared/math/distanceSq.test.ts
+++ b/shared/math/distanceSq.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { distanceSq } from './distanceSq'
+
+describe('distanceSq', () => {
+  it('should return 0 for the same point', () => {
+    expect(distanceSq(5, 10, 5, 10)).toBe(0)
+  })
+
+  it('should return squared distance for horizontal displacement', () => {
+    expect(distanceSq(0, 0, 3, 0)).toBe(9)
+  })
+
+  it('should return squared distance for vertical displacement', () => {
+    expect(distanceSq(0, 0, 0, 4)).toBe(16)
+  })
+
+  it('should return squared distance for diagonal (3-4-5 triangle)', () => {
+    expect(distanceSq(0, 0, 3, 4)).toBe(25)
+  })
+
+  it('should be commutative', () => {
+    expect(distanceSq(1, 2, 5, 8)).toBe(distanceSq(5, 8, 1, 2))
+  })
+
+  it('should handle negative coordinates', () => {
+    expect(distanceSq(-3, -4, 0, 0)).toBe(25)
+  })
+})

--- a/shared/math/distanceSq.ts
+++ b/shared/math/distanceSq.ts
@@ -1,0 +1,14 @@
+/**
+ * Squared Euclidean distance between two points.
+ * Avoids Math.sqrt for cheaper distance comparisons.
+ */
+export function distanceSq(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): number {
+  const dx = x2 - x1
+  const dy = y2 - y1
+  return dx * dx + dy * dy
+}

--- a/src/domain/systems/minionXpDistribution.ts
+++ b/src/domain/systems/minionXpDistribution.ts
@@ -2,12 +2,7 @@ import type { HeroState } from '@shared/entities/Hero'
 import type { Position, Team } from '@/domain/types'
 import { MINION_XP_REWARD, XP_GRANT_RANGE } from '@shared/constants'
 import { grantXp } from '@/domain/systems/grantXp'
-
-function distanceSq(a: Position, b: Position): number {
-  const dx = a.x - b.x
-  const dy = a.y - b.y
-  return dx * dx + dy * dy
-}
+import { distanceSq } from '@shared/math/distanceSq'
 
 export interface XpUpdate {
   readonly heroId: string
@@ -23,7 +18,7 @@ export function distributeMinionXp(
   const allyTeam = minionTeam === 'blue' ? 'red' : 'blue'
 
   const eligibleHeroes = heroes.filter(
-    (h) => !h.dead && h.team === allyTeam && distanceSq(h.position, deathPosition) <= rangeSq,
+    (h) => !h.dead && h.team === allyTeam && distanceSq(h.position.x, h.position.y, deathPosition.x, deathPosition.y) <= rangeSq,
   )
 
   if (eligibleHeroes.length === 0) return []


### PR DESCRIPTION
## Summary
- Extract 5 duplicate `distanceSq` definitions into `shared/math/distanceSq.ts`
- Update all call sites: ServerProjectileSystem, ServerBotSystem, aoeEffectHandler, ServerZoneSystem, minionXpDistribution
- Add unit tests for the shared utility

Closes #228

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 866 tests passing (includes 6 new distanceSq tests)

Generated with [Claude Code](https://claude.com/claude-code)