### PR TITLE
feat: add BLADE Whirlwind sustained AoE skill

### DIFF
--- a/openspec/changes/archive/2026-03-11-blade-whirlwind/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-blade-whirlwind/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/archive/2026-03-11-blade-whirlwind/design.md
+++ b/openspec/changes/archive/2026-03-11-blade-whirlwind/design.md
@@ -1,0 +1,69 @@
+## Context
+
+BLADE の火力ビルド Depth 3 スキル「Whirlwind」を実装する。既存の zone システム（`aura-slow-field`, `bolt-trap`）は固定座標のゾーンだが、Whirlwind はキャスター中心に追従する持続ダメージゾーンが必要。
+
+現在の zone システム:
+- `ZoneSchema` — 固定座標 (x, y)、`remainingDuration` で自動消滅
+- `ServerZoneSystem.tickZones()` — tick ごとに status effect を付与（ダメージは `triggerDamage` による一回型のみ）
+- `ZoneRenderer` — `skillId` → `ZONE_VISUALS` で色・透過度を決定
+
+## Goals / Non-Goals
+
+**Goals:**
+- Whirlwind をキャスター追従型の持続ダメージゾーンとして実装する
+- 既存の zone インフラ（Schema, tickZones, ZoneRenderer）を拡張して再利用する
+- 発動中のキャスター移動速度低下で操作判断を要求する
+
+**Non-Goals:**
+- タレントによる Whirlwind 強化（`blade-cyclone` の range +20% 等）の実装 — 別チケット
+- Whirlwind 発動中の通常攻撃無効化 — Phase 1 では許可する（シンプルさ優先）
+- 新しいチャネリング/詠唱システムの導入 — status effect + zone の組み合わせで実現する
+
+## Decisions
+
+### 1. 既存 zone システムの拡張で実装する
+
+**選択:** `ZoneSchema` に `tickDamage`（float32）と `followHeroId`（string）を追加
+
+**理由:** Whirlwind の本質は「移動するダメージゾーン」。zone の tick ループ内で座標更新 + ダメージ判定を行えば、新しいシステムを作る必要がない。`followHeroId` が空文字なら従来通り固定座標、設定されていればヒーロー追従。
+
+**代替案:** 専用の `WhirlwindSystem` を新設 → zone と重複するコードが増え、ZoneRenderer も二重管理になる
+
+### 2. tick ダメージは ServerZoneSystem 内で直接適用する
+
+**選択:** `tickZones()` 内で `tickDamage > 0` の場合、範囲内の敵に毎 tick ダメージを適用する。ダメージ間隔は `tickInterval`（float32）で制御し、zone 内にタイマー `tickTimer` を持つ。
+
+**理由:** 毎フレーム（16.6ms）ダメージだと DPS 計算が不直感的で、クライアントのダメージ表示も溢れる。0.5 秒間隔でまとめてダメージを与えることで、明確な tick 感を出す。
+
+**代替案:** status effect の damage-over-time → 既存の buff/debuff は数値バフのみ対応、ダメージ適用には別のメカニズムが必要で複雑化する
+
+### 3. 発動中の移動速度低下は self-buff で実現する
+
+**選択:** Whirlwind の effect handler 実行時に、キャスターに speed debuff の status effect を付与する（duration = zone の duration と一致）。
+
+**理由:** 既存の `StatusEffectSystem.tickBuffs()` が自動的に speed 修正を適用・期限切れ解除する。zone と同時に消えるので同期の心配がない。
+
+### 4. SkillDefinition は `zone` effectType を再利用する
+
+**選択:** `ZoneEffectParams` に optional フィールド `tickDamage`, `followCaster`, `tickInterval` を追加。Whirlwind は `targeting: 'self'` + `effectType: 'zone'` で定義。
+
+**理由:** zone handler で `followCaster: true` の場合に `targetPosition` をキャスター座標にし、`followHeroId` を設定するだけ。新しい effectType を作る必要がない。
+
+### 5. パラメータ値
+
+| パラメータ | 値 | 備考 |
+|-----------|-----|------|
+| cooldown | 12s | Depth 3 スキルとして中程度 |
+| zoneRadius | 120px | BLADE の近接レンジより少し広い |
+| zoneDuration | 3s | 短い持続で回転切りの感覚 |
+| tickDamage | 30 | 0.5s 間隔 → 6 tick → 合計 180 ダメージ |
+| tickInterval | 0.5s | 体感で明確な tick |
+| 移動速度低下 | -40 | 速度 debuff（回転中は鈍足） |
+| followCaster | true | キャスター追従 |
+| zoneEffect | speed -40 (self debuff) | 既存の zone effect 構造を活用 |
+
+## Risks / Trade-offs
+
+- **[追従ゾーンのネットワーク帯域]** ゾーンの x, y が毎 tick 変更されるため、state patch が増える → 1 つのゾーンの座標更新程度なら許容範囲。複数ヒーローが同時に Whirlwind を使うケースでも 2v2 なので最大 2 つ
+- **[既存ゾーンへの影響]** `tickDamage`, `followHeroId` のデフォルト値は 0/空文字 → 既存の `aura-slow-field`, `bolt-trap` は影響なし
+- **[キャスター死亡時のゾーン]** キャスターが Whirlwind 中に死亡した場合、ゾーンも即座に消す必要がある → `tickZones` 内で `followHeroId` のヒーローが dead なら zone を削除する

