### PR TITLE
feat: AURA Barrier point-placed protective zone (#213)

### DIFF
--- a/openspec/changes/archive/2026-03-11-aura-barrier/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-aura-barrier/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-11-aura-barrier/design.md
+++ b/openspec/changes/archive/2026-03-11-aura-barrier/design.md
@@ -1,0 +1,37 @@
+## Overview
+
+Barrier is a point-placed ally-protection zone for AURA. Unlike Sanctuary (follow caster, heal+DR), Barrier is a fixed-position zone that provides higher damage reduction but no healing. It's a simpler, earlier-available alternative (Depth 2 vs Depth 7).
+
+## Parameters
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| cooldown | 14s | Mid-tier, same as slow-field |
+| range | 500px | Point targeting range |
+| radius | 180px | Larger than Sanctuary (160) — fixed position needs wider coverage |
+| duration | 4s | Same as slow-field |
+| damageReduction | 0.30 (30%) | Higher than Sanctuary (25%) to compensate for no healing and fixed position |
+| target | ally | Only affects allied heroes |
+
+## Key Design Decisions
+
+### Decision #1: No new infrastructure needed
+Barrier is a pure skill definition + zone visual registration. The existing zone system already supports:
+- Point-placed zones (`targeting: 'point'`, no `followCaster`)
+- Ally targeting (`target: 'ally'`, `shouldAffect()` handles this)
+- Damage reduction buff (`buffType: 'damageReduction'`)
+- Zone status effect refresh (allies in range keep the buff, expires on leaving)
+
+### Decision #2: Fixed position (not follow caster)
+Unlike Sanctuary, Barrier is placed at a target point. This creates a strategic choice: place it on an ally being focused, on a choke point, or on an objective. The tradeoff vs Sanctuary is mobility — Barrier doesn't move but has higher DR.
+
+### Decision #3: No healing component
+Barrier provides pure damage reduction. Healing is covered by Heal (single target) and Sanctuary (zone). This keeps each skill focused on one thing.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `shared/skills/skillDefinitions.ts` | Register `aura-barrier` definition |
+| `shared/zone/zoneVisuals.ts` | Add visual entry (green-cyan) |
+| `server/src/__tests__/auraBarrier.test.ts` | New test file |

--- a/openspec/changes/archive/2026-03-11-aura-barrier/proposal.md
+++ b/openspec/changes/archive/2026-03-11-aura-barrier/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+AURA lacks an early-game protective tool. Heal and Haste are Depth 1 support skills, but there's no mid-tier zone-based protection. Barrier fills the Depth 2 / Cost 2 slot as a point-placed damage reduction zone, giving AURA a strategic area-denial/protection tool that complements the late-game Sanctuary (Depth 7 follow zone).
+
+## What Changes
+
+- Register `aura-barrier` as a point-targeting fixed zone skill (`target: 'ally'`, `damageReduction`)
+- Add green-cyan zone visual for Barrier in `ZONE_VISUALS`
+- No infrastructure changes — reuses existing zone system entirely
+
+## Capabilities
+
+### New Capabilities
+- `aura-barrier`: AURA's point-placed protective zone — damage reduction buff for allies standing in the area
+
+### Modified Capabilities
+_(none — pure registration, no infrastructure changes)_
+
+## Impact
+
+- **Shared:** `skillDefinitions.ts` (+definition), `zoneVisuals.ts` (+visual entry)
+- **Tests:** New test file for Barrier
+- **No server code changes** — existing zone system handles everything

--- a/openspec/changes/archive/2026-03-11-aura-barrier/specs/aura-barrier/spec.md
+++ b/openspec/changes/archive/2026-03-11-aura-barrier/specs/aura-barrier/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Barrier skill definition
+The system SHALL register `aura-barrier` in `SKILL_DEFINITIONS` with `targeting: 'point'`, `effectType: 'zone'`, `cooldown: 14`, `range: 500`, `zoneRadius: 180`, `zoneDuration: 4`.
+
+#### Scenario: Skill definition is registered
+- **WHEN** `getSkillDefinition('aura-barrier')` is called
+- **THEN** it SHALL return a valid `SkillDefinition` with `effectType: 'zone'`, `cooldown: 14`, `zoneRadius: 180`, `zoneDuration: 4`
+
+### Requirement: Barrier creates a fixed zone at target position
+When an AURA hero activates `aura-barrier`, the server SHALL create a zone at the target position. The zone SHALL NOT follow the caster.
+
+#### Scenario: Zone is created at target position
+- **WHEN** an AURA hero activates `aura-barrier` targeting position (600, 400)
+- **THEN** a zone SHALL be created with `x: 600`, `y: 400`, `radius: 180`, `remainingDuration: 4`, and `followHeroId: ''`
+
+### Requirement: Barrier applies damage reduction to allies in radius
+The zone SHALL apply a `damageReduction` status effect with `value: 0.30` to all ally heroes within its radius. The effect SHALL refresh while in range and expire shortly after leaving.
+
+#### Scenario: Ally receives damage reduction
+- **WHEN** an ally hero is within 180px of the Barrier zone center
+- **THEN** the ally SHALL have a `damageReduction` status effect with `value: 0.30`
+
+#### Scenario: Enemies are not affected
+- **WHEN** an enemy hero is within the Barrier zone radius
+- **THEN** the enemy SHALL NOT receive any status effect from the zone
+
+#### Scenario: Effect expires after leaving zone
+- **WHEN** an ally hero moves outside the zone radius
+- **THEN** the `damageReduction` effect SHALL expire within `ZONE_EFFECT_DURATION` (0.1s)
+
+### Requirement: Barrier cooldown
+After successful activation, the skill's cooldown SHALL be set to 14 seconds.
+
+#### Scenario: Cooldown is applied after activation
+- **WHEN** `aura-barrier` is successfully activated on slot Q
+- **THEN** the caster's `cooldownQ` SHALL be set to 14
+
+### Requirement: Barrier is blocked during dash
+Barrier activation SHALL be rejected if the caster is currently dashing.
+
+#### Scenario: Activation rejected while dashing
+- **WHEN** a hero with `dashTimer > 0` attempts to activate `aura-barrier`
+- **THEN** the activation SHALL return null and no zone SHALL be created
+
+### Requirement: Barrier zone visual
+The client SHALL render the Barrier zone with a green-cyan color scheme in `ZONE_VISUALS`. The zone SHALL be visible to all players.
+
+#### Scenario: Zone is visible to all players
+- **WHEN** a Barrier zone is active
+- **THEN** both ally and enemy players SHALL see the zone rendered as a filled circle with border
+
+### Requirement: Barrier zone expires after duration
+The zone SHALL be removed after its duration expires (4 seconds).
+
+#### Scenario: Zone removed after duration
+- **WHEN** 4 seconds have elapsed since Barrier was placed
+- **THEN** the zone SHALL be removed

--- a/openspec/changes/archive/2026-03-11-aura-barrier/tasks.md
+++ b/openspec/changes/archive/2026-03-11-aura-barrier/tasks.md
@@ -1,0 +1,8 @@
+## Backend Tasks
+
+- [x] 1. Register `aura-barrier` skill definition in `SKILL_DEFINITIONS`
+- [x] 2. Write server tests: skill definition, zone creation at target position, DR applied to allies, enemies not affected, cooldown, dash rejection, zone expiry
+
+## Frontend Tasks
+
+- [x] 3. Add `aura-barrier` entry in `shared/zone/zoneVisuals.ts` (green-cyan, visible to all)

--- a/openspec/specs/aura-barrier/spec.md
+++ b/openspec/specs/aura-barrier/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Barrier skill definition
+The system SHALL register `aura-barrier` in `SKILL_DEFINITIONS` with `targeting: 'point'`, `effectType: 'zone'`, `cooldown: 14`, `range: 500`, `zoneRadius: 180`, `zoneDuration: 4`.
+
+#### Scenario: Skill definition is registered
+- **WHEN** `getSkillDefinition('aura-barrier')` is called
+- **THEN** it SHALL return a valid `SkillDefinition` with `effectType: 'zone'`, `cooldown: 14`, `zoneRadius: 180`, `zoneDuration: 4`
+
+### Requirement: Barrier creates a fixed zone at target position
+When an AURA hero activates `aura-barrier`, the server SHALL create a zone at the target position. The zone SHALL NOT follow the caster.
+
+#### Scenario: Zone is created at target position
+- **WHEN** an AURA hero activates `aura-barrier` targeting position (600, 400)
+- **THEN** a zone SHALL be created with `x: 600`, `y: 400`, `radius: 180`, `remainingDuration: 4`, and `followHeroId: ''`
+
+### Requirement: Barrier applies damage reduction to allies in radius
+The zone SHALL apply a `damageReduction` status effect with `value: 0.30` to all ally heroes within its radius. The effect SHALL refresh while in range and expire shortly after leaving.
+
+#### Scenario: Ally receives damage reduction
+- **WHEN** an ally hero is within 180px of the Barrier zone center
+- **THEN** the ally SHALL have a `damageReduction` status effect with `value: 0.30`
+
+#### Scenario: Enemies are not affected
+- **WHEN** an enemy hero is within the Barrier zone radius
+- **THEN** the enemy SHALL NOT receive any status effect from the zone
+
+#### Scenario: Effect expires after leaving zone
+- **WHEN** an ally hero moves outside the zone radius
+- **THEN** the `damageReduction` effect SHALL expire within `ZONE_EFFECT_DURATION` (0.1s)
+
+### Requirement: Barrier cooldown
+After successful activation, the skill's cooldown SHALL be set to 14 seconds.
+
+#### Scenario: Cooldown is applied after activation
+- **WHEN** `aura-barrier` is successfully activated on slot Q
+- **THEN** the caster's `cooldownQ` SHALL be set to 14
+
+### Requirement: Barrier is blocked during dash
+Barrier activation SHALL be rejected if the caster is currently dashing.
+
+#### Scenario: Activation rejected while dashing
+- **WHEN** a hero with `dashTimer > 0` attempts to activate `aura-barrier`
+- **THEN** the activation SHALL return null and no zone SHALL be created
+
+### Requirement: Barrier zone visual
+The client SHALL render the Barrier zone with a green-cyan color scheme in `ZONE_VISUALS`. The zone SHALL be visible to all players.
+
+#### Scenario: Zone is visible to all players
+- **WHEN** a Barrier zone is active
+- **THEN** both ally and enemy players SHALL see the zone rendered as a filled circle with border
+
+### Requirement: Barrier zone expires after duration
+The zone SHALL be removed after its duration expires (4 seconds).
+
+#### Scenario: Zone removed after duration
+- **WHEN** 4 seconds have elapsed since Barrier was placed
+- **THEN** the zone SHALL be removed

--- a/server/src/__tests__/auraBarrier.test.ts
+++ b/server/src/__tests__/auraBarrier.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { ZoneSchema } from '../schema/ZoneSchema.js'
+import { tickZones } from '../game/ServerZoneSystem.js'
+import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
+import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+
+let tracker: ProjectileTracker
+
+function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 650
+  hero.maxHp = 650
+  hero.dead = false
+  hero.team = 'blue'
+  hero.x = 400
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'AURA'
+  hero.skillSlotQ = 'aura-barrier'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+function createBarrierZone(
+  casterId: string,
+  team: string,
+  x: number,
+  y: number,
+): ZoneSchema {
+  const zone = new ZoneSchema()
+  zone.x = x
+  zone.y = y
+  zone.radius = 180
+  zone.remainingDuration = 4
+  zone.team = team
+  zone.casterId = casterId
+  zone.skillId = 'aura-barrier'
+  zone.buffType = 'damageReduction'
+  zone.value = 0.30
+  zone.isDebuff = false
+  zone.target = 'ally'
+  return zone
+}
+
+beforeEach(() => {
+  registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
+})
+
+// ── Skill definition ──
+
+describe('getSkillDefinition — aura-barrier', () => {
+  it('should return aura-barrier definition with correct params', () => {
+    const def = getSkillDefinition('aura-barrier')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('aura-barrier')
+    expect(def!.targeting).toBe('point')
+    expect(def!.cooldown).toBe(14)
+    expect(def!.range).toBe(500)
+    expect(def!.effect.effectType).toBe('zone')
+    if (def!.effect.effectType === 'zone') {
+      expect(def!.effect.zoneRadius).toBe(180)
+      expect(def!.effect.zoneDuration).toBe(4)
+      expect(def!.effect.zoneEffect.buffType).toBe('damageReduction')
+      expect(def!.effect.zoneEffect.value).toBe(0.30)
+      expect(def!.effect.zoneEffect.target).toBe('ally')
+    }
+  })
+})
+
+// ── Skill execution ──
+
+describe('executeSkill — aura-barrier', () => {
+  it('should create a fixed zone at target position', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 600, y: 400 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('aura-barrier')
+    expect(zones.size).toBe(1)
+
+    const zone = [...zones.values()][0]
+    expect(zone.x).toBe(600)
+    expect(zone.y).toBe(400)
+    expect(zone.radius).toBe(180)
+    expect(zone.remainingDuration).toBe(4)
+    expect(zone.followHeroId).toBe('') // fixed position, not follow
+  })
+
+  it('should set cooldown to 14 seconds', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 600, y: 400 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(caster.cooldownQ).toBe(14)
+  })
+
+  it('should reject activation while dashing', () => {
+    const caster = createHero({ x: 400, y: 300, dashTimer: 0.2 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 600, y: 400 }, new MapSchema<ProjectileSchema>(), heroes, tracker, zones)
+
+    expect(event).toBeNull()
+    expect(zones.size).toBe(0)
+  })
+})
+
+// ── Zone effects ──
+
+describe('tickZones — Barrier damage reduction', () => {
+  it('should apply damageReduction to ally in radius', () => {
+    const ally = createHero({ x: 600, y: 400 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createBarrierZone('caster-1', 'blue', 600, 400))
+
+    tickZones(zones, heroes, 0.016)
+
+    const effect = ally.statusEffects.get('zone-1')
+    expect(effect).toBeDefined()
+    expect(effect!.buffType).toBe('damageReduction')
+    expect(effect!.value).toBe(0.30)
+    expect(effect!.isDebuff).toBe(false)
+  })
+
+  it('should NOT apply damageReduction to enemy in radius', () => {
+    const enemy = createHero({ x: 600, y: 400, team: 'red' })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('enemy-1', enemy)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createBarrierZone('caster-1', 'blue', 600, 400))
+
+    tickZones(zones, heroes, 0.016)
+
+    expect(enemy.statusEffects.get('zone-1')).toBeUndefined()
+  })
+
+  it('should not affect ally outside radius', () => {
+    const farAlly = createHero({ x: 900, y: 400 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('ally-1', farAlly)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createBarrierZone('caster-1', 'blue', 600, 400))
+
+    tickZones(zones, heroes, 0.016)
+
+    expect(farAlly.statusEffects.get('zone-1')).toBeUndefined()
+  })
+
+  it('should remain at fixed position (not follow caster)', () => {
+    const caster = createHero({ x: 400, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createBarrierZone('caster-1', 'blue', 600, 400))
+
+    // Move caster far away
+    caster.x = 100
+    caster.y = 100
+
+    tickZones(zones, heroes, 0.016)
+
+    const zone = zones.get('zone-1')!
+    expect(zone.x).toBe(600) // stays at original position
+    expect(zone.y).toBe(400)
+  })
+
+  it('should expire after 4 seconds', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createBarrierZone('caster-1', 'blue', 600, 400))
+
+    tickZones(zones, heroes, 4.0)
+
+    expect(zones.size).toBe(0)
+  })
+})

