### PR TITLE
feat: add BLADE Fury skill with multi-buff and attack speed integration

### DIFF
--- a/openspec/changes/archive/2026-03-10-blade-fury/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-10-blade-fury/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/archive/2026-03-10-blade-fury/design.md
+++ b/openspec/changes/archive/2026-03-10-blade-fury/design.md
@@ -1,0 +1,61 @@
+## Technical Approach
+
+Fury is a self-cast buff that boosts attackDamage and attackSpeed simultaneously. The existing buff system supports one buffType per skill, so we extend it with `additionalBuffs`.
+
+### Skill Definition
+
+```typescript
+'blade-fury': {
+  id: 'blade-fury',
+  targeting: 'self',
+  cooldown: 18,
+  effect: {
+    effectType: 'buff',
+    buffType: 'attackDamage',
+    value: 25,
+    duration: 5,
+    isDebuff: false,
+    additionalBuffs: [
+      { buffType: 'attackSpeed', value: 0.5 },
+    ],
+  },
+}
+```
+
+### BuffEffectParams Extension
+
+```typescript
+export interface BuffEffectParams {
+  // ... existing fields
+  readonly additionalBuffs?: readonly {
+    readonly buffType: string
+    readonly value: number
+  }[]
+}
+```
+
+### buffEffectHandler Changes
+
+After applying the primary buff (keyed by skillId), iterate `additionalBuffs` and create additional StatusEffectSchema entries keyed by `${skillId}:${buffType}`.
+
+### ServerCombatManager Change
+
+```typescript
+// Before: hero.attackCooldown = 1 / hero.attackSpeed
+// After:
+const effectiveAS = getEffectiveStat(hero.attackSpeed, hero, 'attackSpeed')
+hero.attackCooldown = 1 / effectiveAS
+```
+
+### Talent Tree
+
+`blade-fury` node (Depth 6, Cost 3) changes from `grant_skill: 'blade-fury'` — it already is a grant_skill. Verified: no change needed to talent tree.
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `shared/skills/skillDefinitions.ts` | Extend BuffEffectParams, add blade-fury |
+| `server/src/game/skills/handlers/buffEffectHandler.ts` | Apply additionalBuffs |
+| `server/src/game/ServerCombatManager.ts` | Use getEffectiveStat for attackSpeed |
+| `shared/talents/bladeTalents.ts` | Already grant_skill — no change |

--- a/openspec/changes/archive/2026-03-10-blade-fury/proposal.md
+++ b/openspec/changes/archive/2026-03-10-blade-fury/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+BLADE has no offensive steroid skill. Fury adds a self-cast buff boosting both attack damage and attack speed, enabling burst windows for aggressive plays. This requires extending BuffEffectParams to support multiple stat buffs from a single skill.
+
+## What Changes
+
+- Add `blade-fury` skill definition with dual buffs (attackDamage + attackSpeed)
+- Extend `BuffEffectParams` with optional `additionalBuffs` array
+- Update `buffEffectHandler` to apply additional buffs
+- Apply `getEffectiveStat` to attack speed in `ServerCombatManager`
+- Update talent tree node from stat_modifier to grant_skill
+
+## Capabilities
+
+### New Capabilities
+- `blade-fury`: Self-cast buff that temporarily increases attack damage and attack speed
+
+### Modified Capabilities
+- `skill-execution`: BuffEffectParams gains `additionalBuffs` for multi-stat buffs; ServerCombatManager uses getEffectiveStat for attackSpeed
+
+## Impact
+
+- `shared/skills/skillDefinitions.ts` — extend BuffEffectParams, add skill
+- `server/src/game/skills/handlers/buffEffectHandler.ts` — handle additionalBuffs
+- `server/src/game/ServerCombatManager.ts` — apply attackSpeed status effects
+- `shared/talents/bladeTalents.ts` — update talent node
+
+## Non-goals
+
+- No visual attack speed animation changes (future)
+- No interaction with attack range

