### PR TITLE
feat: add BLADE Fortify skill with damage reduction mechanic

### DIFF
--- a/openspec/changes/archive/2026-03-10-blade-fortify/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-10-blade-fortify/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/archive/2026-03-10-blade-fortify/design.md
+++ b/openspec/changes/archive/2026-03-10-blade-fortify/design.md
@@ -1,0 +1,59 @@
+## Technical Approach
+
+Fortify is a self-cast buff that reduces incoming damage by 30% for 4 seconds. It reuses the existing StatusEffect system (same pattern as aura-haste, aura-weaken).
+
+### Key Decision: Damage Reduction via StatusEffect
+
+The `damageReduction` buffType stores a fractional reduction value (e.g., 0.3 = 30%). HeroSchema overrides `applyDamage` to consult this effect before subtracting HP.
+
+**Why override in HeroSchema instead of CombatEntitySchema:**
+- Only heroes have `statusEffects` (MapSchema)
+- Towers/minions don't need damage reduction
+- Keeps CombatEntitySchema simple
+
+### Skill Definition
+
+```typescript
+'blade-fortify': {
+  id: 'blade-fortify',
+  targeting: 'self',
+  cooldown: 14,
+  effect: {
+    effectType: 'buff',
+    buffType: 'damageReduction',
+    value: 0.3,           // 30% reduction
+    duration: 4,
+    isDebuff: false,
+  },
+}
+```
+
+### Talent Tree Change
+
+The existing `blade-fortify` node (Depth 3, Cost 2) changes from `stat_modifier` (HP+120) to `grant_skill`. The HP bonus is redistributed to maintain tree balance — `blade-iron-will` is nearby and provides HP.
+
+### Damage Reduction Flow
+
+```
+attacker.applyDamage(hero, amount)
+  → HeroSchema.applyDamage(amount)
+    → check statusEffects for 'damageReduction'
+    → reducedAmount = amount * (1 - reductionValue)
+    → super.applyDamage(reducedAmount)
+```
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `shared/skills/skillDefinitions.ts` | Add `blade-fortify` definition |
+| `shared/talents/bladeTalents.ts` | Change node from stat_modifier to grant_skill |
+| `server/src/schema/HeroSchema.ts` | Override `applyDamage` to apply damageReduction |
+| `server/src/game/StatusEffectSystem.ts` | No change needed (getStatusEffectValue already generic) |
+| `server/src/game/skills/handlers/buffEffectHandler.ts` | No change needed (handles all buff types) |
+
+### Tests
+
+- HeroSchema: `applyDamage` with/without damageReduction status effect
+- Skill execution: blade-fortify applies buff to self
+- Talent tree integrity: existing tests validate structure automatically

--- a/openspec/changes/archive/2026-03-10-blade-fortify/proposal.md
+++ b/openspec/changes/archive/2026-03-10-blade-fortify/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+BLADE has no defensive skill. Fortify adds a self-cast damage reduction buff, giving BLADE survivability in fights. This rounds out the hero's toolkit and is a straightforward buff using the existing StatusEffect system.
+
+## What Changes
+
+- Add `blade-fortify` skill definition to `shared/skills/skillDefinitions.ts`
+- Override `applyDamage` in `HeroSchema` to apply `damageReduction` status effect
+- Add skill to BLADE's talent tree
+- Add tests for damage reduction logic
+
+## Capabilities
+
+### New Capabilities
+- `blade-fortify`: Self-cast buff that reduces incoming damage by a percentage for a duration
+
+### Modified Capabilities
+- `skill-execution`: HeroSchema.applyDamage must consult damageReduction status effects before applying damage
+
+## Impact
+
+- `server/src/schema/HeroSchema.ts` — override applyDamage to check damageReduction buff
+- `shared/skills/skillDefinitions.ts` — new skill entry
+- `shared/talents/` — BLADE talent tree entry for Fortify
+- No client changes needed (buff rendering uses existing StatusEffect sync)
+
+## Non-goals
+
+- Fortify does not block/parry specific attacks (flat percentage reduction only)
+- No visual shield effect on client (future enhancement)
+- No stacking with other damage reduction sources (single buff, refreshes on recast)

