### PR TITLE
feat: Solo モードにレベル最大化ボタンを追加

### DIFF
--- a/server/src/game/maxLevelUtils.ts
+++ b/server/src/game/maxLevelUtils.ts
@@ -1,0 +1,27 @@
+import { MAX_LEVEL, XP_THRESHOLDS } from '@shared/constants'
+import type { HeroType } from '@shared/types'
+import { TALENT_TREES } from '@shared/talents/index'
+import type { HeroSchema } from '../schema/HeroSchema.js'
+import { recalculateEffectiveStats } from './ServerTalentSystem.js'
+import { applyStatsGrowth } from './xpUtils.js'
+
+/**
+ * Set a hero to maximum level instantly.
+ * Grants all remaining talent points and recalculates stats.
+ * Intended for Solo mode debug use only.
+ */
+export function applyMaxLevel(hero: HeroSchema): void {
+  if (hero.level >= MAX_LEVEL) return
+
+  const levelsGained = MAX_LEVEL - hero.level
+  hero.level = MAX_LEVEL
+  hero.xp = XP_THRESHOLDS[MAX_LEVEL - 1]!
+  hero.talentPoints = hero.talentPoints + levelsGained
+
+  const treeDef = TALENT_TREES[hero.heroType as HeroType]
+  if (treeDef) {
+    recalculateEffectiveStats(hero, treeDef)
+  } else {
+    applyStatsGrowth(hero, MAX_LEVEL)
+  }
+}

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -36,6 +36,7 @@ import { executeSkill, tickCooldowns } from '../game/ServerSkillExecutionSystem.
 import { tickBuffs } from '../game/StatusEffectSystem.js'
 import { tickZones } from '../game/ServerZoneSystem.js'
 import { processDashDamage, cleanupDashHitSets } from '../game/ServerDashDamageSystem.js'
+import { applyMaxLevel } from '../game/maxLevelUtils.js'
 import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
 import { TALENT_TREES } from '@shared/talents/index'
 import type { SkillSlot } from '@shared/talents/types'
@@ -173,6 +174,15 @@ export class GameRoom extends Room<GameRoomState> {
       if (!hero) return
       const isInBase = isHeroInBase(hero)
       unequipSkillSlot(hero, message.slot, isInBase)
+    })
+
+    // Max level handler (solo mode only)
+    this.onMessage('maxLevel', (client) => {
+      if (!this.isSoloMode) return
+      if (this.state.matchPhase !== 'playing') return
+      const hero = this.state.heroes.get(client.sessionId)
+      if (!hero) return
+      applyMaxLevel(hero)
     })
 
     // Skill activation handler