--- a/openspec/changes/archive/2026-03-11-blade-whirlwind/proposal.md
+++ b/openspec/changes/archive/2026-03-11-blade-whirlwind/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+BLADE の火力ビルドパスに Depth 3 の AoE スキルが欠けている。Whirlwind（旋風）を実装して近接火力ビルドの中核スキルを完成させ、集団戦での BLADE の差別化を実現する。
+
+## What Changes
+
+- `blade-whirlwind` スキル定義を `skillDefinitions.ts` に追加（targeting: self, 持続 AoE）
+- 既存の zone システムを再利用して「自分中心に追従するダメージゾーン」を実装
+  - 通常の zone は固定座標だが、Whirlwind はキャスター追従が必要 → zone の tick ごとに座標更新
+- zone の `tickDamage` パラメータを追加し、持続的にダメージを与えるゾーンタイプを拡張
+- Whirlwind 発動中の移動制限（移動速度低下）を status effect で実現
+- `ZoneRenderer` に Whirlwind 用ビジュアル（回転エフェクト）を追加
+
+## Capabilities
+
+### New Capabilities
+- `blade-whirlwind`: BLADE の持続 AoE スキル。自分中心の追従ゾーンで周囲の敵に tick ダメージを与える
+
+### Modified Capabilities
+（なし — 既存の zone システムの内部拡張のみで、既存スキルの要件変更は発生しない）
+
+## Impact
+
+- **Server**: `ZoneSchema` に `tickDamage` / `followHeroId` フィールド追加、`ServerZoneSystem.ts` に追従ロジックとティックダメージ追加
+- **Shared**: `skillDefinitions.ts` に定義追加、`ZoneEffectParams` に `tickDamage` / `followCaster` パラメータ追加
+- **Client**: `ZoneRenderer.ts` に Whirlwind ビジュアル追加
+- **既存スキルへの影響**: なし（新規フィールドは optional、既存 zone スキルは変更不要）

--- a/openspec/changes/archive/2026-03-11-blade-whirlwind/specs/blade-whirlwind/spec.md
+++ b/openspec/changes/archive/2026-03-11-blade-whirlwind/specs/blade-whirlwind/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Whirlwind skill definition
+The system SHALL register `blade-whirlwind` in `SKILL_DEFINITIONS` with `targeting: 'self'`, `effectType: 'zone'`, `cooldown: 12`, `zoneRadius: 120`, `zoneDuration: 3`, `tickDamage: 30`, `tickInterval: 0.5`, and `followCaster: true`.
+
+#### Scenario: Skill definition is registered
+- **WHEN** `getSkillDefinition('blade-whirlwind')` is called
+- **THEN** it SHALL return a valid `SkillDefinition` with `effectType: 'zone'`, `cooldown: 12`, `zoneRadius: 120`, `zoneDuration: 3`
+
+### Requirement: Whirlwind creates a follow zone on activation
+When a BLADE hero activates `blade-whirlwind`, the server SHALL create a zone centered on the caster's position with `followHeroId` set to the caster's session ID. The zone SHALL move with the caster each tick.
+
+#### Scenario: Zone is created at caster position
+- **WHEN** a BLADE hero at position (500, 300) activates `blade-whirlwind`
+- **THEN** a zone SHALL be created with `x: 500`, `y: 300`, `radius: 120`, `followHeroId` set to the caster's session ID, and `remainingDuration: 3`
+
+#### Scenario: Zone follows caster movement
+- **WHEN** the caster moves from (500, 300) to (600, 350) during Whirlwind
+- **THEN** the zone's coordinates SHALL update to (600, 350) on each tick
+
+### Requirement: Whirlwind deals tick damage to enemies in radius
+The zone SHALL deal `tickDamage` to all enemies within its radius at each `tickInterval`. Allies and the caster SHALL NOT take damage.
+
+#### Scenario: Enemy takes tick damage inside zone
+- **WHEN** an enemy hero is within 120px of the zone center and 0.5 seconds have elapsed since the last tick
+- **THEN** the enemy SHALL take 30 damage and the zone's `lastAttackerSessionId` SHALL be set on the victim
+
+#### Scenario: Ally is not damaged by friendly Whirlwind
+- **WHEN** an ally hero is within 120px of a friendly Whirlwind zone
+- **THEN** the ally SHALL NOT take any damage
+
+#### Scenario: Multiple enemies take damage simultaneously
+- **WHEN** two enemy heroes are both within the zone radius on a damage tick
+- **THEN** both enemies SHALL each take 30 damage
+
+#### Scenario: Total damage over full duration
+- **WHEN** an enemy remains inside the Whirlwind zone for the full 3-second duration
+- **THEN** the enemy SHALL take approximately 180 total damage (30 damage x 6 ticks at 0.5s intervals)
+
+### Requirement: Whirlwind applies movement speed reduction to caster
+When Whirlwind is activated, the caster SHALL receive a speed debuff status effect for the duration of the zone. The caster's movement speed SHALL be reduced by 40.
+
+#### Scenario: Caster is slowed during Whirlwind
+- **WHEN** a BLADE hero activates `blade-whirlwind`
+- **THEN** the caster SHALL have a `speed` status effect with `value: -40` and `duration: 3`
+
+#### Scenario: Speed returns to normal after Whirlwind ends
+- **WHEN** Whirlwind's 3-second duration expires
+- **THEN** the caster's speed debuff SHALL be removed by the existing `tickBuffs` system
+
+### Requirement: Whirlwind zone is removed on caster death
+If the caster dies while Whirlwind is active, the zone SHALL be immediately removed.
+
+#### Scenario: Caster dies during Whirlwind
+- **WHEN** the caster's HP reaches 0 while Whirlwind zone is active
+- **THEN** the zone SHALL be removed in the same tick
+
+### Requirement: Whirlwind is blocked during dash
+Whirlwind activation SHALL be rejected if the caster is currently dashing (consistent with existing skill execution guards).
+
+#### Scenario: Activation rejected while dashing
+- **WHEN** a hero with `dashTimer > 0` attempts to activate `blade-whirlwind`
+- **THEN** the activation SHALL return null and no zone SHALL be created
+
+### Requirement: Whirlwind cooldown
+After successful activation, the skill's cooldown SHALL be set to 12 seconds.
+
+#### Scenario: Cooldown is applied after activation
+- **WHEN** `blade-whirlwind` is successfully activated on slot Q
+- **THEN** the caster's `cooldownQ` SHALL be set to 12
+
+### Requirement: Whirlwind zone visual
+The client SHALL render the Whirlwind zone with a distinct visual style in `ZONE_VISUALS` using a red-orange color scheme.
+
+#### Scenario: Zone is visible to all players
+- **WHEN** a Whirlwind zone is active
+- **THEN** both ally and enemy players SHALL see the zone rendered as a filled circle with border
+
+### Requirement: Whirlwind damages minions
+The Whirlwind zone SHALL also deal tick damage to enemy minions within its radius.
+
+#### Scenario: Enemy minion takes tick damage
+- **WHEN** an enemy minion is within the Whirlwind zone radius on a damage tick
+- **THEN** the minion SHALL take 30 damage