--- a/openspec/changes/archive/2026-03-10-blade-fortify/specs/blade-fortify/spec.md
+++ b/openspec/changes/archive/2026-03-10-blade-fortify/specs/blade-fortify/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Fortify skill definition
+The system SHALL define `blade-fortify` as a self-targeting buff skill with cooldown 14s, applying `damageReduction` buffType with value 0.3 (30%) for 4 seconds.
+
+#### Scenario: Fortify activation
+- **WHEN** a BLADE hero activates Fortify
+- **THEN** a `damageReduction` status effect SHALL be applied to the caster with value 0.3 and duration 4s
+
+#### Scenario: Fortify refresh
+- **WHEN** Fortify is activated while an existing Fortify buff is active
+- **THEN** the buff duration SHALL be refreshed to 4s (not stacked)
+
+### Requirement: Damage reduction mechanic
+HeroSchema.applyDamage SHALL consult `damageReduction` status effects and reduce incoming damage accordingly.
+
+#### Scenario: Damage with active Fortify
+- **WHEN** a hero with 30% damageReduction takes 100 damage
+- **THEN** the hero SHALL receive 70 damage (100 * (1 - 0.3))
+
+#### Scenario: Damage without Fortify
+- **WHEN** a hero with no damageReduction takes 100 damage
+- **THEN** the hero SHALL receive 100 damage (unchanged)
+
+#### Scenario: Damage reduction expires
+- **WHEN** the Fortify buff expires
+- **THEN** subsequent damage SHALL be applied at full value
+
+### Requirement: Talent tree integration
+The `blade-fortify` talent node SHALL grant the Fortify skill (grant_skill) instead of a stat modifier.
+
+#### Scenario: Talent unlocks skill
+- **WHEN** a BLADE hero selects the Fortify talent
+- **THEN** `blade-fortify` SHALL appear in the hero's skill slots
+
+## MODIFIED Requirements
+
+### Modified: skill-execution
+The skill execution system already handles `buff` effectType via `buffEffectHandler`. No behavioral changes required — `blade-fortify` uses the existing buff pipeline with a new `buffType: 'damageReduction'`.

--- a/openspec/changes/archive/2026-03-10-blade-fortify/tasks.md
+++ b/openspec/changes/archive/2026-03-10-blade-fortify/tasks.md
@@ -1,0 +1,11 @@
+## Tasks
+
+### Backend
+- [x] Add `blade-fortify` skill definition to `shared/skills/skillDefinitions.ts`
+- [x] Override `applyDamage` in `HeroSchema` to apply `damageReduction` from status effects
+- [x] Update `blade-fortify` talent node in `bladeTalents.ts` from `stat_modifier` to `grant_skill`
+- [x] Add tests for HeroSchema.applyDamage with damageReduction
+- [x] Add test for blade-fortify skill execution (buff applied to self)
+
+### Frontend
+- [x] No client changes needed (StatusEffect sync already handles buff display)

--- a/openspec/specs/blade-fortify/spec.md
+++ b/openspec/specs/blade-fortify/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Fortify skill definition
+The system SHALL define `blade-fortify` as a self-targeting buff skill with cooldown 14s, applying `damageReduction` buffType with value 0.3 (30%) for 4 seconds.
+
+#### Scenario: Fortify activation
+- **WHEN** a BLADE hero activates Fortify
+- **THEN** a `damageReduction` status effect SHALL be applied to the caster with value 0.3 and duration 4s
+
+#### Scenario: Fortify refresh
+- **WHEN** Fortify is activated while an existing Fortify buff is active
+- **THEN** the buff duration SHALL be refreshed to 4s (not stacked)
+
+### Requirement: Damage reduction mechanic
+HeroSchema.applyDamage SHALL consult `damageReduction` status effects and reduce incoming damage accordingly.
+
+#### Scenario: Damage with active Fortify
+- **WHEN** a hero with 30% damageReduction takes 100 damage
+- **THEN** the hero SHALL receive 70 damage (100 * (1 - 0.3))
+
+#### Scenario: Damage without Fortify
+- **WHEN** a hero with no damageReduction takes 100 damage
+- **THEN** the hero SHALL receive 100 damage (unchanged)
+
+#### Scenario: Damage reduction expires
+- **WHEN** the Fortify buff expires
+- **THEN** subsequent damage SHALL be applied at full value
+
+### Requirement: Talent tree integration
+The `blade-fortify` talent node SHALL grant the Fortify skill (grant_skill) instead of a stat modifier.
+
+#### Scenario: Talent unlocks skill
+- **WHEN** a BLADE hero selects the Fortify talent
+- **THEN** `blade-fortify` SHALL appear in the hero's skill slots
+
+## MODIFIED Requirements
+
+### Modified: skill-execution
+The skill execution system already handles `buff` effectType via `buffEffectHandler`. No behavioral changes required — `blade-fortify` uses the existing buff pipeline with a new `buffType: 'damageReduction'`.

--- a/server/src/__tests__/HeroSchema.test.ts
+++ b/server/src/__tests__/HeroSchema.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { ArraySchema } from '@colyseus/schema'
 import { HeroSchema } from '../schema/HeroSchema.js'