--- a/server/src/__tests__/auraBarrier.test.ts
+++ b/server/src/__tests__/auraBarrier.test.ts
@@ -41,7 +41,7 @@ function createBarrierZone(
   zone.casterId = casterId
   zone.skillId = 'aura-barrier'
   zone.buffType = 'damageReduction'
-  zone.value = 0.30
+  zone.value = 0.3
   zone.isDebuff = false
   zone.target = 'ally'
   return zone
@@ -67,7 +67,7 @@ describe('getSkillDefinition — aura-barrier', () => {
       expect(def!.effect.zoneRadius).toBe(180)
       expect(def!.effect.zoneDuration).toBe(4)
       expect(def!.effect.zoneEffect.buffType).toBe('damageReduction')
-      expect(def!.effect.zoneEffect.value).toBe(0.30)
+      expect(def!.effect.zoneEffect.value).toBe(0.3)
       expect(def!.effect.zoneEffect.target).toBe('ally')
     }
   })
@@ -136,7 +136,7 @@ describe('tickZones — Barrier damage reduction', () => {
     const effect = ally.statusEffects.get('zone-1')
     expect(effect).toBeDefined()
     expect(effect!.buffType).toBe('damageReduction')
-    expect(effect!.value).toBe(0.30)
+    expect(effect!.value).toBe(0.3)
     expect(effect!.isDebuff).toBe(false)
   })
 
