### PR TITLE
feat: add BLADE Block skill with flat damage absorption

### DIFF
--- a/openspec/changes/archive/2026-03-10-blade-block/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-10-blade-block/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/archive/2026-03-10-blade-block/design.md
+++ b/openspec/changes/archive/2026-03-10-blade-block/design.md
@@ -1,0 +1,57 @@
+## Technical Approach
+
+Block is a self-cast buff that absorbs flat damage per hit. It uses the existing buff system with a new `blockAmount` buffType, integrated into `HeroSchema.applyDamage` after `damageReduction`.
+
+### Skill Definition
+
+```typescript
+'blade-block': {
+  id: 'blade-block',
+  targeting: 'self',
+  cooldown: 10,
+  effect: {
+    effectType: 'buff',
+    buffType: 'blockAmount',
+    value: 30,
+    duration: 3,
+    isDebuff: false,
+  },
+}
+```
+
+### HeroSchema.applyDamage Change
+
+```typescript
+override applyDamage(amount: number): void {
+  if (this.dead) return
+  const reduction = getStatusEffectValue(this, 'damageReduction')
+  const reduced = reduction > 0 ? amount * (1 - Math.min(reduction, 1)) : amount
+  const block = getStatusEffectValue(this, 'blockAmount')
+  const final = block > 0 ? Math.max(0, reduced - block) : reduced
+  super.applyDamage(final)
+}
+```
+
+Damage pipeline order: raw → damageReduction (%) → blockAmount (flat) → clamp to 0.
+
+### Talent Tree
+
+New node at Depth 1:
+```typescript
+{
+  id: 'blade-block',
+  name: 'Block',
+  description: 'Unlock Block — absorb damage per hit',
+  cost: 1,
+  prerequisites: ['blade-toughness'],
+  effects: [{ type: 'grant_skill', skillId: 'blade-block' }],
+}
+```
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `shared/skills/skillDefinitions.ts` | Add `blade-block` definition |
+| `server/src/schema/HeroSchema.ts` | Extend `applyDamage` with `blockAmount` |
+| `shared/talents/bladeTalents.ts` | Add `blade-block` talent node at Depth 1 |

--- a/openspec/changes/archive/2026-03-10-blade-block/proposal.md
+++ b/openspec/changes/archive/2026-03-10-blade-block/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+BLADE currently has Fortify (percentage damage reduction) but no flat damage absorption. Block adds a complementary defensive skill at Depth 1 in the talent tree, giving tanky BLADE builds early access to damage mitigation that is especially strong against rapid low-damage attacks (e.g. BOLT auto-attacks).
+
+## What Changes
+
+- Add `blade-block` skill definition — self-targeting buff that absorbs a fixed amount of damage per hit for a duration
+- Introduce `blockAmount` buffType — a new status effect that subtracts flat damage before HP is reduced
+- Integrate `blockAmount` into `HeroSchema.applyDamage` alongside existing `damageReduction`
+- Add `blade-block` talent node at Depth 1 (Cost 1, prerequisite: `blade-toughness`)
+
+## Capabilities
+
+### New Capabilities
+- `blade-block`: Block skill definition, blockAmount mechanic, and talent tree integration
+
+### Modified Capabilities
+- `blade-fortify`: `HeroSchema.applyDamage` gains `blockAmount` handling (applied after damageReduction)
+
+## Impact
+
+- `shared/skills/skillDefinitions.ts` — add `blade-block` definition
+- `server/src/schema/HeroSchema.ts` — extend `applyDamage` to apply `blockAmount` after `damageReduction`
+- `shared/talents/bladeTalents.ts` — add `blade-block` talent node at Depth 1
+- `server/src/__tests__/` — new tests for blockAmount mechanic and skill execution
+
+## Non-goals
+
+- No visual shield/block indicator (future)
+- No interaction with block and critical hits
+- Block does not stack with multiple casts (refreshes duration)

