### PR TITLE
feat: add BLADE Dodge Roll skill with invulnerability frames

### DIFF
--- a/openspec/changes/archive/2026-03-10-blade-dodge/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-10-blade-dodge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/archive/2026-03-10-blade-dodge/design.md
+++ b/openspec/changes/archive/2026-03-10-blade-dodge/design.md
@@ -1,0 +1,68 @@
+## Technical Approach
+
+Dodge Roll reuses the existing dash system with a new `invulnerable` flag. No new effectType needed.
+
+### Skill Definition
+
+```typescript
+'blade-dodge': {
+  id: 'blade-dodge',
+  targeting: 'direction',
+  cooldown: 8,
+  effect: {
+    effectType: 'dash',
+    distance: 150,
+    duration: 0.15,
+    damage: 0,
+    invulnerable: true,
+  },
+}
+```
+
+### DashEffectParams Extension
+
+```typescript
+export interface DashEffectParams {
+  // ... existing fields
+  readonly invulnerable?: boolean  // true = invulnerable during dash
+}
+```
+
+### dashEffectHandler Change
+
+```typescript
+hero.dashInvulnerable = params.invulnerable ?? false
+```
+
+### HeroSchema Change
+
+```typescript
+// Server-only field (no @type decorator)
+dashInvulnerable: boolean = false
+
+override applyDamage(amount: number): void {
+  if (this.dead) return
+  if (this.dashInvulnerable) return  // invulnerable during dodge
+  // ... existing pipeline
+}
+```
+
+### ServerMovementSystem Change
+
+When dash ends (`dashTimer <= 0`), clear invulnerability:
+```typescript
+if (hero.dashTimer <= 0) {
+  hero.dashDamage = 0
+  hero.dashInvulnerable = false  // add this
+}
+```
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `shared/skills/skillDefinitions.ts` | Extend DashEffectParams, add blade-dodge |
+| `server/src/game/skills/handlers/dashEffectHandler.ts` | Set dashInvulnerable |
+| `server/src/schema/HeroSchema.ts` | Add dashInvulnerable field, update applyDamage |
+| `server/src/game/ServerMovementSystem.ts` | Clear dashInvulnerable on dash end |
+| `shared/talents/bladeTalents.ts` | No change (node already exists) |

--- a/openspec/changes/archive/2026-03-10-blade-dodge/proposal.md
+++ b/openspec/changes/archive/2026-03-10-blade-dodge/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+BLADE lacks a defensive mobility option. Dodge Roll provides a short invulnerable dash, giving skilled players a way to dodge key abilities. This complements the existing dash system (blade-charge, bolt-dash) by adding invulnerability frames as a new dash feature.
+
+## What Changes
+
+- Add `blade-dodge` skill definition — direction-targeting dash with invulnerability frames
+- Extend `DashEffectParams` with optional `invulnerable` flag
+- Add `dashInvulnerable` server-only field to HeroSchema
+- Update `dashEffectHandler` to set invulnerability when `invulnerable: true`
+- Update `HeroSchema.applyDamage` to ignore damage during invulnerable dash
+- Clear invulnerability when dash ends in `ServerMovementSystem`
+- Talent node already exists at Depth 3 (`blade-dodge` → `grant_skill: 'blade-dodge'`)
+
+## Capabilities
+
+### New Capabilities
+- `blade-dodge`: Dodge Roll skill definition and invulnerability frame mechanic
+
+### Modified Capabilities
+
+## Impact
+
+- `shared/skills/skillDefinitions.ts` — extend DashEffectParams, add blade-dodge
+- `server/src/game/skills/handlers/dashEffectHandler.ts` — set dashInvulnerable
+- `server/src/schema/HeroSchema.ts` — add dashInvulnerable field, update applyDamage
+- `server/src/game/ServerMovementSystem.ts` — clear dashInvulnerable on dash end
+
+## Non-goals
+
+- No visual invulnerability indicator (future)
+- No interaction with CC/debuffs during invulnerability (future)