--- a/openspec/changes/archive/2026-03-10-blade-fury/specs/blade-fury/spec.md
+++ b/openspec/changes/archive/2026-03-10-blade-fury/specs/blade-fury/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Fury skill definition
+The system SHALL define `blade-fury` as a self-targeting buff skill with cooldown 18s, applying `attackDamage` +25 and `attackSpeed` +0.5 for 5 seconds.
+
+#### Scenario: Fury activation
+- **WHEN** a BLADE hero activates Fury
+- **THEN** an `attackDamage` status effect (+25) and an `attackSpeed` status effect (+0.5) SHALL be applied to the caster for 5s
+
+#### Scenario: Fury refresh
+- **WHEN** Fury is activated while an existing Fury buff is active
+- **THEN** both buff durations SHALL be refreshed to 5s
+
+### Requirement: Multi-buff support in BuffEffectParams
+BuffEffectParams SHALL support an optional `additionalBuffs` array to apply multiple status effects from a single skill activation.
+
+#### Scenario: Additional buffs applied
+- **WHEN** a buff skill with `additionalBuffs` is activated
+- **THEN** all additional buffs SHALL be applied as separate status effects keyed by `${skillId}:${buffType}`
+
+### Requirement: Attack speed status effect integration
+ServerCombatManager SHALL apply `attackSpeed` status effects when calculating attack cooldown.
+
+#### Scenario: Attack with Fury active
+- **WHEN** a hero with attackSpeed 1.0 and Fury (+0.5) attacks
+- **THEN** the attack cooldown SHALL be 1 / 1.5 = 0.667s instead of 1 / 1.0 = 1.0s
+
+## MODIFIED Requirements
+
+### Modified: skill-execution
+BuffEffectParams gains `additionalBuffs` field. buffEffectHandler applies extra status effects.

--- a/openspec/changes/archive/2026-03-10-blade-fury/tasks.md
+++ b/openspec/changes/archive/2026-03-10-blade-fury/tasks.md
@@ -1,0 +1,10 @@
+## Tasks
+
+### Backend
+- [x] Extend `BuffEffectParams` with optional `additionalBuffs` array in `skillDefinitions.ts`
+- [x] Add `blade-fury` skill definition to `skillDefinitions.ts`
+- [x] Update `buffEffectHandler` to apply additional buffs keyed by `${skillId}:${buffType}`
+- [x] Apply `getEffectiveStat` for `attackSpeed` in `ServerCombatManager`
+- [x] Add tests for buffEffectHandler with additionalBuffs
+- [x] Add test for blade-fury skill execution (both buffs applied)
+- [x] Add test for attack speed buff integration in ServerCombatManager

--- a/openspec/specs/aura-haste/spec.md
+++ b/openspec/specs/aura-haste/spec.md
@@ -25,11 +25,15 @@ AURA Haste スキル — 味方に移動速度バフを付与するオーラス�
 - **THEN** `statusEffects` に `'aura-haste'` と `'aura-slow'` の2エントリが別々に存在する
 
 ### Requirement: BuffEffectParams 定義
-`shared/skills/skillDefinitions.ts` に `BuffEffectParams` インターフェースを追加しなければならない（SHALL）。`effectType: 'buff'`、`buffType: string`（効果種別）、`value: number`（効果量）、`duration: number`（持続秒数）、`isDebuff: boolean`（デバフフラグ）を持たなければならない（SHALL）。`SkillEffectParams` 共用体に `BuffEffectParams` を追加しなければならない（SHALL）。
+`shared/skills/skillDefinitions.ts` に `BuffEffectParams` インターフェースを追加しなければならない（SHALL）。`effectType: 'buff'`、`buffType: string`（効果種別）、`value: number`（効果量）、`duration: number`（持続秒数）、`isDebuff: boolean`（デバフフラグ）を持たなければならない（SHALL）。オプションの `additionalBuffs` 配列（`{ buffType: string, value: number }[]`）を持たなければならない（SHALL）。`SkillEffectParams` 共用体に `BuffEffectParams` を追加しなければならない（SHALL）。
 
 #### Scenario: BuffEffectParams の型定義
 - **WHEN** `BuffEffectParams` を定義する
 - **THEN** `effectType`, `buffType`, `value`, `duration`, `isDebuff` のプロパティを持つ