@@ -164,6 +164,29 @@ describe('tickZones — Barrier damage reduction', () => {
     tickZones(zones, heroes, 0.016)
 
     expect(farAlly.statusEffects.get('zone-1')).toBeUndefined()
+  })
+
+  it('should expire damageReduction after ally leaves zone radius', () => {
+    const ally = createHero({ x: 600, y: 400 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('ally-1', ally)
+
+    const zones = new MapSchema<ZoneSchema>()
+    zones.set('zone-1', createBarrierZone('caster-1', 'blue', 600, 400))
+
+    // Ally inside zone — gets DR
+    tickZones(zones, heroes, 0.016)
+    expect(ally.statusEffects.get('zone-1')).toBeDefined()
+
+    // Ally moves outside zone radius
+    ally.x = 900
+    tickZones(zones, heroes, 0.016)
+
+    // Effect has short duration (ZONE_EFFECT_DURATION = 0.1s), not refreshed
+    const effect = ally.statusEffects.get('zone-1')
+    expect(effect).toBeDefined()
+    // Duration was set to ZONE_EFFECT_DURATION (0.1s) last time in range, not refreshed
+    expect(effect!.remainingDuration).toBeLessThanOrEqual(0.1)
   })
 
   it('should remain at fixed position (not follow caster)', () => {

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -164,6 +164,23 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       radius: 200,
     },
   },
+  'aura-barrier': {
+    id: 'aura-barrier',
+    targeting: 'point',
+    cooldown: 14,
+    range: 500,
+    effect: {
+      effectType: 'zone',
+      zoneRadius: 180,
+      zoneDuration: 4,
+      zoneEffect: {
+        buffType: 'damageReduction',
+        value: 0.30,
+        isDebuff: false,
+        target: 'ally',
+      },
+    },
+  },
   'aura-slow-field': {
     id: 'aura-slow-field',
     targeting: 'point',

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -175,7 +175,7 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       zoneDuration: 4,
       zoneEffect: {
         buffType: 'damageReduction',
-        value: 0.30,
+        value: 0.3,
         isDebuff: false,
         target: 'ally',
       },

--- a/shared/zone/zoneVisuals.ts
+++ b/shared/zone/zoneVisuals.ts
@@ -28,6 +28,13 @@ export const ZONE_VISUALS: Record<string, ZoneVisualDef> = {
     borderAlpha: 0.7,
     borderWidth: 2,
   },
+  'aura-barrier': {
+    color: 0x2ecc71,
+    alpha: 0.2,
+    borderColor: 0x1abc9c,
+    borderAlpha: 0.6,
+    borderWidth: 2,
+  },
   'aura-sanctuary': {
     color: 0x3498db,
     alpha: 0.2,


### PR DESCRIPTION
## Summary
- Add `aura-barrier` skill: point-placed fixed zone with 30% damage reduction for allies
- Pure skill registration — no infrastructure changes, reuses existing zone system
- 9 new server tests

## Parameters
| Param | Value |
|-------|-------|
| Cooldown | 14s |
| Range | 500px (point targeting) |
| Radius | 180px |
| Duration | 4s |
| Damage Reduction | 30% to allies |
| Position | Fixed (not follow caster) |

## Test plan
- [x] Skill definition registered with correct params
- [x] Zone created at target position (not caster position)
- [x] followHeroId is empty (fixed position)
- [x] damageReduction applied to allies in radius
- [x] Enemies not affected
- [x] Allies outside radius not affected
- [x] Zone stays at fixed position when caster moves
- [x] Zone expires after 4 seconds
- [x] Dash rejection
- [x] Lint clean, 950 tests pass

Closes #213