--- a/openspec/changes/archive/2026-03-10-blade-dodge/specs/blade-dodge/spec.md
+++ b/openspec/changes/archive/2026-03-10-blade-dodge/specs/blade-dodge/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Dodge Roll skill definition
+The system SHALL define `blade-dodge` as a direction-targeting dash skill with cooldown 8s, distance 150px, duration 0.15s, damage 0, and invulnerable true.
+
+#### Scenario: Dodge Roll activation
+- **WHEN** a BLADE hero activates Dodge Roll in a direction
+- **THEN** the hero SHALL dash 150px over 0.15s in that direction with 0 damage
+
+#### Scenario: Invulnerability during Dodge Roll
+- **WHEN** a hero is dashing with invulnerable frames (dashInvulnerable = true)
+- **THEN** all incoming damage SHALL be ignored until the dash ends
+
+#### Scenario: Invulnerability clears on dash end
+- **WHEN** the dash timer reaches 0
+- **THEN** dashInvulnerable SHALL be set to false and damage applies normally
+
+#### Scenario: Dodge Roll cooldown
+- **WHEN** Dodge Roll is activated
+- **THEN** the cooldown SHALL be set to 8 seconds
+
+### Requirement: DashEffectParams invulnerable extension
+DashEffectParams SHALL support an optional `invulnerable` boolean field. When true, the dashEffectHandler sets `dashInvulnerable` on the hero.
+
+#### Scenario: Non-invulnerable dashes unaffected
+- **WHEN** a dash skill without `invulnerable: true` is activated (e.g. blade-charge, bolt-dash)
+- **THEN** dashInvulnerable SHALL remain false
+
+### Requirement: Talent tree integration
+The `blade-dodge` talent node at Depth 3 already grants `blade-dodge` skill via `grant_skill`. No talent tree changes needed.

--- a/openspec/changes/archive/2026-03-10-blade-dodge/tasks.md
+++ b/openspec/changes/archive/2026-03-10-blade-dodge/tasks.md
@@ -1,0 +1,11 @@
+## Tasks
+
+### Backend
+- [x] Extend `DashEffectParams` with optional `invulnerable` field in `skillDefinitions.ts`
+- [x] Add `blade-dodge` skill definition to `skillDefinitions.ts`
+- [x] Add `dashInvulnerable` server-only field to `HeroSchema`
+- [x] Update `HeroSchema.applyDamage` to ignore damage when `dashInvulnerable` is true
+- [x] Update `dashEffectHandler` to set `dashInvulnerable` from params
+- [x] Update `ServerMovementSystem` to clear `dashInvulnerable` when dash ends
+- [x] Add tests for invulnerability during dodge (damage ignored, clears on end, non-invulnerable dash unaffected)
+- [x] Add test for blade-dodge skill execution (dash state, cooldown)

--- a/server/src/__tests__/HeroSchema.test.ts
+++ b/server/src/__tests__/HeroSchema.test.ts
@@ -163,3 +163,28 @@ describe('HeroSchema — applyDamage with blockAmount', () => {
     expect(hero.hp).toBe(400)
   })
 })
+
+describe('HeroSchema — applyDamage with dashInvulnerable', () => {
+  it('should ignore damage when dashInvulnerable is true', () => {
+    const hero = createHero(500)
+    hero.dashInvulnerable = true
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(500)
+  })
+
+  it('should apply damage normally when dashInvulnerable is false', () => {
+    const hero = createHero(500)
+    hero.dashInvulnerable = false
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(400)
+  })
+
+  it('should ignore damage even with damageReduction and blockAmount active', () => {
+    const hero = createHero(500)
+    hero.dashInvulnerable = true
+    addDamageReduction(hero, 0.3)
+    addBlock(hero, 30)
+    hero.applyDamage(100)
+    expect(hero.hp).toBe(500) // invulnerable takes priority
+  })
+})