--- a/src/network/GameMode.ts
+++ b/src/network/GameMode.ts
@@ -106,6 +106,9 @@ export interface GameMode {
   /** Send skill activation */
   sendUseSkill(slot: string, target: { x: number; y: number }): void
 
+  /** Send max level request (solo mode debug) */
+  sendMaxLevel(): void
+
   /** Register callback for server hero state sync */
   onServerHeroUpdate(callback: (state: ServerHeroState) => void): void
 

--- a/src/network/OnlineGameMode.ts
+++ b/src/network/OnlineGameMode.ts
@@ -376,6 +376,10 @@ export class OnlineGameMode implements GameMode {
     this.room?.send('useSkill', { slot, target })
   }
 
+  sendMaxLevel(): void {
+    this.room?.send('maxLevel')
+  }
+
   onServerHeroUpdate(callback: (state: ServerHeroState) => void): void {
     this.serverHeroUpdateCallbacks = [...this.serverHeroUpdateCallbacks, callback]
   }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -56,6 +56,7 @@ export class GameScene extends Phaser.Scene {
   private localTeam: Team = 'blue'
   private localSpawnPosition: Position = { x: GAME_WIDTH / 4, y: WORLD_HEIGHT / 2 }
   private localHeroType: HeroType = 'BLADE'
+  private isSoloMode = false
 
   // Match end state
   private matchEnded = false
@@ -71,7 +72,7 @@ export class GameScene extends Phaser.Scene {
     super({ key: 'GameScene' })
   }
 
-  init(data?: { gameMode?: GameMode; localTeam?: Team; localPosition?: Position; heroType?: HeroType }): void {
+  init(data?: { gameMode?: GameMode; localTeam?: Team; localPosition?: Position; heroType?: HeroType; isSoloMode?: boolean }): void {
     if (!data?.gameMode) {
       logger.error('No gameMode provided, returning to LobbyScene')
       this.scene.start('LobbyScene')
@@ -81,6 +82,7 @@ export class GameScene extends Phaser.Scene {
     this.localTeam = data.localTeam ?? 'blue'
     this.localSpawnPosition = data.localPosition ?? { x: GAME_WIDTH / 4, y: WORLD_HEIGHT / 2 }
     this.localHeroType = data.heroType ?? 'BLADE'
+    this.isSoloMode = data.isSoloMode ?? false
 
     // Reset state from previous game (Phaser reuses scene instances — property initializers only run in constructor)
     this.matchEnded = false
@@ -164,8 +166,9 @@ export class GameScene extends Phaser.Scene {
     this.respawnText.setVisible(false)
 
     // Game HUD (skill bar, level badge, XP bar, HP bar)
-    this.gameHud = new GameHud(this, CAMERA_ZOOM, () => {
-      this.talentTreeOverlay.toggle()
+    this.gameHud = new GameHud(this, CAMERA_ZOOM, {
+      onTalentButtonClick: () => this.talentTreeOverlay.toggle(),
+      onMaxLevelClick: this.isSoloMode ? () => this.networkBridge.sendMaxLevel() : undefined,
     })
 
     // Talent tree overlay

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -30,6 +30,7 @@ export class LobbyScene extends Phaser.Scene {
   private lobbyState: LobbyState = 'menu'
   private networkClient: NetworkClient | null = null
   private selectedHeroType: HeroType = 'BLADE'
+  private isSoloMode = false
   private heroButtonGraphics: Map<HeroType, Phaser.GameObjects.Graphics> = new Map()
   private statusText!: Phaser.GameObjects.Text
   private errorText!: Phaser.GameObjects.Text
@@ -156,6 +157,7 @@ export class LobbyScene extends Phaser.Scene {
     if (this.lobbyState !== 'menu') return
 
     this.setState('connecting')
+    this.isSoloMode = true
     this.networkClient = new NetworkClient()
 
     try {
@@ -176,6 +178,7 @@ export class LobbyScene extends Phaser.Scene {
     if (this.lobbyState !== 'menu') return
 
     this.setState('connecting')
+    this.isSoloMode = false
     this.networkClient = new NetworkClient()
 
     try {
@@ -223,7 +226,7 @@ export class LobbyScene extends Phaser.Scene {
         ? { x: localHero.x as number, y: localHero.y as number }
         : undefined
 
-      this.scene.start('GameScene', { gameMode, localTeam, localPosition, heroType: this.selectedHeroType })
+      this.scene.start('GameScene', { gameMode, localTeam, localPosition, heroType: this.selectedHeroType, isSoloMode: this.isSoloMode })
     })
   }
 

--- a/src/scenes/NetworkBridge.ts
+++ b/src/scenes/NetworkBridge.ts
@@ -115,6 +115,10 @@ export class NetworkBridge {
     this.gameMode.sendUseSkill(slot, target)
   }
 
+  sendMaxLevel(): void {
+    this.gameMode.sendMaxLevel()
+  }
+
   dispose(): void {
     this.gameMode.dispose()
   }

--- a/src/scenes/ui/GameHud.ts
+++ b/src/scenes/ui/GameHud.ts
@@ -20,6 +20,16 @@ const TALENT_BUTTON_COLOR = 0x2c3e50
 const TALENT_BUTTON_BORDER = 0xf39c12
 const BADGE_COLOR = 0xe74c3c
 
+const MAX_LEVEL_BUTTON_WIDTH = 60
+const MAX_LEVEL_BUTTON_HEIGHT = 24
+const MAX_LEVEL_BUTTON_COLOR = 0x8e44ad
+const MAX_LEVEL_BUTTON_BORDER = 0xbb6bd9
+
+export interface GameHudOptions {
+  readonly onTalentButtonClick: () => void
+  readonly onMaxLevelClick?: () => void
+}
+
 /**
  * Base design dimensions for HUD layout.
  * computeHudLayout returns positions in this 1280x720 coordinate space.
@@ -48,6 +58,7 @@ export class GameHud {
   private readonly scene: Phaser.Scene
   private readonly cameraZoom: number
   private readonly onTalentButtonClick: () => void
+  private readonly onMaxLevelClick?: () => void
 
   // Talent button
   private readonly talentButtonGfx: Phaser.GameObjects.Graphics
@@ -57,14 +68,21 @@ export class GameHud {
   private talentButtonY: number
   private lastBadgeCount = 0
 
+  // Max level button (solo mode only)
+  private readonly maxLevelGfx?: Phaser.GameObjects.Graphics
+  private readonly maxLevelText?: Phaser.GameObjects.Text
+  private maxLevelButtonX = 0
+  private maxLevelButtonY = 0
+
   // Track current slot config to avoid unnecessary rebuilds
   private currentSlotKeys: string[] = []
 
-  constructor(scene: Phaser.Scene, cameraZoom: number, onTalentButtonClick: () => void) {
+  constructor(scene: Phaser.Scene, cameraZoom: number, options: GameHudOptions) {
     this.scene = scene
     this.scale = createUiScale(cameraZoom)
     this.cameraZoom = cameraZoom
-    this.onTalentButtonClick = onTalentButtonClick
+    this.onTalentButtonClick = options.onTalentButtonClick
+    this.onMaxLevelClick = options.onMaxLevelClick
 
     // Initial slots: 3 empty (Q, E, R)
     const initialSlots: SkillSlotConfig[] = [
@@ -159,6 +177,32 @@ export class GameHud {
     this.talentBadgeText.setResolution(cameraZoom)
     this.talentBadgeText.setVisible(false)
     this.container.add(this.talentBadgeText)
+
+    // Max level button (solo mode debug)
+    if (this.onMaxLevelClick) {
+      this.maxLevelButtonX = this.talentButtonX - MAX_LEVEL_BUTTON_WIDTH - 8
+      this.maxLevelButtonY = this.talentButtonY + (TALENT_BUTTON_SIZE - MAX_LEVEL_BUTTON_HEIGHT) / 2
+
+      this.maxLevelGfx = scene.add.graphics()
+      this.drawMaxLevelButton()
+      this.container.add(this.maxLevelGfx)
+
+      this.maxLevelText = createText(
+        scene,
+        this.maxLevelButtonX + MAX_LEVEL_BUTTON_WIDTH / 2,
+        this.maxLevelButtonY + MAX_LEVEL_BUTTON_HEIGHT / 2,
+        'MAX LV',
+        {
+          fontSize: this.scale.fontSize(10),
+          color: '#FFFFFF',
+          fontStyle: 'bold',
+          align: 'center',
+        },
+      )
+      this.maxLevelText.setOrigin(0.5)
+      this.maxLevelText.setResolution(cameraZoom)
+      this.container.add(this.maxLevelText)
+    }
   }
 
   get gameObject(): Phaser.GameObjects.Container {
@@ -214,6 +258,27 @@ export class GameHud {
     this.talentButtonGfx.fillRect(cx - barH / 2, cy - r * 0.35, barH, r * 0.7)
   }
 
+  private drawMaxLevelButton(): void {
+    if (!this.maxLevelGfx) return
+    this.maxLevelGfx.clear()
+    this.maxLevelGfx.fillStyle(MAX_LEVEL_BUTTON_COLOR, 0.85)
+    this.maxLevelGfx.fillRoundedRect(
+      this.maxLevelButtonX,
+      this.maxLevelButtonY,
+      MAX_LEVEL_BUTTON_WIDTH,
+      MAX_LEVEL_BUTTON_HEIGHT,
+      4,
+    )
+    this.maxLevelGfx.lineStyle(1.5, MAX_LEVEL_BUTTON_BORDER, 0.9)
+    this.maxLevelGfx.strokeRoundedRect(
+      this.maxLevelButtonX,
+      this.maxLevelButtonY,
+      MAX_LEVEL_BUTTON_WIDTH,
+      MAX_LEVEL_BUTTON_HEIGHT,
+      4,
+    )
+  }
+
   private updateTalentBadge(talentPoints: number): void {
     if (talentPoints === this.lastBadgeCount) return
     this.lastBadgeCount = talentPoints
@@ -232,7 +297,7 @@ export class GameHud {
     }
   }
 
-  /** Handle scene-level pointer click — returns true if talent button was hit. */
+  /** Handle scene-level pointer click — returns true if a HUD button was hit. */
   handlePointerDown(pointer: Phaser.Input.Pointer): boolean {
     const localX = pointer.x / this.cameraZoom
     const localY = pointer.y / this.cameraZoom
@@ -246,6 +311,19 @@ export class GameHud {
     if (dx * dx + dy * dy <= r * r) {
       this.onTalentButtonClick()
       return true
+    }
+
+    // Max level button hit test (rectangle)
+    if (this.onMaxLevelClick) {
+      if (
+        localX >= this.maxLevelButtonX
+        && localX <= this.maxLevelButtonX + MAX_LEVEL_BUTTON_WIDTH
+        && localY >= this.maxLevelButtonY
+        && localY <= this.maxLevelButtonY + MAX_LEVEL_BUTTON_HEIGHT
+      ) {
+        this.onMaxLevelClick()
+        return true
+      }
     }
     return false
   }


### PR DESCRIPTION
## Summary

- Solo モード限定で HUD に「MAX LV」ボタンを追加
- ボタン押下でヒーローのレベルを30（最大）に即座設定、全タレントポイントを付与
- サーバー側で `isSoloMode` ガード済み — オンライン対戦では無効

## Changes

| Layer | File | Change |
|-------|------|--------|
| Server | `maxLevelUtils.ts` | 純粋関数 `applyMaxLevel(hero)` — レベル・XP・タレントポイント設定 + スタッツ再計算 |
| Server | `GameRoom.ts` | `'maxLevel'` メッセージハンドラ（solo mode only） |
| Client | `GameMode.ts` | `sendMaxLevel()` をインターフェースに追加 |
| Client | `OnlineGameMode.ts` | `sendMaxLevel()` 実装 |
| Client | `NetworkBridge.ts` | `sendMaxLevel()` 中継 |
| Client | `LobbyScene.ts` | `isSoloMode` フラグを GameScene に渡す |
| Client | `GameScene.ts` | `isSoloMode` 受け取り、GameHud に `onMaxLevelClick` コールバック渡し |
| Client | `GameHud.ts` | Solo 時のみ「MAX LV」ボタン描画 + ヒットテスト |

## Test plan

- [x] `npm run lint` — pass
- [x] `npm run test` (unit 903 + E2E 11) — all pass
- [ ] Solo モードで「MAX LV」ボタンが表示されること
- [ ] ボタン押下でレベル30・タレントポイント30になること
- [ ] オンライン対戦ではボタンが表示されないこと

Closes #226