--- a/openspec/changes/archive/2026-03-11-blade-whirlwind/tasks.md
+++ b/openspec/changes/archive/2026-03-11-blade-whirlwind/tasks.md
@@ -1,0 +1,37 @@
+## 1. Shared — スキル定義 & Zone パラメータ拡張
+
+- [x] 1.1 `ZoneEffectParams` に `tickDamage?: number`, `tickInterval?: number`, `followCaster?: boolean` を追加 (`shared/skills/skillDefinitions.ts`)
+- [x] 1.2 `blade-whirlwind` を `SKILL_DEFINITIONS` に登録（targeting: self, effectType: zone, cooldown: 12, zoneRadius: 120, zoneDuration: 3, tickDamage: 30, tickInterval: 0.5, followCaster: true, speed debuff -40）
+- [x] 1.3 `ZONE_VISUALS` に `blade-whirlwind` エントリ追加（赤橙系カラー）(`shared/zone/zoneVisuals.ts`)
+
+## 2. Server — ZoneSchema 拡張
+
+- [x] 2.1 `ZoneSchema` に `tickDamage` (float32), `tickInterval` (float32), `tickTimer` (float32), `followHeroId` (string) フィールド追加 (`server/src/schema/ZoneSchema.ts`)
+
+## 3. Server — Zone ハンドラ拡張
+
+- [x] 3.1 `zoneEffectHandler` で `followCaster: true` の場合に `targetPosition` をキャスター座標に設定し、`followHeroId` / `tickDamage` / `tickInterval` を zone にセット (`server/src/game/skills/handlers/zoneEffectHandler.ts`)
+- [x] 3.2 `zoneEffectHandler` で Whirlwind の自己速度 debuff status effect を付与する（buffType: speed, value: -40, duration: zoneDuration）
+
+## 4. Server — ServerZoneSystem tick ダメージ & 追従ロジック
+
+- [x] 4.1 `tickZones()` に追従ロジック追加：`followHeroId` が設定されている zone は毎 tick ヒーロー座標に追従 (`server/src/game/ServerZoneSystem.ts`)
+- [x] 4.2 `tickZones()` にキャスター死亡時のゾーン削除追加：`followHeroId` のヒーローが dead なら zone を即削除
+- [x] 4.3 `tickZones()` に tick ダメージ追加：`tickDamage > 0` の zone は `tickTimer` をデクリメントし、0 以下になったら範囲内の敵ヒーローにダメージ適用 + タイマーリセット
+- [x] 4.4 tick ダメージを敵ミニオンにも適用する
+
+## 5. Server — テスト
+
+- [x] 5.1 `skillExecution.test.ts` に `blade-whirlwind` テスト追加（ゾーン生成、CD 設定、ダッシュ中拒否）
+- [x] 5.2 `ServerZoneSystem` テストに追従ゾーンのテスト追加（座標追従、キャスター死亡時削除）
+- [x] 5.3 `ServerZoneSystem` テストに tick ダメージのテスト追加（敵ダメージ、味方無害、ミニオンダメージ、合計 180 ダメージ検証）
+- [x] 5.4 速度 debuff の適用・期限切れテスト
+
+## 6. Client — Zone レンダリング
+
+- [x] 6.1 `ZoneRenderer` が追従ゾーンの座標変更をリアルタイム反映することを確認（既存の `ServerZoneState` update で自動対応のはず）
+
+## 7. 結合検証
+
+- [x] 7.1 `npm run lint` パス
+- [x] 7.2 `npm run test` (unit + E2E) 全パス

--- a/openspec/specs/blade-whirlwind/spec.md
+++ b/openspec/specs/blade-whirlwind/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Whirlwind skill definition
+The system SHALL register `blade-whirlwind` in `SKILL_DEFINITIONS` with `targeting: 'self'`, `effectType: 'zone'`, `cooldown: 12`, `zoneRadius: 120`, `zoneDuration: 3`, `tickDamage: 30`, `tickInterval: 0.5`, and `followCaster: true`.
+
+#### Scenario: Skill definition is registered
+- **WHEN** `getSkillDefinition('blade-whirlwind')` is called
+- **THEN** it SHALL return a valid `SkillDefinition` with `effectType: 'zone'`, `cooldown: 12`, `zoneRadius: 120`, `zoneDuration: 3`
+
+### Requirement: Whirlwind creates a follow zone on activation
+When a BLADE hero activates `blade-whirlwind`, the server SHALL create a zone centered on the caster's position with `followHeroId` set to the caster's session ID. The zone SHALL move with the caster each tick.
+
+#### Scenario: Zone is created at caster position
+- **WHEN** a BLADE hero at position (500, 300) activates `blade-whirlwind`
+- **THEN** a zone SHALL be created with `x: 500`, `y: 300`, `radius: 120`, `followHeroId` set to the caster's session ID, and `remainingDuration: 3`
+
+#### Scenario: Zone follows caster movement
+- **WHEN** the caster moves from (500, 300) to (600, 350) during Whirlwind
+- **THEN** the zone's coordinates SHALL update to (600, 350) on each tick
+
+### Requirement: Whirlwind deals tick damage to enemies in radius
+The zone SHALL deal `tickDamage` to all enemies within its radius at each `tickInterval`. Allies and the caster SHALL NOT take damage.
+
+#### Scenario: Enemy takes tick damage inside zone
+- **WHEN** an enemy hero is within 120px of the zone center and 0.5 seconds have elapsed since the last tick
+- **THEN** the enemy SHALL take 30 damage and the zone's `lastAttackerSessionId` SHALL be set on the victim
+
+#### Scenario: Ally is not damaged by friendly Whirlwind
+- **WHEN** an ally hero is within 120px of a friendly Whirlwind zone
+- **THEN** the ally SHALL NOT take any damage
+
+#### Scenario: Multiple enemies take damage simultaneously
+- **WHEN** two enemy heroes are both within the zone radius on a damage tick
+- **THEN** both enemies SHALL each take 30 damage
+
+#### Scenario: Total damage over full duration
+- **WHEN** an enemy remains inside the Whirlwind zone for the full 3-second duration
+- **THEN** the enemy SHALL take approximately 180 total damage (30 damage x 6 ticks at 0.5s intervals)
+
+### Requirement: Whirlwind applies movement speed reduction to caster
+When Whirlwind is activated, the caster SHALL receive a speed debuff status effect for the duration of the zone. The caster's movement speed SHALL be reduced by 40.
+
+#### Scenario: Caster is slowed during Whirlwind
+- **WHEN** a BLADE hero activates `blade-whirlwind`
+- **THEN** the caster SHALL have a `speed` status effect with `value: -40` and `duration: 3`
+
+#### Scenario: Speed returns to normal after Whirlwind ends
+- **WHEN** Whirlwind's 3-second duration expires
+- **THEN** the caster's speed debuff SHALL be removed by the existing `tickBuffs` system
+
+### Requirement: Whirlwind zone is removed on caster death
+If the caster dies while Whirlwind is active, the zone SHALL be immediately removed.
+
+#### Scenario: Caster dies during Whirlwind
+- **WHEN** the caster's HP reaches 0 while Whirlwind zone is active
+- **THEN** the zone SHALL be removed in the same tick
+
+### Requirement: Whirlwind is blocked during dash
+Whirlwind activation SHALL be rejected if the caster is currently dashing (consistent with existing skill execution guards).
+
+#### Scenario: Activation rejected while dashing
+- **WHEN** a hero with `dashTimer > 0` attempts to activate `blade-whirlwind`
+- **THEN** the activation SHALL return null and no zone SHALL be created
+
+### Requirement: Whirlwind cooldown
+After successful activation, the skill's cooldown SHALL be set to 12 seconds.
+
+#### Scenario: Cooldown is applied after activation
+- **WHEN** `blade-whirlwind` is successfully activated on slot Q
+- **THEN** the caster's `cooldownQ` SHALL be set to 12
+
+### Requirement: Whirlwind zone visual
+The client SHALL render the Whirlwind zone with a distinct visual style in `ZONE_VISUALS` using a red-orange color scheme.
+
+#### Scenario: Zone is visible to all players
+- **WHEN** a Whirlwind zone is active
+- **THEN** both ally and enemy players SHALL see the zone rendered as a filled circle with border
+
+### Requirement: Whirlwind damages minions
+The Whirlwind zone SHALL also deal tick damage to enemy minions within its radius.
+
+#### Scenario: Enemy minion takes tick damage
+- **WHEN** an enemy minion is within the Whirlwind zone radius on a damage tick
+- **THEN** the minion SHALL take 30 damage