--- a/server/src/__tests__/ServerMovementSystem.test.ts
+++ b/server/src/__tests__/ServerMovementSystem.test.ts
@@ -132,6 +132,24 @@ describe('ServerMovementSystem', () => {
     })
   })
 
+  describe('dash invulnerability cleanup', () => {
+    it('should clear dashInvulnerable when dash ends', () => {
+      const hero = createHero({ dashTimer: 0.05, dashDirX: 1, dashDirY: 0, dashSpeed: 1000, dashInvulnerable: true })
+      processMovement(hero, undefined, 0.1)
+
+      expect(hero.dashTimer).toBe(0)
+      expect(hero.dashInvulnerable).toBe(false)
+    })
+
+    it('should keep dashInvulnerable during active dash', () => {
+      const hero = createHero({ dashTimer: 0.3, dashDirX: 1, dashDirY: 0, dashSpeed: 1000, dashInvulnerable: true })
+      processMovement(hero, undefined, 0.1)
+
+      expect(hero.dashTimer).toBeCloseTo(0.2)
+      expect(hero.dashInvulnerable).toBe(true)
+    })
+  })
+
   describe('speed buff integration', () => {
     it('should use effective speed with buff applied', () => {
       const hero = createHero({ x: 500, y: 360, speed: 200 })

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -599,6 +599,54 @@ describe('executeSkill — aura-weaken', () => {
   })
 })
 
+describe('executeSkill — blade-dodge', () => {
+  function createDodgeHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+    return createHero({
+      heroType: 'BLADE',
+      team: 'blue',
+      hp: 650,
+      maxHp: 650,
+      skillSlotQ: 'blade-dodge',
+      ...overrides,
+    })
+  }
+
+  it('should set dash state with invulnerability', () => {
+    const caster = createDodgeHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('blade-dodge')
+    expect(caster.dashTimer).toBeCloseTo(0.15)
+    expect(caster.dashDirX).toBeCloseTo(1)
+    expect(caster.dashDirY).toBeCloseTo(0)
+    expect(caster.dashSpeed).toBeCloseTo(150 / 0.15)
+    expect(caster.dashDamage).toBe(0)
+    expect(caster.dashInvulnerable).toBe(true)
+  })
+
+  it('should set cooldown to 8 seconds', () => {
+    const caster = createDodgeHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    expect(caster.cooldownQ).toBe(8)
+  })
+
+  it('should ignore damage during dodge', () => {
+    const caster = createDodgeHero({ x: 100, y: 100 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 100 }, new MapSchema<ProjectileSchema>(), heroes, tracker)
+    caster.applyDamage(100)
+    expect(caster.hp).toBe(650) // invulnerable
+  })
+})
+
 describe('executeSkill — blade-block', () => {
   function createBlockHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
     return createHero({

--- a/server/src/__tests__/skillExecution.test.ts
+++ b/server/src/__tests__/skillExecution.test.ts
@@ -104,6 +104,12 @@ describe('executeSkill', () => {
     expect(hero.dashDamage).toBe(80)
   })
 
+  it('should not set dashInvulnerable for blade-charge (non-invulnerable dash)', () => {
+    const hero = createHero()
+    executeSkill(hero, 'player-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
+    expect(hero.dashInvulnerable).toBe(false)
+  })
+
   it('should reject when hero is dead', () => {
     const hero = createHero()
     hero.dead = true
@@ -162,6 +168,12 @@ describe('executeSkill — bolt-dash', () => {
     const hero = createHero({ hp: 500, maxHp: 500, heroType: 'BOLT', skillSlotQ: 'bolt-dash' })
     executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
     expect(hero.cooldownQ).toBe(6)
+  })
+
+  it('should not set dashInvulnerable for bolt-dash (non-invulnerable dash)', () => {
+    const hero = createHero({ hp: 500, maxHp: 500, heroType: 'BOLT', skillSlotQ: 'bolt-dash' })
+    executeSkill(hero, 'bolt-1', 'Q', { x: 400, y: 200 }, new MapSchema<ProjectileSchema>(), new MapSchema<HeroSchema>(), tracker)
+    expect(hero.dashInvulnerable).toBe(false)
   })
 })
 

--- a/server/src/game/ServerDeathSystem.ts
+++ b/server/src/game/ServerDeathSystem.ts
@@ -25,6 +25,7 @@ function respawnHero(hero: HeroSchema, spawn: SpawnPosition): void {
   hero.dashDirY = 0
   hero.dashSpeed = 0
   hero.dashDamage = 0
+  hero.dashInvulnerable = false
   hero.cooldownQ = 0
   hero.cooldownE = 0
   hero.cooldownR = 0

--- a/server/src/game/ServerMovementSystem.ts
+++ b/server/src/game/ServerMovementSystem.ts
@@ -63,6 +63,7 @@ function processDashMovement(hero: HeroSchema, deltaTime: number): void {
     hero.dashDirY = 0
     hero.dashSpeed = 0
     hero.dashDamage = 0
+    hero.dashInvulnerable = false
   }
 }
 

--- a/server/src/game/skills/handlers/dashEffectHandler.ts
+++ b/server/src/game/skills/handlers/dashEffectHandler.ts
@@ -10,6 +10,7 @@ export const dashEffectHandler: SkillEffectHandler<DashEffectParams> = {
     hero.dashDirY = direction.y
     hero.dashSpeed = params.distance / params.duration
     hero.dashDamage = params.damage
+    hero.dashInvulnerable = params.invulnerable ?? false
     hero.facing = Math.atan2(direction.y, direction.x)
   },
 }

--- a/server/src/schema/HeroSchema.ts
+++ b/server/src/schema/HeroSchema.ts
@@ -39,6 +39,8 @@ export class HeroSchema extends CombatEntitySchema {
   dashSpeed: number = 0
   /** Contact damage dealt during this dash (set by effect handler, 0 = no damage) */
   dashDamage: number = 0
+  /** True during invulnerable dashes (e.g. Dodge Roll) — ignores incoming damage */
+  dashInvulnerable: boolean = false
   @type('boolean') isBot: boolean = false
 
   /**
@@ -47,6 +49,7 @@ export class HeroSchema extends CombatEntitySchema {
    */
   override applyDamage(amount: number): void {
     if (this.dead) return
+    if (this.dashInvulnerable) return
     const reduction = getStatusEffectValue(this, 'damageReduction')
     const reduced = reduction > 0 ? amount * (1 - Math.min(reduction, 1)) : amount
     const block = getStatusEffectValue(this, 'blockAmount')

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -5,6 +5,7 @@ export interface DashEffectParams {
   readonly distance: number       // px traveled during dash
   readonly duration: number       // seconds
   readonly damage: number         // contact damage during dash
+  readonly invulnerable?: boolean // true = invulnerable during dash
 }
 
 export interface ProjectileEffectParams {
@@ -194,6 +195,18 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
         target: 'enemy',
         duration: 2,
       },
+    },
+  },
+  'blade-dodge': {
+    id: 'blade-dodge',
+    targeting: 'direction',
+    cooldown: 8,
+    effect: {
+      effectType: 'dash',
+      distance: 150,
+      duration: 0.15,
+      damage: 0,
+      invulnerable: true,
     },
   },
   'blade-block': {


### PR DESCRIPTION
## Summary
- Add `blade-dodge` skill: direction-targeting dash (CD 8s, 150px over 0.15s) with invulnerability frames
- Extend `DashEffectParams` with optional `invulnerable` field for reuse by future dash skills
- Full damage pipeline integration: `dashInvulnerable` bypasses all damage during dodge
- Automatic cleanup: invulnerability clears when dash timer expires

## Test plan
- [x] HeroSchema: dashInvulnerable ignores damage, applies normally when false, priority over other mitigation
- [x] ServerMovementSystem: dashInvulnerable clears on dash end, persists during active dash
- [x] skillExecution: blade-dodge sets dash state, cooldown, invulnerability flag

Closes #199