--- a/openspec/changes/archive/2026-03-10-blade-block/specs/blade-block/spec.md
+++ b/openspec/changes/archive/2026-03-10-blade-block/specs/blade-block/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Block skill definition
+The system SHALL define `blade-block` as a self-targeting buff skill with cooldown 10s, applying `blockAmount` buffType with value 30 for 3 seconds.
+
+#### Scenario: Block activation
+- **WHEN** a BLADE hero activates Block
+- **THEN** a `blockAmount` status effect SHALL be applied to the caster with value 30 and duration 3s
+
+#### Scenario: Block refresh
+- **WHEN** Block is activated while an existing Block buff is active
+- **THEN** the buff duration SHALL be refreshed to 3s (not stacked)
+
+### Requirement: Block damage absorption mechanic
+HeroSchema.applyDamage SHALL consult `blockAmount` status effects and subtract the flat value from incoming damage after `damageReduction` is applied.
+
+#### Scenario: Damage with active Block
+- **WHEN** a hero with blockAmount 30 takes 100 damage (no damageReduction)
+- **THEN** the hero SHALL receive 70 damage (100 - 30)
+
+#### Scenario: Block absorbs more than incoming damage
+- **WHEN** a hero with blockAmount 30 takes 20 damage
+- **THEN** the hero SHALL receive 0 damage (clamped, block absorbs all)
+
+#### Scenario: Block combined with Fortify
+- **WHEN** a hero with damageReduction 0.3 and blockAmount 30 takes 100 damage
+- **THEN** the hero SHALL receive 40 damage (100 * 0.7 = 70, then 70 - 30 = 40)
+
+#### Scenario: Damage without Block
+- **WHEN** a hero with no blockAmount takes 100 damage
+- **THEN** the hero SHALL receive 100 damage (unchanged)
+
+#### Scenario: Block expires
+- **WHEN** the Block buff expires
+- **THEN** subsequent damage SHALL be applied without flat absorption
+
+### Requirement: Talent tree integration
+The `blade-block` talent node SHALL be added at Depth 1 (Cost 1, prerequisite: `blade-toughness`) granting the Block skill.
+
+#### Scenario: Talent unlocks skill
+- **WHEN** a BLADE hero selects the Block talent
+- **THEN** `blade-block` SHALL appear in the hero's skill slots
+
+## MODIFIED Requirements
+
+### Modified: blade-fortify
+HeroSchema.applyDamage gains `blockAmount` handling applied after `damageReduction`. Order: raw damage → damageReduction (percentage) → blockAmount (flat subtraction) → clamped to 0.

--- a/openspec/changes/archive/2026-03-10-blade-block/tasks.md
+++ b/openspec/changes/archive/2026-03-10-blade-block/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+### Backend
+- [x] Add `blade-block` skill definition to `skillDefinitions.ts`
+- [x] Extend `HeroSchema.applyDamage` with `blockAmount` flat absorption (after damageReduction)
+- [x] Add `blade-block` talent node at Depth 1 in `bladeTalents.ts`
+- [x] Add tests for blockAmount mechanic in HeroSchema (block only, block+fortify, block > damage, no block)
+- [x] Add test for blade-block skill execution (buff applied to self, cooldown, refresh)

--- a/openspec/specs/blade-block/spec.md
+++ b/openspec/specs/blade-block/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Block skill definition
+The system SHALL define `blade-block` as a self-targeting buff skill with cooldown 10s, applying `blockAmount` buffType with value 30 for 3 seconds.
+
+#### Scenario: Block activation
+- **WHEN** a BLADE hero activates Block
+- **THEN** a `blockAmount` status effect SHALL be applied to the caster with value 30 and duration 3s
+
+#### Scenario: Block refresh
+- **WHEN** Block is activated while an existing Block buff is active
+- **THEN** the buff duration SHALL be refreshed to 3s (not stacked)
+
+### Requirement: Block damage absorption mechanic
+HeroSchema.applyDamage SHALL consult `blockAmount` status effects and subtract the flat value from incoming damage after `damageReduction` is applied.
+
+#### Scenario: Damage with active Block
+- **WHEN** a hero with blockAmount 30 takes 100 damage (no damageReduction)
+- **THEN** the hero SHALL receive 70 damage (100 - 30)
+
+#### Scenario: Block absorbs more than incoming damage
+- **WHEN** a hero with blockAmount 30 takes 20 damage
+- **THEN** the hero SHALL receive 0 damage (clamped, block absorbs all)
+
+#### Scenario: Block combined with Fortify
+- **WHEN** a hero with damageReduction 0.3 and blockAmount 30 takes 100 damage
+- **THEN** the hero SHALL receive 40 damage (100 * 0.7 = 70, then 70 - 30 = 40)
+
+#### Scenario: Damage without Block
+- **WHEN** a hero with no blockAmount takes 100 damage
+- **THEN** the hero SHALL receive 100 damage (unchanged)
+
+#### Scenario: Block expires
+- **WHEN** the Block buff expires
+- **THEN** subsequent damage SHALL be applied without flat absorption
+
+### Requirement: Talent tree integration
+The `blade-block` talent node SHALL be added at Depth 1 (Cost 1, prerequisite: `blade-toughness`) granting the Block skill.
+
+#### Scenario: Talent unlocks skill
+- **WHEN** a BLADE hero selects the Block talent
+- **THEN** `blade-block` SHALL appear in the hero's skill slots
+
+## MODIFIED Requirements
+
+### Modified: blade-fortify
+HeroSchema.applyDamage gains `blockAmount` handling applied after `damageReduction`. Order: raw damage → damageReduction (percentage) → blockAmount (flat subtraction) → clamped to 0.