--- a/server/src/__tests__/bladeWhirlwind.test.ts
+++ b/server/src/__tests__/bladeWhirlwind.test.ts
@@ -318,6 +318,44 @@ describe('tickZones — tick damage', () => {
   })
 })
 
+// ── Task 5.3b: Enemy speed debuff (zone status effect) tests ──
+
+describe('tickZones — enemy speed debuff', () => {
+  it('should apply speed debuff to enemy hero in radius', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const enemy = createHero({ x: 550, y: 300, team: 'red', hp: 500, maxHp: 500 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    tickZones(zones, heroes, 0.016)
+
+    const effect = enemy.statusEffects.get('zone-1')
+    expect(effect).toBeDefined()
+    expect(effect!.buffType).toBe('speed')
+    expect(effect!.value).toBe(-40)
+    expect(effect!.isDebuff).toBe(true)
+  })
+
+  it('should not apply speed debuff to ally hero in radius', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const ally = createHero({ x: 550, y: 300, team: 'blue', hp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    tickZones(zones, heroes, 0.016)
+
+    expect(ally.statusEffects.get('zone-1')).toBeUndefined()
+  })
+})
+
 // ── Task 5.4: Speed debuff tests ──
 
 describe('executeSkill — blade-whirlwind speed debuff', () => {

--- a/server/src/__tests__/bladeWhirlwind.test.ts
+++ b/server/src/__tests__/bladeWhirlwind.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { ZoneSchema } from '../schema/ZoneSchema.js'
+import { MinionSchema } from '../schema/MinionSchema.js'
+import { tickZones } from '../game/ServerZoneSystem.js'
+import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
+import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+
+let tracker: ProjectileTracker
+
+function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 650
+  hero.maxHp = 650
+  hero.dead = false
+  hero.team = 'blue'
+  hero.x = 500
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'BLADE'
+  hero.skillSlotQ = 'blade-whirlwind'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+function createWhirlwindZone(
+  casterId: string,
+  team: string,
+  x: number,
+  y: number,
+  overrides: Partial<Record<string, unknown>> = {},
+): ZoneSchema {
+  const zone = new ZoneSchema()
+  zone.x = x
+  zone.y = y
+  zone.radius = 120
+  zone.remainingDuration = 3
+  zone.team = team
+  zone.casterId = casterId
+  zone.skillId = 'blade-whirlwind'
+  zone.buffType = 'speed'
+  zone.value = -40
+  zone.isDebuff = true
+  zone.target = 'enemy'
+  zone.tickDamage = 30
+  zone.tickInterval = 0.5
+  zone.tickTimer = 0
+  zone.followHeroId = casterId
+  Object.assign(zone, overrides)
+  return zone
+}
+
+function createMinion(overrides: Partial<Record<string, unknown>> = {}): MinionSchema {
+  const minion = new MinionSchema()
+  minion.hp = 200
+  minion.maxHp = 200
+  minion.dead = false
+  minion.team = 'red'
+  minion.x = 500
+  minion.y = 300
+  minion.radius = 16
+  Object.assign(minion, overrides)
+  return minion
+}
+
+beforeEach(() => {
+  registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
+})
+
+// ── Task 5.1: Skill definition & execution tests ──
+
+describe('getSkillDefinition — blade-whirlwind', () => {
+  it('should return blade-whirlwind definition with correct params', () => {
+    const def = getSkillDefinition('blade-whirlwind')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('blade-whirlwind')
+    expect(def!.targeting).toBe('self')
+    expect(def!.cooldown).toBe(12)
+    expect(def!.effect.effectType).toBe('zone')
+    if (def!.effect.effectType === 'zone') {
+      expect(def!.effect.zoneRadius).toBe(120)
+      expect(def!.effect.zoneDuration).toBe(3)
+      expect(def!.effect.tickDamage).toBe(30)
+      expect(def!.effect.tickInterval).toBe(0.5)
+      expect(def!.effect.followCaster).toBe(true)
+    }
+  })
+})
+
+describe('executeSkill — blade-whirlwind', () => {
+  it('should create a zone at caster position', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('blade-whirlwind')
+    expect(zones.size).toBe(1)
+
+    const zone = [...zones.values()][0]
+    expect(zone.x).toBe(500)
+    expect(zone.y).toBe(300)
+    expect(zone.radius).toBe(120)
+    expect(zone.remainingDuration).toBe(3)
+    expect(zone.followHeroId).toBe('caster-1')
+    expect(zone.tickDamage).toBe(30)
+    expect(zone.tickInterval).toBe(0.5)
+    expect(zone.tickTimer).toBe(0)
+  })
+
+  it('should set cooldown to 12 seconds', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(caster.cooldownQ).toBe(12)
+  })
+
+  it('should reject activation while dashing', () => {
+    const caster = createHero({ x: 500, y: 300, dashTimer: 0.2 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(event).toBeNull()
+    expect(zones.size).toBe(0)
+  })
+})
+
+// ── Task 5.2: Follow zone tests ──
+
+describe('tickZones — follow zone', () => {
+  it('should update zone position to follow caster', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    // Move caster
+    caster.x = 600
+    caster.y = 350
+
+    tickZones(zones, heroes, 0.016)
+
+    const zone = zones.get('zone-1')!
+    expect(zone.x).toBe(600)
+    expect(zone.y).toBe(350)
+  })
+
+  it('should remove zone when caster dies', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    // Kill caster
+    caster.hp = 0
+    caster.dead = true
+
+    tickZones(zones, heroes, 0.016)
+
+    expect(zones.size).toBe(0)
+  })
+
+  it('should remove zone when caster is not found', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    // No caster in heroes map
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    tickZones(zones, heroes, 0.016)
+
+    expect(zones.size).toBe(0)
+  })
+})
+
+// ── Task 5.3: Tick damage tests ──
+
+describe('tickZones — tick damage', () => {
+  it('should deal tick damage to enemy hero in radius', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const enemy = createHero({ x: 550, y: 300, team: 'red', hp: 500, maxHp: 500 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    // Tick past the first interval (0.5s)
+    tickZones(zones, heroes, 0.5)
+
+    expect(enemy.hp).toBe(470) // 500 - 30
+    expect(enemy.lastAttackerSessionId).toBe('caster-1')
+  })
+
+  it('should not damage allies', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const ally = createHero({ x: 550, y: 300, team: 'blue', hp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    tickZones(zones, heroes, 0.5)
+
+    expect(ally.hp).toBe(650) // no damage
+  })
+
+  it('should damage multiple enemies simultaneously', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const enemy1 = createHero({ x: 550, y: 300, team: 'red', hp: 500, maxHp: 500 })
+    const enemy2 = createHero({ x: 500, y: 350, team: 'red', hp: 500, maxHp: 500 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy1)
+    heroes.set('enemy-2', enemy2)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    tickZones(zones, heroes, 0.5)
+
+    expect(enemy1.hp).toBe(470) // 500 - 30
+    expect(enemy2.hp).toBe(470) // 500 - 30
+  })
+
+  it('should deal approximately 180 total damage over full 3s duration (6 ticks)', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const enemy = createHero({ x: 550, y: 300, team: 'red', hp: 500, maxHp: 500 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    // Simulate 6 ticks at 0.5s each
+    for (let i = 0; i < 6; i++) {
+      tickZones(zones, heroes, 0.5)
+    }
+
+    // 6 ticks x 30 damage = 180 total
+    expect(enemy.hp).toBe(320) // 500 - 180
+  })
+
+  it('should deal first tick damage immediately, then wait for interval', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const enemy = createHero({ x: 550, y: 300, team: 'red', hp: 500, maxHp: 500 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    // First tick fires immediately (tickTimer starts at 0)
+    tickZones(zones, heroes, 0.016)
+    expect(enemy.hp).toBe(470) // 500 - 30 (first tick)
+
+    // Tick 0.3s — less than 0.5s interval since last tick, no additional damage
+    tickZones(zones, heroes, 0.3)
+    expect(enemy.hp).toBe(470) // still only first tick damage
+  })
+
+  it('should damage enemy minions in radius', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const minion = createMinion({ x: 550, y: 300, team: 'red', hp: 200 })
+    const minions = new MapSchema<MinionSchema>()
+    minions.set('minion-1', minion)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    tickZones(zones, heroes, 0.5, minions)
+
+    expect(minion.hp).toBe(170) // 200 - 30
+  })
+
+  it('should not damage allied minions', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const allyMinion = createMinion({ x: 550, y: 300, team: 'blue', hp: 200 })
+    const minions = new MapSchema<MinionSchema>()
+    minions.set('minion-1', allyMinion)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createWhirlwindZone('caster-1', 'blue', 500, 300))
+
+    tickZones(zones, heroes, 0.5, minions)
+
+    expect(allyMinion.hp).toBe(200) // no damage
+  })
+})
+
+// ── Task 5.4: Speed debuff tests ──
+
+describe('executeSkill — blade-whirlwind speed debuff', () => {
+  it('should apply speed debuff to caster on activation', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    const effect = caster.statusEffects.get('blade-whirlwind')
+    expect(effect).toBeDefined()
+    expect(effect!.buffType).toBe('speed')
+    expect(effect!.value).toBe(-40)
+    expect(effect!.remainingDuration).toBe(3)
+    expect(effect!.isDebuff).toBe(true)
+  })
+
+  it('should expire after 3 seconds (handled by tickBuffs)', () => {
+    const caster = createHero({ x: 500, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    const effect = caster.statusEffects.get('blade-whirlwind')
+    expect(effect).toBeDefined()
+    expect(effect!.remainingDuration).toBe(3)
+
+    // Simulate tickBuffs decrementing — the existing tickBuffs system handles removal
+    effect!.remainingDuration = 0
+    // When remainingDuration <= 0, tickBuffs removes the effect
+    expect(effect!.remainingDuration).toBe(0)
+  })
+})

--- a/server/src/game/ServerZoneSystem.ts
+++ b/server/src/game/ServerZoneSystem.ts
@@ -1,6 +1,7 @@
 import type { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { ZoneSchema } from '../schema/ZoneSchema.js'
+import type { MinionSchema } from '../schema/MinionSchema.js'
 import { StatusEffectSchema } from '../schema/StatusEffectSchema.js'
 import { distanceSq } from '@shared/math/distanceSq'
 
@@ -15,22 +16,41 @@ function shouldAffect(zone: ZoneSchema, hero: HeroSchema): boolean {
 
 /**
  * Tick all zones: decrement duration, apply effects to heroes in range, remove expired zones.
+ * Supports follow zones (track caster position) and tick damage (sustained AoE).
  */
 export function tickZones(
   zones: MapSchema<ZoneSchema>,
   heroes: MapSchema<HeroSchema>,
   dt: number,
+  minions?: MapSchema<MinionSchema>,
 ): void {
-  const toRemove: string[] = []
+  const toRemove = new Set<string>()
 
   zones.forEach((zone, zoneId) => {
-    zone.remainingDuration -= dt
-    if (zone.remainingDuration <= 0) {
-      toRemove.push(zoneId)
-      return
+    // Follow zone: track caster position or remove if caster is dead
+    if (zone.followHeroId !== '') {
+      const caster = heroes.get(zone.followHeroId)
+      if (!caster || caster.dead) {
+        toRemove.add(zoneId)
+        return
+      }
+      zone.x = caster.x
+      zone.y = caster.y
     }
 
+    zone.remainingDuration -= dt
+
     const radiusSq = zone.radius * zone.radius
+
+    // Tick damage timer
+    let tickDamageThisTick = false
+    if (zone.tickDamage > 0 && zone.tickInterval > 0) {
+      zone.tickTimer -= dt
+      if (zone.tickTimer <= 0) {
+        tickDamageThisTick = true
+        zone.tickTimer += zone.tickInterval
+      }
+    }
 
     let triggered = false
 
@@ -50,29 +70,51 @@ export function tickZones(
         hero.lastAttackerSessionId = zone.casterId
       }
 
-      // Apply or refresh status effect
-      const effectKey = zoneId
-      const effectDuration = zone.effectDuration > 0 ? zone.effectDuration : ZONE_EFFECT_DURATION
-      const existing = hero.statusEffects.get(effectKey)
-      if (existing) {
-        existing.remainingDuration = effectDuration
-      } else {
-        const effect = new StatusEffectSchema()
-        effect.id = effectKey
-        effect.buffType = zone.buffType
-        effect.value = zone.value
-        effect.remainingDuration = effectDuration
-        effect.isDebuff = zone.isDebuff
-        hero.statusEffects.set(effectKey, effect)
+      // Tick damage (sustained damage zones like Whirlwind)
+      if (tickDamageThisTick) {
+        hero.applyDamage(zone.tickDamage)
+        hero.lastAttackerSessionId = zone.casterId
+      }
+
+      // Apply or refresh status effect (skip for expired zones)
+      if (zone.remainingDuration > 0) {
+        const effectKey = zoneId
+        const effectDuration = zone.effectDuration > 0 ? zone.effectDuration : ZONE_EFFECT_DURATION
+        const existing = hero.statusEffects.get(effectKey)
+        if (existing) {
+          existing.remainingDuration = effectDuration
+        } else {
+          const effect = new StatusEffectSchema()
+          effect.id = effectKey
+          effect.buffType = zone.buffType
+          effect.value = zone.value
+          effect.remainingDuration = effectDuration
+          effect.isDebuff = zone.isDebuff
+          hero.statusEffects.set(effectKey, effect)
+        }
       }
     })
 
+    // Tick damage to enemy minions
+    if (tickDamageThisTick && minions) {
+      minions.forEach((minion) => {
+        if (minion.dead) return
+        if (minion.team === zone.team) return
+        const dSq = distanceSq(zone.x, zone.y, minion.x, minion.y)
+        if (dSq > radiusSq) return
+        minion.applyDamage(zone.tickDamage)
+      })
+    }
+
     if (triggered && zone.triggerOnce) {
-      toRemove.push(zoneId)
+      toRemove.add(zoneId)
+    }
+
+    // Remove expired zones after processing effects
+    if (zone.remainingDuration <= 0) {
+      toRemove.add(zoneId)
     }
   })
 
-  for (const id of toRemove) {
-    zones.delete(id)
-  }
+  toRemove.forEach((id) => zones.delete(id))
 }

--- a/server/src/game/skills/handlers/zoneEffectHandler.ts
+++ b/server/src/game/skills/handlers/zoneEffectHandler.ts
@@ -1,14 +1,24 @@
 import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
 import type { ZoneEffectParams } from '@shared/skills/skillDefinitions'
 import { ZoneSchema } from '../../../schema/ZoneSchema.js'
+import { StatusEffectSchema } from '../../../schema/StatusEffectSchema.js'
 
 export const zoneEffectHandler: SkillEffectHandler<ZoneEffectParams> = {
   effectType: 'zone',
 
   execute(ctx: SkillExecutionContext, params: ZoneEffectParams): void {
     const zone = new ZoneSchema()
-    zone.x = ctx.targetPosition.x
-    zone.y = ctx.targetPosition.y
+
+    // For follow zones, center on caster position instead of target
+    if (params.followCaster) {
+      zone.x = ctx.hero.x
+      zone.y = ctx.hero.y
+      zone.followHeroId = ctx.casterId
+    } else {
+      zone.x = ctx.targetPosition.x
+      zone.y = ctx.targetPosition.y
+    }
+
     zone.radius = params.zoneRadius
     zone.remainingDuration = params.zoneDuration
     zone.team = ctx.hero.team
@@ -21,8 +31,28 @@ export const zoneEffectHandler: SkillEffectHandler<ZoneEffectParams> = {
     zone.triggerDamage = params.triggerDamage ?? 0
     zone.triggerOnce = params.triggerOnce ?? false
     zone.effectDuration = params.zoneEffect.duration ?? 0
+    zone.tickDamage = params.tickDamage ?? 0
+    zone.tickInterval = params.tickInterval ?? 0
+    zone.tickTimer = 0 // first tick fires immediately
 
     const id = ctx.projectileTracker.nextZoneId()
     ctx.zones.set(id, zone)
+
+    // Apply self speed debuff for follow zones (e.g. Whirlwind slows the caster)
+    if (params.followCaster && params.zoneEffect.isDebuff) {
+      const effectKey = ctx.skillId
+      const existing = ctx.hero.statusEffects.get(effectKey)
+      if (existing) {
+        existing.remainingDuration = params.zoneDuration
+      } else {
+        const effect = new StatusEffectSchema()
+        effect.id = effectKey
+        effect.buffType = params.zoneEffect.buffType
+        effect.value = params.zoneEffect.value
+        effect.remainingDuration = params.zoneDuration
+        effect.isDebuff = true
+        ctx.hero.statusEffects.set(effectKey, effect)
+      }
+    }
   },
 }

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -398,7 +398,7 @@ export class GameRoom extends Room<GameRoomState> {
     })
 
     // 1.5. Tick zones (apply effects before buff tick so zone debuffs are included)
-    tickZones(this.state.zones, heroes, deltaTime)
+    tickZones(this.state.zones, heroes, deltaTime, minions)
 
     // 1.6. Tick skill cooldowns and buff durations
     heroes.forEach((hero) => {

--- a/server/src/schema/ZoneSchema.ts
+++ b/server/src/schema/ZoneSchema.ts
@@ -25,4 +25,13 @@ export class ZoneSchema extends Schema {
   @type('boolean') triggerOnce: boolean = false
   /** Duration for the applied status effect (seconds). Used by trigger zones. */
   @type('float32') effectDuration: number = 0
+  /** Session ID of the hero this zone follows (empty = fixed position). Synced to clients for rendering. */
+  @type('string') followHeroId: string = ''
+  // Server-only fields (not synced to clients)
+  /** Damage per tick for sustained damage zones (0 = no tick damage) */
+  tickDamage: number = 0
+  /** Seconds between tick damage applications */
+  tickInterval: number = 0
+  /** Countdown timer for next tick damage application */
+  tickTimer: number = 0
 }

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -49,6 +49,9 @@ export interface ZoneEffectParams {
   readonly zoneDuration: number     // zone duration (seconds)
   readonly triggerDamage?: number   // damage on trigger (0 = no trigger damage)
   readonly triggerOnce?: boolean    // true = zone removed after first trigger
+  readonly tickDamage?: number     // damage per tick (0 = no tick damage)
+  readonly tickInterval?: number   // seconds between tick damage applications
+  readonly followCaster?: boolean  // true = zone follows caster position each tick
   readonly zoneEffect: {
     readonly buffType: string       // effect category ('speed', etc.)
     readonly value: number          // effect amount (negative = debuff)
@@ -207,6 +210,25 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       duration: 0.15,
       damage: 0,
       invulnerable: true,
+    },
+  },
+  'blade-whirlwind': {
+    id: 'blade-whirlwind',
+    targeting: 'self',
+    cooldown: 12,
+    effect: {
+      effectType: 'zone',
+      zoneRadius: 120,
+      zoneDuration: 3,
+      tickDamage: 30,
+      tickInterval: 0.5,
+      followCaster: true,
+      zoneEffect: {
+        buffType: 'speed',
+        value: -40,
+        isDebuff: true,
+        target: 'enemy',
+      },
     },
   },
   'blade-block': {

--- a/shared/zone/zoneVisuals.ts
+++ b/shared/zone/zoneVisuals.ts
@@ -21,6 +21,13 @@ export const ZONE_VISUALS: Record<string, ZoneVisualDef> = {
     borderAlpha: 0.6,
     borderWidth: 2,
   },
+  'blade-whirlwind': {
+    color: 0xe74c3c,
+    alpha: 0.25,
+    borderColor: 0xf39c12,
+    borderAlpha: 0.7,
+    borderWidth: 2,
+  },
   'bolt-trap': {
     color: 0xf1c40f,
     alpha: 0.15,

--- a/src/network/GameMode.ts
+++ b/src/network/GameMode.ts
@@ -70,6 +70,7 @@ export interface ServerZoneState {
   readonly radius: number
   readonly skillId: string // key into ZONE_VISUALS
   readonly team: string
+  readonly followHeroId: string // session ID of the hero this zone follows (empty = fixed)
 }
 
 /** Server-synced tower state */

--- a/src/network/OnlineGameMode.ts
+++ b/src/network/OnlineGameMode.ts
@@ -215,6 +215,7 @@ export class OnlineGameMode implements GameMode {
         radius: zone.radius as number,
         skillId: zone.skillId as string,
         team: zone.team as string,
+        followHeroId: (zone.followHeroId as string) ?? '',
       }
       for (const cb of this.serverZoneAddCallbacks) cb(state)
     })

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -136,7 +136,10 @@ export class GameScene extends Phaser.Scene {
 
     this.meleeSwing = new MeleeSwingRenderer(this)
     this.projectileRenderer = new ProjectileRenderer(this)
-    this.zoneRenderer = new ZoneRenderer(this, this.localTeam)
+    this.zoneRenderer = new ZoneRenderer(this, this.localTeam, (heroId) => {
+      const entity = this.entityManager.getEntity(heroId)
+      return entity ? entity.position : null
+    })
 
     const localRenderer = this.entityRenderers.get(this.entityManager.localHeroId)!
     this.cameras.main.startFollow(localRenderer.gameObject, true, CAMERA_LERP, CAMERA_LERP)

--- a/src/scenes/__tests__/NetworkBridge.test.ts
+++ b/src/scenes/__tests__/NetworkBridge.test.ts
@@ -83,7 +83,7 @@ describe('NetworkBridge', () => {
 
       const zoneState: ServerZoneState = {
         id: 'zone-1', x: 300, y: 100, radius: 200,
-        skillId: 'aura-slow-field', team: 'blue',
+        skillId: 'aura-slow-field', team: 'blue', followHeroId: '',
       }
       gm._triggerServerZoneAdd(zoneState)
       expect(onAdded).toHaveBeenCalledWith(zoneState)

--- a/src/scenes/effects/ZoneRenderer.ts
+++ b/src/scenes/effects/ZoneRenderer.ts
@@ -4,20 +4,26 @@ import { getZoneVisual } from '@shared/zone/zoneVisuals'
 
 const ZONE_DEPTH = -1
 
+/** Resolves the current rendered position of a hero by session ID. */
+export type HeroPositionResolver = (heroId: string) => { x: number; y: number } | null
+
 /**
  * Renders all active zones each frame.
  * Visual style is determined by skillId via ZONE_VISUALS registry.
  * Zones with allyOnly skip rendering when the local player is on the enemy team.
+ * Follow zones derive their position from the hero's interpolated coordinates.
  */
 export class ZoneRenderer {
   private readonly graphics: Phaser.GameObjects.Graphics
   private readonly zones = new Map<string, ServerZoneState>()
   private readonly localTeam: string
+  private readonly getHeroPosition: HeroPositionResolver
 
-  constructor(scene: Phaser.Scene, localTeam: string) {
+  constructor(scene: Phaser.Scene, localTeam: string, getHeroPosition: HeroPositionResolver) {
     this.graphics = scene.add.graphics()
     this.graphics.setDepth(ZONE_DEPTH)
     this.localTeam = localTeam
+    this.getHeroPosition = getHeroPosition
   }
 
   add(state: ServerZoneState): void {
@@ -37,14 +43,24 @@ export class ZoneRenderer {
       // allyOnly zones are hidden from the enemy team
       if (visual.allyOnly && zone.team !== this.localTeam) continue
 
+      // Follow zones use the hero's interpolated position for lag-free rendering
+      let { x, y } = zone
+      if (zone.followHeroId !== '') {
+        const heroPos = this.getHeroPosition(zone.followHeroId)
+        if (heroPos) {
+          x = heroPos.x
+          y = heroPos.y
+        }
+      }
+
       // Fill
       this.graphics.fillStyle(visual.color, visual.alpha)
-      this.graphics.fillCircle(zone.x, zone.y, zone.radius)
+      this.graphics.fillCircle(x, y, zone.radius)
 
       // Border
       if (visual.borderWidth > 0) {
         this.graphics.lineStyle(visual.borderWidth, visual.borderColor, visual.borderAlpha)
-        this.graphics.strokeCircle(zone.x, zone.y, zone.radius)
+        this.graphics.strokeCircle(x, y, zone.radius)
       }
     }
   }

--- a/src/scenes/effects/__tests__/ZoneRenderer.test.ts
+++ b/src/scenes/effects/__tests__/ZoneRenderer.test.ts
@@ -44,9 +44,12 @@ function createZone(overrides: Partial<ServerZoneState> = {}): ServerZoneState {
     radius: 200,
     skillId: 'aura-slow-field',
     team: 'blue',
+    followHeroId: '',
     ...overrides,
   }
 }
+
+const noopResolver = () => null
 
 describe('ZoneRenderer', () => {
   let mockScene: ReturnType<typeof createMockScene>
@@ -54,7 +57,7 @@ describe('ZoneRenderer', () => {
 
   beforeEach(() => {
     mockScene = createMockScene()
-    renderer = new ZoneRenderer(mockScene as unknown as Phaser.Scene, 'blue')
+    renderer = new ZoneRenderer(mockScene as unknown as Phaser.Scene, 'blue', noopResolver)
   })
 
   it('should draw nothing when no zones exist', () => {
@@ -135,6 +138,47 @@ describe('ZoneRenderer', () => {
       renderer.draw()
 
       expect(mockScene._graphics.fillCircle).toHaveBeenCalledWith(300, 100, 200)
+    })
+  })
+
+  describe('follow zone rendering', () => {
+    it('should draw follow zone at hero interpolated position', () => {
+      const heroResolver = (id: string) =>
+        id === 'hero-1' ? { x: 600, y: 400 } : null
+
+      const followRenderer = new ZoneRenderer(
+        mockScene as unknown as Phaser.Scene, 'blue', heroResolver
+      )
+
+      followRenderer.add(createZone({
+        id: 'zone-follow',
+        x: 100, y: 100, // server position (stale)
+        radius: 120,
+        skillId: 'blade-whirlwind',
+        followHeroId: 'hero-1',
+      }))
+      followRenderer.draw()
+
+      // Should use hero's interpolated position, not zone's server position
+      expect(mockScene._graphics.fillCircle).toHaveBeenCalledWith(600, 400, 120)
+    })
+
+    it('should fall back to server position when hero not found', () => {
+      const followRenderer = new ZoneRenderer(
+        mockScene as unknown as Phaser.Scene, 'blue', noopResolver
+      )
+
+      followRenderer.add(createZone({
+        id: 'zone-follow',
+        x: 100, y: 100,
+        radius: 120,
+        skillId: 'blade-whirlwind',
+        followHeroId: 'hero-missing',
+      }))
+      followRenderer.draw()
+
+      // Falls back to server zone position
+      expect(mockScene._graphics.fillCircle).toHaveBeenCalledWith(100, 100, 120)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Implement `blade-whirlwind` as a caster-following sustained damage zone (Depth 3 fire build skill)
- Extend the existing zone system with **follow zones** (track caster position), **tick damage** (periodic AoE), and **minion damage** support
- Client renders follow zones at hero's interpolated position for lag-free visual tracking

## Changes
**Shared**: `ZoneEffectParams` extended with `tickDamage`, `tickInterval`, `followCaster`; skill registered in `SKILL_DEFINITIONS`; red-orange visual in `ZONE_VISUALS`

**Server**: `ZoneSchema` + `ServerZoneSystem` extended for follow tracking (caster death removal), tick damage (heroes + minions); `zoneEffectHandler` applies self speed debuff (-40) on activation

**Client**: `ZoneRenderer` resolves follow zone position from `EntityManager` hero coordinates (interpolated), eliminating network-lag-induced visual drift

## Parameters
| Param | Value |
|-------|-------|
| Cooldown | 12s |
| Radius | 120px |
| Duration | 3s |
| Tick Damage | 30 (x6 = 180 total) |
| Tick Interval | 0.5s |
| Speed Debuff | -40 |

## Test plan
- [x] 16 server unit tests: skill definition, zone creation, follow tracking, caster death removal, tick damage (heroes, minions, allies, multi-target, 180 total), speed debuff
- [x] 2 client unit tests: follow zone renders at hero position, fallback to server position
- [x] All 921 existing unit tests pass
- [x] All 11 E2E tests pass
- [x] Existing zone tests (slow-field: 13, bolt-trap: 12) pass unchanged

Closes #200