+import { StatusEffectSchema } from '../schema/StatusEffectSchema.js'
 
 describe('HeroSchema — talent fields', () => {
   it('should initialize acquiredTalents as empty ArraySchema', () => {
@@ -54,5 +55,68 @@ describe('HeroSchema — talent fields', () => {
     expect(hero.skillSlotQ).toBe('blade-charge')
     expect(hero.skillSlotE).toBe('blade-cleave')
     expect(hero.skillSlotR).toBe('')
+  })
+})
+
+describe('HeroSchema — applyDamage with damageReduction', () => {
+  function createHero(hp: number): HeroSchema {
+    const hero = new HeroSchema()
+    hero.hp = hp
+    hero.maxHp = hp
+    return hero
+  }
+
+  function addDamageReduction(hero: HeroSchema, value: number): void {
+    const effect = new StatusEffectSchema()
+    effect.id = 'blade-fortify'
+    effect.buffType = 'damageReduction'
+    effect.value = value
+    effect.remainingDuration = 4
+    effect.isDebuff = false
+    hero.statusEffects.set('blade-fortify', effect)
+  }
+
+  it('should apply full damage without damageReduction', () => {
+    const hero = createHero(500)
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(400)
+  })
+
+  it('should reduce damage by 30% with 0.3 damageReduction', () => {
+    const hero = createHero(500)
+    addDamageReduction(hero, 0.3)
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(430)
+  })
+
+  it('should reduce damage by 50% with 0.5 damageReduction', () => {
+    const hero = createHero(500)
+    addDamageReduction(hero, 0.5)
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(450)
+  })
+
+  it('should clamp damageReduction to 100% max', () => {
+    const hero = createHero(500)
+    addDamageReduction(hero, 1.5)
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(500)
+  })
+
+  it('should still set dead flag when reduced damage kills', () => {
+    const hero = createHero(50)
+    addDamageReduction(hero, 0.3)
+    hero.applyDamage(100)
+    // 100 * 0.7 = 70 damage, 50 - 70 = -20 → clamped to 0
+    expect(hero.hp).toBe(0)
+    expect(hero.dead).toBe(true)
+  })
+
+  it('should not apply reduction when hero is dead', () => {
+    const hero = createHero(500)
+    hero.dead = true
+    addDamageReduction(hero, 0.3)
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(500) // no change — dead heroes ignore damage
   })
 })

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -599,6 +599,70 @@ describe('executeSkill — aura-weaken', () => {
   })
 })
 