+
+#### Scenario: BuffEffectParams の additionalBuffs フィールド
+- **WHEN** `BuffEffectParams` に `additionalBuffs` を指定する
+- **THEN** 各要素は `{ buffType: string, value: number }` であり、同じ `duration` と `isDebuff` で追加のステータスエフェクトが適用される
 
 #### Scenario: SkillEffectParams 共用体の拡張
 - **WHEN** `SkillEffectParams` 型を参照する
@@ -43,7 +47,7 @@ AURA Haste スキル — 味方に移動速度バフを付与するオーラス�
 - **THEN** `targeting: 'ally'`、`cooldown: 12`、`range: 400`、`effect.effectType: 'buff'`、`effect.buffType: 'speed'`、`effect.value: 80`、`effect.duration: 3`、`effect.isDebuff: false` のスキル定義が返される
 
 ### Requirement: buffEffectHandler
-サーバーに `buffEffectHandler` を実装しなければならない（SHALL）。`effectType: 'buff'` として効果ハンドラレジストリに登録しなければならない（SHALL）。実行時に対象ヒーロー（`ctx.targetHero ?? ctx.hero`）の `statusEffects` にスキルIDをキーとして `StatusEffectSchema` を追加しなければならない（SHALL）。同じスキルIDのエントリが既に存在する場合は `remainingDuration` と `value` を上書きしなければならない（SHALL）。
+サーバーに `buffEffectHandler` を実装しなければならない（SHALL）。`effectType: 'buff'` として効果ハンドラレジストリに登録しなければならない（SHALL）。実行時に対象ヒーロー（`ctx.targetHero ?? ctx.hero`）の `statusEffects` にスキルIDをキーとして `StatusEffectSchema` を追加しなければならない（SHALL）。同じスキルIDのエントリが既に存在する場合は `remainingDuration` と `value` を上書きしなければならない（SHALL）。`additionalBuffs` が定義されている場合、各追加バフを `${skillId}:${buffType}` をキーとして個別の `StatusEffectSchema` エントリとして追加しなければならない（SHALL）。
 
 #### Scenario: 味方に速度バフを適用
 - **WHEN** スキルID `aura-haste` で `targetHero` が味方、`buffType: 'speed'`、`value: 80`、`duration: 3` で実行する
@@ -56,6 +60,10 @@ AURA Haste スキル — 味方に移動速度バフを付与するオーラス�
 #### Scenario: 同じスキルの持続時間リフレッシュ
 - **WHEN** 既に `aura-haste` エントリ（`remainingDuration: 1.5`）がある状態で同じスキルを再度適用する
 - **THEN** `remainingDuration` が 3 に更新される
+
+#### Scenario: additionalBuffs の適用
+- **WHEN** `additionalBuffs: [{ buffType: 'attackSpeed', value: 0.5 }]` を持つバフスキル `blade-fury` で実行する
+- **THEN** `statusEffects` に `'blade-fury:attackSpeed'` をキーとして `buffType: 'attackSpeed'`、`value: 0.5` のエントリが追加される
 
 ### Requirement: バフタイマー自己管理
 サーバーは毎 tick、各ヒーローの `statusEffects` を走査し、`remainingDuration` を deltaSeconds 分減算しなければならない（SHALL）。0 以下になったエントリは `statusEffects` から削除しなければならない（SHALL）。