--- a/openspec/specs/blade-fortify/spec.md
+++ b/openspec/specs/blade-fortify/spec.md
@@ -11,8 +11,8 @@ The system SHALL define `blade-fortify` as a self-targeting buff skill with cool
 - **WHEN** Fortify is activated while an existing Fortify buff is active
 - **THEN** the buff duration SHALL be refreshed to 4s (not stacked)
 
-### Requirement: Damage reduction mechanic
-HeroSchema.applyDamage SHALL consult `damageReduction` status effects and reduce incoming damage accordingly.
+### Requirement: Damage mitigation pipeline
+HeroSchema.applyDamage SHALL apply damage mitigation in order: damageReduction (percentage) → blockAmount (flat subtraction) → clamp to 0.
 
 #### Scenario: Damage with active Fortify
 - **WHEN** a hero with 30% damageReduction takes 100 damage

--- a/server/src/__tests__/HeroSchema.test.ts
+++ b/server/src/__tests__/HeroSchema.test.ts
@@ -120,3 +120,63 @@ describe('HeroSchema — applyDamage with damageReduction', () => {
     expect(hero.hp).toBe(500) // no change — dead heroes ignore damage
   })
 })
+
+describe('HeroSchema — applyDamage with blockAmount', () => {
+  function createHero(hp: number): HeroSchema {
+    const hero = new HeroSchema()
+    hero.hp = hp
+    hero.maxHp = hp
+    return hero
+  }
+
+  function addBlock(hero: HeroSchema, value: number): void {
+    const effect = new StatusEffectSchema()
+    effect.id = 'blade-block'
+    effect.buffType = 'blockAmount'
+    effect.value = value
+    effect.remainingDuration = 3
+    effect.isDebuff = false
+    hero.statusEffects.set('blade-block', effect)
+  }
+
+  function addDamageReduction(hero: HeroSchema, value: number): void {
+    const effect = new StatusEffectSchema()
+    effect.id = 'blade-fortify'
+    effect.buffType = 'damageReduction'
+    effect.value = value
+    effect.remainingDuration = 4
+    effect.isDebuff = false
+    hero.statusEffects.set('blade-fortify', effect)
+  }
+
+  it('should subtract flat blockAmount from damage', () => {
+    const hero = createHero(500)
+    addBlock(hero, 30)
+    hero.applyDamage(100)
+    // 100 - 30 = 70 damage → 500 - 70 = 430
+    expect(hero.hp).toBe(430)
+  })
+
+  it('should clamp to 0 when blockAmount exceeds damage', () => {
+    const hero = createHero(500)
+    addBlock(hero, 30)
+    hero.applyDamage(20)
+    // 20 - 30 = clamped to 0 → no damage
+    expect(hero.hp).toBe(500)
+  })
+
+  it('should apply blockAmount after damageReduction', () => {
+    const hero = createHero(500)
+    addDamageReduction(hero, 0.3)
+    addBlock(hero, 30)
+    hero.applyDamage(100)
+    // 100 * 0.7 = 70, then 70 - 30 = 40 → 500 - 40 = 460
+    expect(hero.hp).toBe(460)
+  })
+
+  it('should apply full damage when no blockAmount', () => {
+    const hero = createHero(500)
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(400)
+  })
+})