+describe('executeSkill — blade-fortify', () => {
+  function createFortifyHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+    return createHero({
+      heroType: 'BLADE',
+      team: 'blue',
+      hp: 650,
+      maxHp: 650,
+      skillSlotQ: 'blade-fortify',
+      ...overrides,
+    })
+  }
+
+  it('should apply damageReduction buff to self', () => {
+    const caster = createFortifyHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('blade-fortify')
+
+    const effect = caster.statusEffects.get('blade-fortify')
+    expect(effect).toBeDefined()
+    expect(effect!.buffType).toBe('damageReduction')
+    expect(effect!.value).toBe(0.3)
+    expect(effect!.remainingDuration).toBe(4)
+    expect(effect!.isDebuff).toBe(false)
+  })
+
+  it('should set cooldown to 14 seconds', () => {
+    const caster = createFortifyHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(caster.cooldownQ).toBe(14)
+  })
+
+  it('should refresh duration on recast', () => {
+    const caster = createFortifyHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    const effect = caster.statusEffects.get('blade-fortify')!
+    effect.remainingDuration = 1 // simulate time passing
+
+    caster.cooldownQ = 0 // reset CD for recast
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(caster.statusEffects.get('blade-fortify')!.remainingDuration).toBe(4)
+  })
+
+  it('should actually reduce damage taken while active', () => {
+    const caster = createFortifyHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    caster.applyDamage(100)
+    // 100 * (1 - 0.3) = 70 damage → 650 - 70 = 580
+    expect(caster.hp).toBe(580)
+  })
+})
+
 describe('tickCooldowns', () => {
   it('should decrement cooldowns by dt', () => {
     const hero = createHero()

--- a/server/src/game/ServerSkillExecutionSystem.ts
+++ b/server/src/game/ServerSkillExecutionSystem.ts
@@ -115,7 +115,9 @@ export function executeSkill(
   // Resolve target hero for ally/enemy targeting
   let targetHero: HeroSchema | undefined
   const range = def.range ?? 0
-  if (def.targeting === 'ally' && heroes) {
+  if (def.targeting === 'self') {
+    targetHero = hero
+  } else if (def.targeting === 'ally' && heroes) {
     const allyFilter = (c: HeroSchema, sid: string) => sid !== sessionId && c.team === hero.team && !c.dead
     targetHero = resolveHeroTarget(target, heroes, range, allyFilter) ?? hero
   } else if (def.targeting === 'enemy' && heroes) {

--- a/server/src/schema/HeroSchema.ts
+++ b/server/src/schema/HeroSchema.ts
@@ -46,6 +46,7 @@ export class HeroSchema extends CombatEntitySchema {
    * damageReduction value is a fraction (e.g. 0.3 = 30% reduction).
    */
   override applyDamage(amount: number): void {
+    if (this.dead) return
     const reduction = getStatusEffectValue(this, 'damageReduction')
     const reduced = reduction > 0 ? amount * (1 - Math.min(reduction, 1)) : amount
     super.applyDamage(reduced)

--- a/server/src/schema/HeroSchema.ts
+++ b/server/src/schema/HeroSchema.ts
@@ -1,10 +1,12 @@
 import { ArraySchema, MapSchema, type } from '@colyseus/schema'
 import { CombatEntitySchema } from './CombatEntitySchema.js'
 import { StatusEffectSchema } from './StatusEffectSchema.js'
+import { getStatusEffectValue } from '../game/StatusEffectSystem.js'
 
 /**
  * Colyseus state schema for a hero entity.
- * Inherits id, x, y, hp, maxHp, dead, team, radius, applyDamage() from CombatEntitySchema.
+ * Inherits id, x, y, hp, maxHp, dead, team, radius from CombatEntitySchema.
+ * Overrides applyDamage to apply damageReduction from status effects.
  */
 export class HeroSchema extends CombatEntitySchema {
   @type('float32') facing: number = 0
@@ -38,6 +40,16 @@ export class HeroSchema extends CombatEntitySchema {
   /** Contact damage dealt during this dash (set by effect handler, 0 = no damage) */
   dashDamage: number = 0
   @type('boolean') isBot: boolean = false
+
+  /**
+   * Override to apply damageReduction status effects before subtracting HP.
+   * damageReduction value is a fraction (e.g. 0.3 = 30% reduction).
+   */
+  override applyDamage(amount: number): void {
+    const reduction = getStatusEffectValue(this, 'damageReduction')
+    const reduced = reduction > 0 ? amount * (1 - Math.min(reduction, 1)) : amount
+    super.applyDamage(reduced)
+  }
   // Server-only: not synced to clients (no @type decorator)
   lastAttackerSessionId: string = ''
   /** Brief movement pause after firing a ranged attack (seconds remaining) */

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -192,6 +192,18 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       },
     },
   },
+  'blade-fortify': {
+    id: 'blade-fortify',
+    targeting: 'self',
+    cooldown: 14,
+    effect: {
+      effectType: 'buff',
+      buffType: 'damageReduction',
+      value: 0.3,
+      duration: 4,
+      isDebuff: false,
+    },
+  },
 }
 
 export function getSkillDefinition(skillId: string): SkillDefinition | undefined {

--- a/shared/talents/bladeTalents.ts
+++ b/shared/talents/bladeTalents.ts
@@ -117,10 +117,10 @@ export const BLADE_TALENT_TREE: TalentTreeDefinition = {
     {
       id: 'blade-fortify',
       name: 'Fortify',
-      description: 'Max HP +120',
+      description: 'Unlock Fortify — reduce incoming damage',
       cost: 2,
       prerequisites: ['blade-vitality'],
-      effects: [{ type: 'stat_modifier', stat: 'maxHp', value: 120, mode: 'flat' }],
+      effects: [{ type: 'grant_skill', skillId: 'blade-fortify' }],
     },
     {
       id: 'blade-thorns',


### PR DESCRIPTION
## Summary
- Add `blade-fortify` self-cast buff skill: 30% incoming damage reduction for 4 seconds (CD 14s)
- Override `HeroSchema.applyDamage` to consult `damageReduction` status effects before applying damage
- Update `blade-fortify` talent tree node from `stat_modifier` (HP+120) to `grant_skill`
- Reuses existing StatusEffect system (same pattern as aura-haste, aura-weaken)

Closes #201

## Test plan
- [x] `npm run lint` -- clean
- [x] `npm run test:unit` -- 876 tests passing (10 new)
- [x] HeroSchema.applyDamage with/without damageReduction (6 tests)
- [x] blade-fortify skill execution: self-buff, cooldown, refresh, damage integration (4 tests)

Generated with [Claude Code](https://claude.com/claude-code)