--- a/openspec/specs/blade-fury/spec.md
+++ b/openspec/specs/blade-fury/spec.md
@@ -1,0 +1,32 @@
+# Specification
+
+## Purpose
+
+BLADE Fury スキル — 自己ターゲティングバフスキル。攻撃力と攻撃速度を一時的に強化する。
+
+## Requirements
+
+### Requirement: Fury skill definition
+The system SHALL define `blade-fury` as a self-targeting buff skill with cooldown 18s, applying `attackDamage` +25 and `attackSpeed` +0.5 for 5 seconds.
+
+#### Scenario: Fury activation
+- **WHEN** a BLADE hero activates Fury
+- **THEN** an `attackDamage` status effect (+25) and an `attackSpeed` status effect (+0.5) SHALL be applied to the caster for 5s
+
+#### Scenario: Fury refresh
+- **WHEN** Fury is activated while an existing Fury buff is active
+- **THEN** both buff durations SHALL be refreshed to 5s
+
+### Requirement: Multi-buff support in BuffEffectParams
+BuffEffectParams SHALL support an optional `additionalBuffs` array to apply multiple status effects from a single skill activation.
+
+#### Scenario: Additional buffs applied
+- **WHEN** a buff skill with `additionalBuffs` is activated
+- **THEN** all additional buffs SHALL be applied as separate status effects keyed by `${skillId}:${buffType}`
+
+### Requirement: Attack speed status effect integration
+ServerCombatManager SHALL apply `attackSpeed` status effects when calculating attack cooldown.
+
+#### Scenario: Attack with Fury active
+- **WHEN** a hero with attackSpeed 1.0 and Fury (+0.5) attacks
+- **THEN** the attack cooldown SHALL be 1 / 1.5 = 0.667s instead of 1 / 1.0 = 1.0s

--- a/server/src/__tests__/ServerCombatManager.test.ts
+++ b/server/src/__tests__/ServerCombatManager.test.ts
@@ -401,6 +401,49 @@ describe('ServerCombatManager', () => {
       expect(events).toHaveLength(0)
     })
 