--- a/server/src/__tests__/HeroSchema.test.ts
+++ b/server/src/__tests__/HeroSchema.test.ts
@@ -3,6 +3,33 @@ import { ArraySchema } from '@colyseus/schema'
 import { HeroSchema } from '../schema/HeroSchema.js'
 import { StatusEffectSchema } from '../schema/StatusEffectSchema.js'
 
+function createHero(hp: number): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = hp
+  hero.maxHp = hp
+  return hero
+}
+
+function addDamageReduction(hero: HeroSchema, value: number): void {
+  const effect = new StatusEffectSchema()
+  effect.id = 'blade-fortify'
+  effect.buffType = 'damageReduction'
+  effect.value = value
+  effect.remainingDuration = 4
+  effect.isDebuff = false
+  hero.statusEffects.set('blade-fortify', effect)
+}
+
+function addBlock(hero: HeroSchema, value: number): void {
+  const effect = new StatusEffectSchema()
+  effect.id = 'blade-block'
+  effect.buffType = 'blockAmount'
+  effect.value = value
+  effect.remainingDuration = 3
+  effect.isDebuff = false
+  hero.statusEffects.set('blade-block', effect)
+}
+
 describe('HeroSchema — talent fields', () => {
   it('should initialize acquiredTalents as empty ArraySchema', () => {
     const hero = new HeroSchema()
@@ -59,23 +86,6 @@ describe('HeroSchema — talent fields', () => {
 })
 
 describe('HeroSchema — applyDamage with damageReduction', () => {
-  function createHero(hp: number): HeroSchema {
-    const hero = new HeroSchema()
-    hero.hp = hp
-    hero.maxHp = hp
-    return hero
-  }
-
-  function addDamageReduction(hero: HeroSchema, value: number): void {
-    const effect = new StatusEffectSchema()
-    effect.id = 'blade-fortify'
-    effect.buffType = 'damageReduction'
-    effect.value = value
-    effect.remainingDuration = 4
-    effect.isDebuff = false
-    hero.statusEffects.set('blade-fortify', effect)
-  }
-
   it('should apply full damage without damageReduction', () => {
     const hero = createHero(500)
     hero.applyDamage(100)
@@ -122,33 +132,6 @@ describe('HeroSchema — applyDamage with damageReduction', () => {
 })
 
 describe('HeroSchema — applyDamage with blockAmount', () => {
-  function createHero(hp: number): HeroSchema {
-    const hero = new HeroSchema()
-    hero.hp = hp
-    hero.maxHp = hp
-    return hero
-  }
-
-  function addBlock(hero: HeroSchema, value: number): void {
-    const effect = new StatusEffectSchema()
-    effect.id = 'blade-block'
-    effect.buffType = 'blockAmount'
-    effect.value = value
-    effect.remainingDuration = 3
-    effect.isDebuff = false
-    hero.statusEffects.set('blade-block', effect)
-  }
-
-  function addDamageReduction(hero: HeroSchema, value: number): void {
-    const effect = new StatusEffectSchema()
-    effect.id = 'blade-fortify'
-    effect.buffType = 'damageReduction'
-    effect.value = value
-    effect.remainingDuration = 4
-    effect.isDebuff = false
-    hero.statusEffects.set('blade-fortify', effect)
-  }
-
   it('should subtract flat blockAmount from damage', () => {
     const hero = createHero(500)
     addBlock(hero, 30)

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -599,6 +599,69 @@ describe('executeSkill — aura-weaken', () => {
   })
 })
 
+describe('executeSkill — blade-block', () => {
+  function createBlockHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+    return createHero({
+      heroType: 'BLADE',
+      team: 'blue',
+      hp: 650,
+      maxHp: 650,
+      skillSlotQ: 'blade-block',
+      ...overrides,
+    })
+  }
+
+  it('should apply blockAmount buff to self', () => {
+    const caster = createBlockHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('blade-block')
+
+    const effect = caster.statusEffects.get('blade-block')
+    expect(effect).toBeDefined()
+    expect(effect!.buffType).toBe('blockAmount')
+    expect(effect!.value).toBe(30)
+    expect(effect!.remainingDuration).toBe(3)
+    expect(effect!.isDebuff).toBe(false)
+  })
+
+  it('should set cooldown to 10 seconds', () => {
+    const caster = createBlockHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(caster.cooldownQ).toBe(10)
+  })
+
+  it('should refresh duration on recast', () => {
+    const caster = createBlockHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    caster.statusEffects.get('blade-block')!.remainingDuration = 0.5
+
+    caster.cooldownQ = 0
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(caster.statusEffects.get('blade-block')!.remainingDuration).toBe(3)
+  })
+
+  it('should actually absorb damage while active', () => {
+    const caster = createBlockHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 100, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    caster.applyDamage(100)
+    // 100 - 30 = 70 damage → 650 - 70 = 580
+    expect(caster.hp).toBe(580)
+  })
+})
+
 describe('executeSkill — blade-fortify', () => {
   function createFortifyHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
     return createHero({

--- a/server/src/schema/HeroSchema.ts
+++ b/server/src/schema/HeroSchema.ts
@@ -42,14 +42,16 @@ export class HeroSchema extends CombatEntitySchema {
   @type('boolean') isBot: boolean = false
 
   /**
-   * Override to apply damageReduction status effects before subtracting HP.
-   * damageReduction value is a fraction (e.g. 0.3 = 30% reduction).
+   * Override to apply damageReduction and blockAmount status effects before subtracting HP.
+   * Pipeline: raw → damageReduction (%) → blockAmount (flat) → clamp to 0.
    */
   override applyDamage(amount: number): void {
     if (this.dead) return
     const reduction = getStatusEffectValue(this, 'damageReduction')
     const reduced = reduction > 0 ? amount * (1 - Math.min(reduction, 1)) : amount
-    super.applyDamage(reduced)
+    const block = getStatusEffectValue(this, 'blockAmount')
+    const final = block > 0 ? Math.max(0, reduced - block) : reduced
+    super.applyDamage(final)
   }
   // Server-only: not synced to clients (no @type decorator)
   lastAttackerSessionId: string = ''

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -196,6 +196,18 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       },
     },
   },
+  'blade-block': {
+    id: 'blade-block',
+    targeting: 'self',
+    cooldown: 10,
+    effect: {
+      effectType: 'buff',
+      buffType: 'blockAmount',
+      value: 30,
+      duration: 3,
+      isDebuff: false,
+    },
+  },
   'blade-fortify': {
     id: 'blade-fortify',
     targeting: 'self',

--- a/shared/talents/bladeTalents.ts
+++ b/shared/talents/bladeTalents.ts
@@ -27,6 +27,14 @@ export const BLADE_TALENT_TREE: TalentTreeDefinition = {
     // Depth 1 — Early branches (4 nodes)
     // =========================================================================
     {
+      id: 'blade-block',
+      name: 'Block',
+      description: 'Unlock Block — absorb damage per hit',
+      cost: 1,
+      prerequisites: ['blade-toughness'],
+      effects: [{ type: 'grant_skill', skillId: 'blade-block' }],
+    },
+    {
       id: 'blade-thick-skin',
       name: 'Thick Skin',
       description: 'Max HP +60',


### PR DESCRIPTION
## Summary
- Add `blade-block` skill: self-targeting buff (CD 10s) that absorbs 30 flat damage per hit for 3s
- Introduce `blockAmount` buffType with flat damage subtraction in `HeroSchema.applyDamage`
- Damage pipeline: raw → damageReduction (%) → blockAmount (flat) → clamp to 0
- Add `blade-block` talent node at Depth 1 (Cost 1, prerequisite: blade-toughness)

## Test plan
- [x] blockAmount: subtract flat damage (100 - 30 = 70)
- [x] blockAmount: clamp to 0 when block exceeds damage (20 - 30 = 0)
- [x] blockAmount + damageReduction combo (100 * 0.7 - 30 = 40)
- [x] No blockAmount: full damage unchanged
- [x] blade-block: buff applied to self with correct params
- [x] blade-block: cooldown set to 10s
- [x] blade-block: refresh duration on recast
- [x] blade-block: actual damage absorption integration

Closes #198