### PR TITLE
feat: AURA Sanctuary protective follow zone (#217)

### DIFF
--- a/openspec/changes/archive/2026-03-11-aura-sanctuary/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-aura-sanctuary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-11-aura-sanctuary/design.md
+++ b/openspec/changes/archive/2026-03-11-aura-sanctuary/design.md
@@ -1,0 +1,59 @@
+## Overview
+
+Sanctuary is a caster-following ally buff zone for AURA. It reuses the follow-zone infrastructure from Whirlwind (#200) and extends `tickZones()` with a `tickHeal` path that mirrors the existing `tickDamage` path but targets allies.
+
+## Parameters
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| cooldown | 20s | High-tier (Depth 7), long commitment |
+| radius | 160px | Slightly larger than Whirlwind (120) — support needs wider coverage |
+| duration | 5s | Longer than Whirlwind (3s) — sustain over burst |
+| damageReduction | 0.25 (25%) | Applied as zone status effect to allies |
+| tickHeal | 15 HP | Per tick to each ally in radius |
+| tickInterval | 1.0s | 5 ticks over 5s = 75 HP total per ally |
+| followCaster | true | Moves with AURA |
+| self slow | none | AURA is support — needs mobility to stay near team. Long cooldown is the tradeoff. |
+
+## Key Design Decisions
+
+### Decision #1: Extend zone system with `tickHeal` (not new effectType)
+`tickDamage` damages enemies on interval. `tickHeal` heals allies on the same interval using the same `tickTimer`. Symmetric design, minimal new code.
+
+**Alternative rejected:** Using `tickDamage` with negative values for healing — confusing semantics, breaks the damage/heal distinction.
+
+### Decision #2: No self-slow on Sanctuary
+Unlike Whirlwind (which slows the caster), Sanctuary has no self-debuff. AURA is a support who needs to position with the team. The tradeoff is the 20s cooldown. This also avoids the self-debuff coupling issue (#241) entirely — `zoneEffect.isDebuff` is `false`, so the existing handler code won't apply a self-effect.
+
+### Decision #3: Damage reduction via zone status effect
+Uses existing `zoneEffect` with `buffType: 'damageReduction'` and `target: 'ally'`. The `shouldAffect()` function already handles ally targeting. Status effect refreshes every tick while in range, expires via `ZONE_EFFECT_DURATION` (0.1s) when leaving — identical to how slow-field works.
+
+### Decision #4: tickHeal uses the same tickTimer as tickDamage
+One zone can have both `tickDamage` and `tickHeal`. Timer is shared. For Sanctuary, only `tickHeal` is set (tickDamage = 0). This keeps the timer logic simple and avoids a second timer.
+
+## Data Flow
+
+```
+executeSkill → zoneEffectHandler
+  → creates ZoneSchema with followHeroId, tickHeal, zoneEffect(damageReduction, ally)
+  → no self-debuff (isDebuff = false)
+
+tickZones (each frame):
+  → follow zone: update x,y from caster
+  → tickTimer: count down, fire on interval
+  → heroes loop (shouldAffect = ally):
+    → apply/refresh damageReduction status effect
+    → if tickHealThisTick: hero.hp = min(hero.hp + tickHeal, hero.maxHp)
+  → minion heal: skip (tickHeal does not affect minions — heroes only)
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `shared/skills/skillDefinitions.ts` | Add `tickHeal?: number` to `ZoneEffectParams`, register `aura-sanctuary` |
+| `server/src/schema/ZoneSchema.ts` | Add `tickHeal: number` (server-only, no `@type`) |
+| `server/src/game/ServerZoneSystem.ts` | Add ally heal loop in `tickZones()` |
+| `server/src/game/skills/handlers/zoneEffectHandler.ts` | Set `zone.tickHeal` from params |
+| `shared/zone/zoneVisuals.ts` | Add `aura-sanctuary` visual (blue-gold) |
+| `server/src/__tests__/auraSanctuary.test.ts` | New test file |

--- a/openspec/changes/archive/2026-03-11-aura-sanctuary/proposal.md
+++ b/openspec/changes/archive/2026-03-11-aura-sanctuary/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+AURA has no sustained protective ability. Current kit (heal, haste, weaken, nova, slow-field) lacks a high-commitment team-fight zone. Sanctuary fills the Depth 7 / Cost 3 slot with a caster-following ally zone that rewards positioning and team coordination. The follow-zone infrastructure from Whirlwind (Issue #200) is already in place, making this a natural next step.
+
+## What Changes
+
+- Register `aura-sanctuary` as a self-targeting follow zone skill (`followCaster: true`, `target: 'ally'`)
+- Extend zone system with `tickHeal` — periodic healing for allies within radius (mirrors `tickDamage` for enemies)
+- Add `tickHeal` field to `ZoneSchema` (server-only) and `ZoneEffectParams`
+- Extend `tickZones()` to heal allies when `tickHeal > 0` on tick intervals
+- Add blue-gold zone visual for Sanctuary in `ZONE_VISUALS`
+
+## Capabilities
+
+### New Capabilities
+- `aura-sanctuary`: AURA's sustained protective follow-zone skill — damage reduction buff + periodic healing for allies in radius
+
+### Modified Capabilities
+_(none — reuses and extends existing zone infrastructure without changing existing behavior)_
+
+## Impact
+
+- **Server:** `ServerZoneSystem.ts` (add ally heal loop), `ZoneSchema.ts` (+tickHeal field), `zoneEffectHandler.ts` (set tickHeal), `skillDefinitions.ts` (+definition)
+- **Client:** `zoneVisuals.ts` (+visual entry). No new rendering logic needed — reuses existing ZoneRenderer.
+- **Shared:** `skillDefinitions.ts` (ZoneEffectParams +tickHeal)
+- **Tests:** New test file for Sanctuary covering creation, follow tracking, tick healing, damage reduction, and edge cases

--- a/openspec/changes/archive/2026-03-11-aura-sanctuary/specs/aura-sanctuary/spec.md
+++ b/openspec/changes/archive/2026-03-11-aura-sanctuary/specs/aura-sanctuary/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Sanctuary skill definition
+The system SHALL register `aura-sanctuary` in `SKILL_DEFINITIONS` with `targeting: 'self'`, `effectType: 'zone'`, `cooldown: 20`, `zoneRadius: 160`, `zoneDuration: 5`, `tickHeal: 15`, `tickInterval: 1.0`, and `followCaster: true`.
+
+#### Scenario: Skill definition is registered
+- **WHEN** `getSkillDefinition('aura-sanctuary')` is called
+- **THEN** it SHALL return a valid `SkillDefinition` with `effectType: 'zone'`, `cooldown: 20`, `zoneRadius: 160`, `zoneDuration: 5`
+
+### Requirement: Sanctuary creates a follow zone on activation
+When an AURA hero activates `aura-sanctuary`, the server SHALL create a zone centered on the caster's position with `followHeroId` set to the caster's session ID. The zone SHALL move with the caster each tick.
+
+#### Scenario: Zone is created at caster position
+- **WHEN** an AURA hero at position (400, 300) activates `aura-sanctuary`
+- **THEN** a zone SHALL be created with `x: 400`, `y: 300`, `radius: 160`, `followHeroId` set to the caster's session ID, and `remainingDuration: 5`
+
+#### Scenario: Zone follows caster movement
+- **WHEN** the caster moves from (400, 300) to (500, 350) during Sanctuary
+- **THEN** the zone's coordinates SHALL update to (500, 350) on each tick
+
+### Requirement: Sanctuary applies damage reduction to allies in radius
+The zone SHALL apply a `damageReduction` status effect with `value: 0.25` to all ally heroes within its radius. The effect SHALL refresh while in range and expire shortly after leaving (via `ZONE_EFFECT_DURATION`).
+
+#### Scenario: Ally receives damage reduction
+- **WHEN** an ally hero is within 160px of the Sanctuary zone center
+- **THEN** the ally SHALL have a `damageReduction` status effect with `value: 0.25`
+
+#### Scenario: Damage reduction expires after leaving zone
+- **WHEN** an ally hero moves outside the zone radius
+- **THEN** the `damageReduction` status effect SHALL expire within `ZONE_EFFECT_DURATION` (0.1s)
+
+#### Scenario: Enemies are not affected by damage reduction
+- **WHEN** an enemy hero is within the Sanctuary zone radius
+- **THEN** the enemy SHALL NOT receive any status effect from the zone
+
+### Requirement: Sanctuary heals allies periodically
+The zone SHALL heal all ally heroes within its radius by `tickHeal` HP at each `tickInterval`. Healing SHALL NOT exceed `maxHp`.
+
+#### Scenario: Ally receives tick healing
+- **WHEN** an ally hero is within 160px of the zone center and 1.0 seconds have elapsed since the last tick
+- **THEN** the ally SHALL be healed for 15 HP (capped at maxHp)
+
+#### Scenario: Healing does not exceed maxHp
+- **WHEN** an ally hero at 645/650 HP is within the Sanctuary zone on a heal tick
+- **THEN** the ally's HP SHALL be set to 650 (not 660)
+
+#### Scenario: Multiple allies healed simultaneously
+- **WHEN** two ally heroes are both within the zone radius on a heal tick
+- **THEN** both allies SHALL each be healed for 15 HP
+
+#### Scenario: Total healing over full duration
+- **WHEN** an ally remains inside the Sanctuary zone for the full 5-second duration
+- **THEN** the ally SHALL receive approximately 75 total healing (15 HP × 5 ticks at 1.0s intervals)
+
+#### Scenario: Enemies are not healed
+- **WHEN** an enemy hero is within the Sanctuary zone radius on a heal tick
+- **THEN** the enemy SHALL NOT receive any healing
+
+### Requirement: Sanctuary zone is removed on caster death
+If the caster dies while Sanctuary is active, the zone SHALL be immediately removed.
+
+#### Scenario: Caster dies during Sanctuary
+- **WHEN** the caster's HP reaches 0 while Sanctuary zone is active
+- **THEN** the zone SHALL be removed in the same tick
+
+### Requirement: Sanctuary is blocked during dash
+Sanctuary activation SHALL be rejected if the caster is currently dashing.
+
+#### Scenario: Activation rejected while dashing
+- **WHEN** a hero with `dashTimer > 0` attempts to activate `aura-sanctuary`
+- **THEN** the activation SHALL return null and no zone SHALL be created
+
+### Requirement: Sanctuary cooldown
+After successful activation, the skill's cooldown SHALL be set to 20 seconds.
+
+#### Scenario: Cooldown is applied after activation
+- **WHEN** `aura-sanctuary` is successfully activated on slot Q
+- **THEN** the caster's `cooldownQ` SHALL be set to 20
+
+### Requirement: Sanctuary zone visual
+The client SHALL render the Sanctuary zone with a blue-gold color scheme in `ZONE_VISUALS`. The zone SHALL be visible to all players.
+
+#### Scenario: Zone is visible to all players
+- **WHEN** a Sanctuary zone is active
+- **THEN** both ally and enemy players SHALL see the zone rendered as a filled circle with border
+
+### Requirement: Sanctuary does not apply self-debuff
+Unlike Whirlwind, Sanctuary SHALL NOT apply any debuff to the caster. The caster retains full movement speed during the zone's duration.
+
+#### Scenario: No self-slow on activation
+- **WHEN** an AURA hero activates `aura-sanctuary`
+- **THEN** the caster SHALL NOT have any new debuff status effects applied

--- a/openspec/changes/archive/2026-03-11-aura-sanctuary/tasks.md
+++ b/openspec/changes/archive/2026-03-11-aura-sanctuary/tasks.md
@@ -1,0 +1,12 @@
+## Backend Tasks
+
+- [x] 1. Add `tickHeal?: number` to `ZoneEffectParams` in `shared/skills/skillDefinitions.ts`
+- [x] 2. Register `aura-sanctuary` skill definition in `SKILL_DEFINITIONS`
+- [x] 3. Add `tickHeal: number = 0` server-only field to `ZoneSchema` (no `@type` decorator)
+- [x] 4. Set `zone.tickHeal` from params in `zoneEffectHandler.ts`
+- [x] 5. Extend `tickZones()` in `ServerZoneSystem.ts` to heal ally heroes when `tickHeal > 0` on tick interval (cap at maxHp)
+- [x] 6. Write server tests: skill definition, zone creation, follow tracking, tick healing (single/multi ally, maxHp cap, total healing, enemy not healed), damage reduction applied to allies, caster death removal, no self-debuff
+
+## Frontend Tasks
+
+- [x] 7. Add `aura-sanctuary` entry in `shared/zone/zoneVisuals.ts` (blue-gold color scheme, visible to all)

--- a/openspec/specs/aura-sanctuary/spec.md
+++ b/openspec/specs/aura-sanctuary/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Sanctuary skill definition
+The system SHALL register `aura-sanctuary` in `SKILL_DEFINITIONS` with `targeting: 'self'`, `effectType: 'zone'`, `cooldown: 20`, `zoneRadius: 160`, `zoneDuration: 5`, `tickHeal: 15`, `tickInterval: 1.0`, and `followCaster: true`.
+
+#### Scenario: Skill definition is registered
+- **WHEN** `getSkillDefinition('aura-sanctuary')` is called
+- **THEN** it SHALL return a valid `SkillDefinition` with `effectType: 'zone'`, `cooldown: 20`, `zoneRadius: 160`, `zoneDuration: 5`
+
+### Requirement: Sanctuary creates a follow zone on activation
+When an AURA hero activates `aura-sanctuary`, the server SHALL create a zone centered on the caster's position with `followHeroId` set to the caster's session ID. The zone SHALL move with the caster each tick.
+
+#### Scenario: Zone is created at caster position
+- **WHEN** an AURA hero at position (400, 300) activates `aura-sanctuary`
+- **THEN** a zone SHALL be created with `x: 400`, `y: 300`, `radius: 160`, `followHeroId` set to the caster's session ID, and `remainingDuration: 5`
+
+#### Scenario: Zone follows caster movement
+- **WHEN** the caster moves from (400, 300) to (500, 350) during Sanctuary
+- **THEN** the zone's coordinates SHALL update to (500, 350) on each tick
+
+### Requirement: Sanctuary applies damage reduction to allies in radius
+The zone SHALL apply a `damageReduction` status effect with `value: 0.25` to all ally heroes within its radius. The effect SHALL refresh while in range and expire shortly after leaving (via `ZONE_EFFECT_DURATION`).
+
+#### Scenario: Ally receives damage reduction
+- **WHEN** an ally hero is within 160px of the Sanctuary zone center
+- **THEN** the ally SHALL have a `damageReduction` status effect with `value: 0.25`
+
+#### Scenario: Damage reduction expires after leaving zone
+- **WHEN** an ally hero moves outside the zone radius
+- **THEN** the `damageReduction` status effect SHALL expire within `ZONE_EFFECT_DURATION` (0.1s)
+
+#### Scenario: Enemies are not affected by damage reduction
+- **WHEN** an enemy hero is within the Sanctuary zone radius
+- **THEN** the enemy SHALL NOT receive any status effect from the zone
+
+### Requirement: Sanctuary heals allies periodically
+The zone SHALL heal all ally heroes within its radius by `tickHeal` HP at each `tickInterval`. Healing SHALL NOT exceed `maxHp`.
+
+#### Scenario: Ally receives tick healing
+- **WHEN** an ally hero is within 160px of the zone center and 1.0 seconds have elapsed since the last tick
+- **THEN** the ally SHALL be healed for 15 HP (capped at maxHp)
+
+#### Scenario: Healing does not exceed maxHp
+- **WHEN** an ally hero at 645/650 HP is within the Sanctuary zone on a heal tick
+- **THEN** the ally's HP SHALL be set to 650 (not 660)
+
+#### Scenario: Multiple allies healed simultaneously
+- **WHEN** two ally heroes are both within the zone radius on a heal tick
+- **THEN** both allies SHALL each be healed for 15 HP
+
+#### Scenario: Total healing over full duration
+- **WHEN** an ally remains inside the Sanctuary zone for the full 5-second duration
+- **THEN** the ally SHALL receive approximately 75 total healing (15 HP × 5 ticks at 1.0s intervals)
+
+#### Scenario: Enemies are not healed
+- **WHEN** an enemy hero is within the Sanctuary zone radius on a heal tick
+- **THEN** the enemy SHALL NOT receive any healing
+
+### Requirement: Sanctuary zone is removed on caster death
+If the caster dies while Sanctuary is active, the zone SHALL be immediately removed.
+
+#### Scenario: Caster dies during Sanctuary
+- **WHEN** the caster's HP reaches 0 while Sanctuary zone is active
+- **THEN** the zone SHALL be removed in the same tick
+
+### Requirement: Sanctuary is blocked during dash
+Sanctuary activation SHALL be rejected if the caster is currently dashing.
+
+#### Scenario: Activation rejected while dashing
+- **WHEN** a hero with `dashTimer > 0` attempts to activate `aura-sanctuary`
+- **THEN** the activation SHALL return null and no zone SHALL be created
+
+### Requirement: Sanctuary cooldown
+After successful activation, the skill's cooldown SHALL be set to 20 seconds.
+
+#### Scenario: Cooldown is applied after activation
+- **WHEN** `aura-sanctuary` is successfully activated on slot Q
+- **THEN** the caster's `cooldownQ` SHALL be set to 20
+
+### Requirement: Sanctuary zone visual
+The client SHALL render the Sanctuary zone with a blue-gold color scheme in `ZONE_VISUALS`. The zone SHALL be visible to all players.
+
+#### Scenario: Zone is visible to all players
+- **WHEN** a Sanctuary zone is active
+- **THEN** both ally and enemy players SHALL see the zone rendered as a filled circle with border
+
+### Requirement: Sanctuary does not apply self-debuff
+Unlike Whirlwind, Sanctuary SHALL NOT apply any debuff to the caster. The caster retains full movement speed during the zone's duration.
+
+#### Scenario: No self-slow on activation
+- **WHEN** an AURA hero activates `aura-sanctuary`
+- **THEN** the caster SHALL NOT have any new debuff status effects applied

--- a/server/src/__tests__/auraSanctuary.test.ts
+++ b/server/src/__tests__/auraSanctuary.test.ts
@@ -207,6 +207,22 @@ describe('tickZones — Sanctuary tick healing', () => {
     expect(ally.hp).toBe(515) // 500 + 15
   })
 
+  it('should heal the caster themselves (same team)', () => {
+    const caster = createHero({ x: 400, y: 300, hp: 500, maxHp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 1.0)
+
+    expect(caster.hp).toBe(515) // 500 + 15 — caster is ally to own zone
+    const effect = caster.statusEffects.get('zone-1')
+    expect(effect).toBeDefined()
+    expect(effect!.buffType).toBe('damageReduction')
+  })
+
   it('should not heal enemies', () => {
     const caster = createHero({ x: 400, y: 300 })
     const enemy = createHero({ x: 450, y: 300, team: 'red', hp: 500, maxHp: 650 })

--- a/server/src/__tests__/auraSanctuary.test.ts
+++ b/server/src/__tests__/auraSanctuary.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { ZoneSchema } from '../schema/ZoneSchema.js'
+import { tickZones } from '../game/ServerZoneSystem.js'
+import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
+import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+
+let tracker: ProjectileTracker
+
+function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 650
+  hero.maxHp = 650
+  hero.dead = false
+  hero.team = 'blue'
+  hero.x = 400
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'AURA'
+  hero.skillSlotQ = 'aura-sanctuary'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+function createSanctuaryZone(
+  casterId: string,
+  team: string,
+  x: number,
+  y: number,
+  overrides: Partial<Record<string, unknown>> = {},
+): ZoneSchema {
+  const zone = new ZoneSchema()
+  zone.x = x
+  zone.y = y
+  zone.radius = 160
+  zone.remainingDuration = 5
+  zone.team = team
+  zone.casterId = casterId
+  zone.skillId = 'aura-sanctuary'
+  zone.buffType = 'damageReduction'
+  zone.value = 0.25
+  zone.isDebuff = false
+  zone.target = 'ally'
+  zone.tickDamage = 0
+  zone.tickHeal = 15
+  zone.tickInterval = 1.0
+  zone.tickTimer = 0
+  zone.followHeroId = casterId
+  Object.assign(zone, overrides)
+  return zone
+}
+
+beforeEach(() => {
+  registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
+})
+
+// ── Skill definition tests ──
+
+describe('getSkillDefinition — aura-sanctuary', () => {
+  it('should return aura-sanctuary definition with correct params', () => {
+    const def = getSkillDefinition('aura-sanctuary')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('aura-sanctuary')
+    expect(def!.targeting).toBe('self')
+    expect(def!.cooldown).toBe(20)
+    expect(def!.effect.effectType).toBe('zone')
+    if (def!.effect.effectType === 'zone') {
+      expect(def!.effect.zoneRadius).toBe(160)
+      expect(def!.effect.zoneDuration).toBe(5)
+      expect(def!.effect.tickHeal).toBe(15)
+      expect(def!.effect.tickInterval).toBe(1.0)
+      expect(def!.effect.followCaster).toBe(true)
+    }
+  })
+})
+
+// ── Skill execution tests ──
+
+describe('executeSkill — aura-sanctuary', () => {
+  it('should create a zone at caster position', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('aura-sanctuary')
+    expect(zones.size).toBe(1)
+
+    const zone = [...zones.values()][0]
+    expect(zone.x).toBe(400)
+    expect(zone.y).toBe(300)
+    expect(zone.radius).toBe(160)
+    expect(zone.remainingDuration).toBe(5)
+    expect(zone.followHeroId).toBe('caster-1')
+    expect(zone.tickHeal).toBe(15)
+    expect(zone.tickInterval).toBe(1.0)
+    expect(zone.tickTimer).toBe(0)
+  })
+
+  it('should set cooldown to 20 seconds', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(caster.cooldownQ).toBe(20)
+  })
+
+  it('should reject activation while dashing', () => {
+    const caster = createHero({ x: 400, y: 300, dashTimer: 0.2 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(event).toBeNull()
+    expect(zones.size).toBe(0)
+  })
+
+  it('should NOT apply self-debuff to caster', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    // Sanctuary has isDebuff: false, so no self-debuff should be applied
+    expect(caster.statusEffects.get('aura-sanctuary')).toBeUndefined()
+  })
+})
+
+// ── Follow zone tests ──
+
+describe('tickZones — Sanctuary follow zone', () => {
+  it('should update zone position to follow caster', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    caster.x = 500
+    caster.y = 350
+
+    tickZones(zones, heroes, 0.016)
+
+    const zone = zones.get('zone-1')!
+    expect(zone.x).toBe(500)
+    expect(zone.y).toBe(350)
+  })
+
+  it('should remove zone when caster dies', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    caster.hp = 0
+    caster.dead = true
+
+    tickZones(zones, heroes, 0.016)
+
+    expect(zones.size).toBe(0)
+  })
+
+  it('should remove zone when caster is not found', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 0.016)
+
+    expect(zones.size).toBe(0)
+  })
+})
+
+// ── Tick healing tests ──
+
+describe('tickZones — Sanctuary tick healing', () => {
+  it('should heal ally hero in radius on tick', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const ally = createHero({ x: 450, y: 300, hp: 500, maxHp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 1.0)
+
+    expect(ally.hp).toBe(515) // 500 + 15
+  })
+
+  it('should not heal enemies', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const enemy = createHero({ x: 450, y: 300, team: 'red', hp: 500, maxHp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 1.0)
+
+    expect(enemy.hp).toBe(500) // no healing
+  })
+
+  it('should cap healing at maxHp', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const ally = createHero({ x: 450, y: 300, hp: 645, maxHp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 1.0)
+
+    expect(ally.hp).toBe(650) // capped at maxHp, not 660
+  })
+
+  it('should heal multiple allies simultaneously', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const ally1 = createHero({ x: 450, y: 300, hp: 500, maxHp: 650 })
+    const ally2 = createHero({ x: 400, y: 350, hp: 400, maxHp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally1)
+    heroes.set('ally-2', ally2)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 1.0)
+
+    expect(ally1.hp).toBe(515) // 500 + 15
+    expect(ally2.hp).toBe(415) // 400 + 15
+  })
+
+  it('should deal approximately 75 total healing over full 5s duration (5 ticks)', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const ally = createHero({ x: 450, y: 300, hp: 400, maxHp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    // Simulate 5 ticks at 1.0s each
+    for (let i = 0; i < 5; i++) {
+      tickZones(zones, heroes, 1.0)
+    }
+
+    // 5 ticks x 15 heal = 75 total
+    expect(ally.hp).toBe(475) // 400 + 75
+  })
+
+  it('should heal on first tick immediately, then wait for interval', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const ally = createHero({ x: 450, y: 300, hp: 500, maxHp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    // First tick fires immediately
+    tickZones(zones, heroes, 0.016)
+    expect(ally.hp).toBe(515) // 500 + 15
+
+    // 0.5s later — less than 1.0s interval, no additional heal
+    tickZones(zones, heroes, 0.5)
+    expect(ally.hp).toBe(515)
+  })
+
+  it('should not heal allies outside radius', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const farAlly = createHero({ x: 700, y: 300, hp: 500, maxHp: 650 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', farAlly)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 1.0)
+
+    expect(farAlly.hp).toBe(500) // too far, no healing
+  })
+})
+
+// ── Damage reduction status effect tests ──
+
+describe('tickZones — Sanctuary damage reduction', () => {
+  it('should apply damageReduction status effect to ally in radius', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const ally = createHero({ x: 450, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 0.016)
+
+    const effect = ally.statusEffects.get('zone-1')
+    expect(effect).toBeDefined()
+    expect(effect!.buffType).toBe('damageReduction')
+    expect(effect!.value).toBe(0.25)
+    expect(effect!.isDebuff).toBe(false)
+  })
+
+  it('should NOT apply damageReduction to enemy in radius', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const enemy = createHero({ x: 450, y: 300, team: 'red' })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createSanctuaryZone('caster-1', 'blue', 400, 300))
+
+    tickZones(zones, heroes, 0.016)
+
+    expect(enemy.statusEffects.get('zone-1')).toBeUndefined()
+  })
+})

--- a/server/src/game/ServerZoneSystem.ts
+++ b/server/src/game/ServerZoneSystem.ts
@@ -16,7 +16,7 @@ function shouldAffect(zone: ZoneSchema, hero: HeroSchema): boolean {
 
 /**
  * Tick all zones: decrement duration, apply effects to heroes in range, remove expired zones.
- * Supports follow zones (track caster position) and tick damage (sustained AoE).
+ * Supports follow zones (track caster position), tick damage (sustained AoE), and tick heal (sustained ally heal).
  */
 export function tickZones(
   zones: MapSchema<ZoneSchema>,
@@ -42,12 +42,12 @@ export function tickZones(
 
     const radiusSq = zone.radius * zone.radius
 
-    // Tick damage timer
-    let tickDamageThisTick = false
-    if (zone.tickDamage > 0 && zone.tickInterval > 0) {
+    // Tick timer (shared by tickDamage and tickHeal)
+    let tickFiredThisTick = false
+    if ((zone.tickDamage > 0 || zone.tickHeal > 0) && zone.tickInterval > 0) {
       zone.tickTimer -= dt
       if (zone.tickTimer <= 0) {
-        tickDamageThisTick = true
+        tickFiredThisTick = true
         zone.tickTimer += zone.tickInterval
       }
     }
@@ -71,9 +71,14 @@ export function tickZones(
       }
 
       // Tick damage (sustained damage zones like Whirlwind)
-      if (tickDamageThisTick) {
+      if (tickFiredThisTick && zone.tickDamage > 0) {
         hero.applyDamage(zone.tickDamage)
         hero.lastAttackerSessionId = zone.casterId
+      }
+
+      // Tick heal (sustained heal zones like Sanctuary)
+      if (tickFiredThisTick && zone.tickHeal > 0) {
+        hero.hp = Math.min(hero.hp + zone.tickHeal, hero.maxHp)
       }
 
       // Apply or refresh status effect (skip for expired zones)
@@ -96,7 +101,7 @@ export function tickZones(
     })
 
     // Tick damage to enemy minions
-    if (tickDamageThisTick && minions) {
+    if (tickFiredThisTick && zone.tickDamage > 0 && minions) {
       minions.forEach((minion) => {
         if (minion.dead) return
         if (minion.team === zone.team) return

--- a/server/src/game/skills/handlers/zoneEffectHandler.ts
+++ b/server/src/game/skills/handlers/zoneEffectHandler.ts
@@ -32,6 +32,7 @@ export const zoneEffectHandler: SkillEffectHandler<ZoneEffectParams> = {
     zone.triggerOnce = params.triggerOnce ?? false
     zone.effectDuration = params.zoneEffect.duration ?? 0
     zone.tickDamage = params.tickDamage ?? 0
+    zone.tickHeal = params.tickHeal ?? 0
     zone.tickInterval = params.tickInterval ?? 0
     zone.tickTimer = 0 // first tick fires immediately
 

--- a/server/src/schema/ZoneSchema.ts
+++ b/server/src/schema/ZoneSchema.ts
@@ -30,6 +30,8 @@ export class ZoneSchema extends Schema {
   // Server-only fields (not synced to clients)
   /** Damage per tick for sustained damage zones (0 = no tick damage) */
   tickDamage: number = 0
+  /** Healing per tick for sustained heal zones (0 = no tick heal) */
+  tickHeal: number = 0
   /** Seconds between tick damage applications */
   tickInterval: number = 0
   /** Countdown timer for next tick damage application */

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -50,7 +50,8 @@ export interface ZoneEffectParams {
   readonly triggerDamage?: number   // damage on trigger (0 = no trigger damage)
   readonly triggerOnce?: boolean    // true = zone removed after first trigger
   readonly tickDamage?: number     // damage per tick (0 = no tick damage)
-  readonly tickInterval?: number   // seconds between tick damage applications
+  readonly tickHeal?: number       // healing per tick to allies (0 = no tick heal)
+  readonly tickInterval?: number   // seconds between tick damage/heal applications
   readonly followCaster?: boolean  // true = zone follows caster position each tick
   readonly zoneEffect: {
     readonly buffType: string       // effect category ('speed', etc.)
@@ -228,6 +229,25 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
         value: -40,
         isDebuff: true,
         target: 'enemy',
+      },
+    },
+  },
+  'aura-sanctuary': {
+    id: 'aura-sanctuary',
+    targeting: 'self',
+    cooldown: 20,
+    effect: {
+      effectType: 'zone',
+      zoneRadius: 160,
+      zoneDuration: 5,
+      tickHeal: 15,
+      tickInterval: 1.0,
+      followCaster: true,
+      zoneEffect: {
+        buffType: 'damageReduction',
+        value: 0.25,
+        isDebuff: false,
+        target: 'ally',
       },
     },
   },

--- a/shared/zone/zoneVisuals.ts
+++ b/shared/zone/zoneVisuals.ts
@@ -28,6 +28,13 @@ export const ZONE_VISUALS: Record<string, ZoneVisualDef> = {
     borderAlpha: 0.7,
     borderWidth: 2,
   },
+  'aura-sanctuary': {
+    color: 0x3498db,
+    alpha: 0.2,
+    borderColor: 0xf1c40f,
+    borderAlpha: 0.6,
+    borderWidth: 2,
+  },
   'bolt-trap': {
     color: 0xf1c40f,
     alpha: 0.15,


### PR DESCRIPTION
## Summary
- Add `aura-sanctuary` skill: caster-following ally zone with damage reduction (25%) and periodic healing (15 HP/s)
- Extend zone system with `tickHeal` field (mirrors `tickDamage` for allies)
- Generalize tick timer to support both damage and heal zones
- 17 new server tests covering skill definition, zone creation, follow tracking, tick healing, damage reduction, and edge cases

## Parameters
| Param | Value |
|-------|-------|
| Cooldown | 20s |
| Radius | 160px |
| Duration | 5s |
| Tick Heal | 15 HP / 1.0s (75 HP total) |
| Damage Reduction | 25% to allies |
| Follow | Caster |

## Test plan
- [x] Skill definition registered correctly
- [x] Zone created at caster position with followHeroId
- [x] Zone follows caster movement
- [x] Zone removed on caster death
- [x] Allies healed per tick (single, multi, maxHp cap)
- [x] 75 total healing over 5s duration
- [x] Enemies not healed
- [x] damageReduction status effect applied to allies
- [x] No self-debuff on caster
- [x] Existing Whirlwind tests still pass
- [x] Lint clean, 940 tests pass

Closes #217