+    it('should use effective attackSpeed with buff for attack cooldown', () => {
+      const attacker = createHero('attacker', {
+        x: 100, y: 100, team: 'blue', radius: 22,
+        attackRange: 60, attackDamage: 60, attackSpeed: 1.0, attackCooldown: 0,
+        heroType: 'BLADE',
+      })
+      // Apply attackSpeed buff (+0.5)
+      const buff = new StatusEffectSchema()
+      buff.id = 'blade-fury:attackSpeed'
+      buff.buffType = 'attackSpeed'
+      buff.value = 0.5
+      buff.remainingDuration = 5
+      buff.isDebuff = false
+      attacker.statusEffects.set('blade-fury:attackSpeed', buff)
+
+      const target = createHero('target', { x: 160, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('attacker', attacker)
+      heroes.set('target', target)
+
+      const input = createInput({ attackTargetId: 'target' })
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
+
+      // effectiveAS = 1.0 + 0.5 = 1.5, cooldown = 1 / 1.5 ≈ 0.667
+      expect(attacker.attackCooldown).toBeCloseTo(1 / 1.5, 2)
+    })
+
+    it('should use base attackSpeed when no buff is active', () => {
+      const attacker = createHero('attacker', {
+        x: 100, y: 100, team: 'blue', radius: 22,
+        attackRange: 60, attackDamage: 60, attackSpeed: 0.8, attackCooldown: 0,
+        heroType: 'BLADE',
+      })
+      const target = createHero('target', { x: 160, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('attacker', attacker)
+      heroes.set('target', target)
+
+      const input = createInput({ attackTargetId: 'target' })
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
+
+      // No buff, so cooldown = 1 / 0.8 = 1.25
+      expect(attacker.attackCooldown).toBeCloseTo(1 / 0.8, 2)
+    })
+
     it('should attack tower targets', () => {
       const attacker = createHero('attacker', {
         x: 100, y: 100, team: 'blue', radius: 22,

--- a/server/src/__tests__/ServerCombatManager.test.ts
+++ b/server/src/__tests__/ServerCombatManager.test.ts
@@ -427,6 +427,33 @@ describe('ServerCombatManager', () => {
       expect(attacker.attackCooldown).toBeCloseTo(1 / 1.5, 2)
     })
 
+    it('should clamp effective attackSpeed to minimum 0.1 to prevent division by zero', () => {
+      const attacker = createHero('attacker', {
+        x: 100, y: 100, team: 'blue', radius: 22,
+        attackRange: 60, attackDamage: 60, attackSpeed: 1.0, attackCooldown: 0,
+        heroType: 'BLADE',
+      })
+      // Apply attackSpeed debuff that exceeds base → effective would be negative without clamp
+      const debuff = new StatusEffectSchema()
+      debuff.id = 'test-debuff'
+      debuff.buffType = 'attackSpeed'
+      debuff.value = -1.5
+      debuff.remainingDuration = 5
+      debuff.isDebuff = true
+      attacker.statusEffects.set('test-debuff', debuff)
+
+      const target = createHero('target', { x: 160, y: 100, team: 'red', radius: 22, hp: 650 })
+      heroes.set('attacker', attacker)
+      heroes.set('target', target)
+
+      const input = createInput({ attackTargetId: 'target' })
+      processHeroCombat(attacker, 'attacker', input, heroes, towers, projectiles, ProjectileSchema, 0.1, tracker)
+
+      // Clamped to 0.1, so cooldown = 1 / 0.1 = 10
+      expect(attacker.attackCooldown).toBeCloseTo(10, 2)
+      expect(Number.isFinite(attacker.attackCooldown)).toBe(true)
+    })
+
     it('should use base attackSpeed when no buff is active', () => {
       const attacker = createHero('attacker', {
         x: 100, y: 100, team: 'blue', radius: 22,

--- a/server/src/__tests__/buffEffectHandler.test.ts
+++ b/server/src/__tests__/buffEffectHandler.test.ts
@@ -97,6 +97,74 @@ describe('buffEffectHandler', () => {
     expect(effect.value).toBe(80)
   })
 
+  it('should apply additionalBuffs as separate status effects', () => {
+    const caster = createHero()
+    const furyParams: BuffEffectParams = {
+      effectType: 'buff',
+      buffType: 'attackDamage',
+      value: 25,
+      duration: 5,
+      isDebuff: false,
+      additionalBuffs: [
+        { buffType: 'attackSpeed', value: 0.5 },
+      ],
+    }
+    const ctx = createContext(caster, { skillId: 'blade-fury' })
+
+    buffEffectHandler.execute(ctx, furyParams)
+
+    // Primary buff keyed by skillId
+    const primary = caster.statusEffects.get('blade-fury')
+    expect(primary).toBeDefined()
+    expect(primary!.buffType).toBe('attackDamage')
+    expect(primary!.value).toBe(25)
+    expect(primary!.remainingDuration).toBe(5)
+
+    // Additional buff keyed by ${skillId}:${buffType}
+    const extra = caster.statusEffects.get('blade-fury:attackSpeed')
+    expect(extra).toBeDefined()
+    expect(extra!.buffType).toBe('attackSpeed')
+    expect(extra!.value).toBe(0.5)
+    expect(extra!.remainingDuration).toBe(5)
+  })
+
+  it('should refresh all buffs including additionalBuffs on recast', () => {
+    const caster = createHero()
+    const furyParams: BuffEffectParams = {
+      effectType: 'buff',
+      buffType: 'attackDamage',
+      value: 25,
+      duration: 5,
+      isDebuff: false,
+      additionalBuffs: [
+        { buffType: 'attackSpeed', value: 0.5 },
+      ],
+    }
+    const ctx = createContext(caster, { skillId: 'blade-fury' })
+
+    buffEffectHandler.execute(ctx, furyParams)
+
+    // Simulate time passing
+    caster.statusEffects.get('blade-fury')!.remainingDuration = 1
+    caster.statusEffects.get('blade-fury:attackSpeed')!.remainingDuration = 1
+
+    // Recast
+    buffEffectHandler.execute(ctx, furyParams)
+
+    expect(caster.statusEffects.get('blade-fury')!.remainingDuration).toBe(5)
+    expect(caster.statusEffects.get('blade-fury:attackSpeed')!.remainingDuration).toBe(5)
+  })
+
+  it('should not create additionalBuffs when not present in params', () => {
+    const caster = createHero()
+    const ctx = createContext(caster)
+
+    buffEffectHandler.execute(ctx, HASTE_PARAMS)
+
+    expect(caster.statusEffects.size).toBe(1)
+    expect(caster.statusEffects.get('aura-haste')).toBeDefined()
+  })
+
   it('should set isDebuff flag correctly for debuffs', () => {
     const caster = createHero()
     const target = createHero()

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -663,6 +663,70 @@ describe('executeSkill — blade-fortify', () => {
   })
 })
 
+describe('executeSkill — blade-fury', () => {
+  function createFuryHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+    return createHero({
+      heroType: 'BLADE',
+      team: 'blue',
+      hp: 650,
+      maxHp: 650,
+      skillSlotQ: 'blade-fury',
+      ...overrides,
+    })
+  }
+
+  it('should apply both attackDamage and attackSpeed buffs to self', () => {
+    const caster = createFuryHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('blade-fury')
+
+    // Primary buff: attackDamage
+    const adBuff = caster.statusEffects.get('blade-fury')
+    expect(adBuff).toBeDefined()
+    expect(adBuff!.buffType).toBe('attackDamage')
+    expect(adBuff!.value).toBe(25)
+    expect(adBuff!.remainingDuration).toBe(5)
+
+    // Additional buff: attackSpeed
+    const asBuff = caster.statusEffects.get('blade-fury:attackSpeed')
+    expect(asBuff).toBeDefined()
+    expect(asBuff!.buffType).toBe('attackSpeed')
+    expect(asBuff!.value).toBe(0.5)
+    expect(asBuff!.remainingDuration).toBe(5)
+  })
+
+  it('should set cooldown to 18 seconds', () => {
+    const caster = createFuryHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(caster.cooldownQ).toBe(18)
+  })
+
+  it('should refresh both buff durations on recast', () => {
+    const caster = createFuryHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+
+    // Simulate time passing
+    caster.statusEffects.get('blade-fury')!.remainingDuration = 1
+    caster.statusEffects.get('blade-fury:attackSpeed')!.remainingDuration = 1
+
+    caster.cooldownQ = 0
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+
+    expect(caster.statusEffects.get('blade-fury')!.remainingDuration).toBe(5)
+    expect(caster.statusEffects.get('blade-fury:attackSpeed')!.remainingDuration).toBe(5)
+  })
+})
+
 describe('tickCooldowns', () => {
   it('should decrement cooldowns by dt', () => {
     const hero = createHero()

--- a/server/src/game/ServerCombatManager.ts
+++ b/server/src/game/ServerCombatManager.ts
@@ -113,8 +113,8 @@ export function processHeroCombat(
       return events
     }
 
-    // Reset cooldown (apply attackSpeed status effects)
-    const effectiveAS = getEffectiveStat(hero.attackSpeed, hero, 'attackSpeed')
+    // Reset cooldown (apply attackSpeed status effects, min 0.1 to prevent division by zero)
+    const effectiveAS = Math.max(0.1, getEffectiveStat(hero.attackSpeed, hero, 'attackSpeed'))
     hero.attackCooldown = 1 / effectiveAS
 
     const heroType = hero.heroType as HeroType

--- a/server/src/game/ServerCombatManager.ts
+++ b/server/src/game/ServerCombatManager.ts
@@ -113,8 +113,9 @@ export function processHeroCombat(
       return events
     }
 
-    // Reset cooldown
-    hero.attackCooldown = 1 / hero.attackSpeed
+    // Reset cooldown (apply attackSpeed status effects)
+    const effectiveAS = getEffectiveStat(hero.attackSpeed, hero, 'attackSpeed')
+    hero.attackCooldown = 1 / effectiveAS
 
     const heroType = hero.heroType as HeroType
     const def = HERO_DEFINITIONS[heroType]

--- a/server/src/game/skills/handlers/buffEffectHandler.ts
+++ b/server/src/game/skills/handlers/buffEffectHandler.ts
@@ -2,25 +2,44 @@ import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHa
 import type { BuffEffectParams } from '@shared/skills/skillDefinitions'
 import { StatusEffectSchema } from '../../../schema/StatusEffectSchema.js'
 
+function applyBuff(
+  target: { statusEffects: import('@colyseus/schema').MapSchema<StatusEffectSchema> },
+  key: string,
+  buffType: string,
+  value: number,
+  duration: number,
+  isDebuff: boolean,
+): void {
+  const existing = target.statusEffects.get(key)
+  if (existing) {
+    existing.remainingDuration = duration
+    existing.value = value
+  } else {
+    const effect = new StatusEffectSchema()
+    effect.id = key
+    effect.buffType = buffType
+    effect.value = value
+    effect.remainingDuration = duration
+    effect.isDebuff = isDebuff
+    target.statusEffects.set(key, effect)
+  }
+}
+
 export const buffEffectHandler: SkillEffectHandler<BuffEffectParams> = {
   effectType: 'buff',
 
   execute(ctx: SkillExecutionContext, params: BuffEffectParams): void {
     const target = ctx.targetHero ?? ctx.hero
 
-    const existing = target.statusEffects.get(ctx.skillId)
-    if (existing) {
-      // Refresh: overwrite duration and value
-      existing.remainingDuration = params.duration
-      existing.value = params.value
-    } else {
-      const effect = new StatusEffectSchema()
-      effect.id = ctx.skillId
-      effect.buffType = params.buffType
-      effect.value = params.value
-      effect.remainingDuration = params.duration
-      effect.isDebuff = params.isDebuff
-      target.statusEffects.set(ctx.skillId, effect)
+    // Apply primary buff keyed by skillId
+    applyBuff(target, ctx.skillId, params.buffType, params.value, params.duration, params.isDebuff)
+
+    // Apply additional buffs keyed by ${skillId}:${buffType}
+    if (params.additionalBuffs) {
+      for (const extra of params.additionalBuffs) {
+        const key = `${ctx.skillId}:${extra.buffType}`
+        applyBuff(target, key, extra.buffType, extra.value, params.duration, params.isDebuff)
+      }
     }
   },
 }

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -29,6 +29,10 @@ export interface BuffEffectParams {
   readonly value: number         // effect amount (positive = buff, negative = debuff)
   readonly duration: number      // duration in seconds
   readonly isDebuff: boolean     // true = debuff (for future dispel logic)
+  readonly additionalBuffs?: readonly {
+    readonly buffType: string
+    readonly value: number
+  }[]
 }
 
 export interface AoEEffectParams {
@@ -202,6 +206,21 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       value: 0.3,
       duration: 4,
       isDebuff: false,
+    },
+  },
+  'blade-fury': {
+    id: 'blade-fury',
+    targeting: 'self',
+    cooldown: 18,
+    effect: {
+      effectType: 'buff',
+      buffType: 'attackDamage',
+      value: 25,
+      duration: 5,
+      isDebuff: false,
+      additionalBuffs: [
+        { buffType: 'attackSpeed', value: 0.5 },
+      ],
     },
   },
 }


### PR DESCRIPTION
## Summary
- Add `blade-fury` skill: self-targeting buff (CD 18s) that grants attackDamage +25 and attackSpeed +0.5 for 5s
- Extend `BuffEffectParams` with `additionalBuffs` array for multi-stat buff skills
- Update `buffEffectHandler` to apply additional buffs keyed by `${skillId}:${buffType}`
- Apply `getEffectiveStat` for `attackSpeed` in `ServerCombatManager` attack cooldown calculation

## Test plan
- [x] buffEffectHandler: additionalBuffs apply as separate status effects
- [x] buffEffectHandler: refresh all buffs including additionalBuffs on recast
- [x] buffEffectHandler: no additionalBuffs when not present in params
- [x] blade-fury: both attackDamage and attackSpeed buffs applied to self
- [x] blade-fury: cooldown set to 18 seconds
- [x] blade-fury: refresh both buff durations on recast
- [x] ServerCombatManager: attackSpeed buff reduces attack cooldown (1.0 + 0.5 = 1.5, cooldown ≈ 0.667s)
- [x] ServerCombatManager: base attackSpeed unchanged when no buff

Closes #202