### PR TITLE
feat: BOLT Barrage burst-fire skill (#207)

### DIFF
--- a/openspec/changes/archive/2026-03-11-bolt-barrage/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-bolt-barrage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-11-bolt-barrage/design.md
+++ b/openspec/changes/archive/2026-03-11-bolt-barrage/design.md
@@ -1,0 +1,52 @@
+## Context
+
+BOLT currently has Pierce Shot as its only fire-power active skill. The skill catalog defines Barrage as a burst-fire skill (Depth 3, Cost 2) that fires multiple projectiles. The existing `projectileEffectHandler` creates a single projectile per activation. We need to extend it to support multi-shot.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extend `ProjectileEffectParams` to support multi-projectile spawning
+- Implement Barrage as a fan-spread burst (all projectiles spawn simultaneously)
+- Reuse existing linear projectile movement, collision, and pierce logic
+
+**Non-Goals:**
+- Channeling or cast-time system (all shots fire instantly)
+- Staggered burst with delay between shots (adds server-side scheduling complexity)
+- New effect type (reuse `projectile`)
+
+## Decisions
+
+### 1. Extend `ProjectileEffectParams` with optional multi-shot fields
+
+Add `projectileCount` (default 1) and `spreadAngle` (total fan angle in radians) to `ProjectileEffectParams`. When `projectileCount > 1`, the handler distributes projectiles evenly across `spreadAngle` centered on the cursor direction.
+
+**Why not a new effect type?** Barrage projectiles behave identically to existing linear projectiles (move, collide, pierce). Only the spawn logic differs. Adding 2 optional fields is simpler than duplicating an entire effect type.
+
+### 2. Simultaneous spawn (no burst delay)
+
+All projectiles spawn in the same tick. This avoids needing a server-side timer/scheduler for delayed spawns. The visual "burst" effect comes from the angular spread — projectiles fan out naturally.
+
+**Alternative considered:** Staggered spawn with `burstDelay` — would require tracking pending projectile spawns per hero across ticks (similar to channeling). Too complex for the prototype phase.
+
+### 3. Parameter values
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| cooldown | 10s | Depth 3, Cost 2 — expensive skill |
+| projectileCount | 5 | Visible fan, rewarding aim |
+| damage/projectile | 25 | Total 125 max (if all hit), comparable to Pierce Shot's 60×3 |
+| speed | 700 px/s | Slightly slower than Pierce Shot (800) for readability |
+| range | 450 px | Shorter than Pierce Shot (600) — close-mid range burst |
+| radius | 4 px | Slightly smaller than Pierce Shot (5) |
+| pierceCount | 0 | Single-hit per projectile — balanced by count |
+| spreadAngle | 25° (0.436 rad) | Tight enough to hit 1-2 targets at range, wide enough to be distinct |
+
+### 4. Visual type
+
+Reuse `'circle'` projectile visual. All 5 projectiles render as small circles in team color — visually distinct from Pierce Shot's diamonds.
+
+## Risks / Trade-offs
+
+- **5 simultaneous projectiles → more entities per tick** → Mitigation: 2v2 arena means max ~10 projectiles from Barrage across both teams. Well within performance budget.
+- **All-at-once spawn less visually dramatic than staggered** → Mitigation: Fan spread provides visual drama. Can add stagger later if desired.
+- **pierceCount=0 means each bullet is single-hit** → Intentional: total projectile count compensates. Pierce + count would be overpowered.

--- a/openspec/changes/archive/2026-03-11-bolt-barrage/proposal.md
+++ b/openspec/changes/archive/2026-03-11-bolt-barrage/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+BOLT's fire-power build path currently has only Pierce Shot as an active skill. Adding Barrage (Depth 3, Cost 2) gives BOLT a high-commitment burst damage option that rewards good aim — firing multiple projectiles in a fan spread. This fulfills the skill catalog's "火力" branch (#207).
+
+## What Changes
+
+- Add `bolt-barrage` skill definition to the shared skill registry
+- Extend `ProjectileEffectParams` with optional multi-shot fields (`projectileCount`, `spreadAngle`)
+- Modify `projectileEffectHandler` to spawn multiple projectiles when `projectileCount > 1`
+- Add visual entry for barrage projectiles in `PROJECTILE_VISUALS`
+- Register in BOLT's talent tree
+
+## Non-goals
+
+- Channeling/cast-time system — Barrage fires all projectiles instantly (no channeling)
+- New effect type — Reuses and extends existing `projectile` effectType
+- Burst delay between shots — All projectiles spawn simultaneously with angular spread
+
+## Capabilities
+
+### New Capabilities
+- `bolt-barrage`: BOLT burst-fire skill that spawns multiple projectiles in a fan spread
+
+### Modified Capabilities
+- `projectile-system`: Extend ProjectileEffectParams to support multi-shot (projectileCount, spreadAngle)
+
+## Impact
+
+- `shared/skills/skillDefinitions.ts` — Add optional fields to `ProjectileEffectParams`, add `bolt-barrage` entry
+- `server/src/game/skills/handlers/projectileEffectHandler.ts` — Multi-projectile spawn logic
+- `shared/projectile/projectileVisuals.ts` — Add barrage visual entry
+- `openspec/specs/heroes.md` — BOLT skill list update

--- a/openspec/changes/archive/2026-03-11-bolt-barrage/specs/bolt-barrage/spec.md
+++ b/openspec/changes/archive/2026-03-11-bolt-barrage/specs/bolt-barrage/spec.md
@@ -1,0 +1,44 @@
+# Specification
+
+## Purpose
+BOLT の火力ビルドパス用バースト連射スキル。複数の弾をファン状に同時発射する。
+
+## Requirements
+
+## ADDED Requirements
+
+### Requirement: bolt-barrage スキル定義
+`SKILL_DEFINITIONS` に `bolt-barrage` エントリを追加しなければならない（SHALL）。targeting は `direction`、effectType は `projectile`、cooldown は 10 秒とする。
+
+#### Scenario: スキル定義の取得
+- **WHEN** `getSkillDefinition('bolt-barrage')` を呼び出す
+- **THEN** id='bolt-barrage', targeting='direction', cooldown=10 のスキル定義が返される
+
+#### Scenario: エフェクトパラメータ
+- **WHEN** bolt-barrage の effect を参照する
+- **THEN** effectType='projectile', damage=25, speed=700, range=450, radius=4, pierceCount=0, projectileCount=5, spreadAngle=0.436 が含まれる
+
+### Requirement: 複数プロジェクタイル生成
+bolt-barrage の発動時、`projectileCount` 個のプロジェクタイルを `spreadAngle` の扇状に分散して同時生成しなければならない（SHALL）。各プロジェクタイルはカーソル方向を中心に均等に配置される。
+
+#### Scenario: 5発のプロジェクタイルが扇状に生成される
+- **WHEN** BOLT が右方向（dirX=1, dirY=0）に bolt-barrage を発動する
+- **THEN** 5つのプロジェクタイルが -12.5° から +12.5° の範囲に 6.25° 間隔で生成される
+
+#### Scenario: 各プロジェクタイルが独立したダメージを持つ
+- **WHEN** bolt-barrage で生成された5つのプロジェクタイルのうち2つが敵に命中する
+- **THEN** 敵は 25×2 = 50 のダメージを受ける
+
+### Requirement: ダッシュ中の発動拒否
+ダッシュ中（dashTimer > 0）は bolt-barrage を発動できない（SHALL）。
+
+#### Scenario: ダッシュ中に発動を試みる
+- **WHEN** dashTimer > 0 の BOLT が bolt-barrage を発動しようとする
+- **THEN** スキルは発動されず、クールダウンは消費されない
+
+### Requirement: クールダウン設定
+bolt-barrage 発動後、10秒のクールダウンが設定されなければならない（SHALL）。
+
+#### Scenario: クールダウンの適用
+- **WHEN** BOLT が bolt-barrage を発動する
+- **THEN** 使用したスキルスロットのクールダウンが 10 に設定される

--- a/openspec/changes/archive/2026-03-11-bolt-barrage/specs/projectile-system/spec.md
+++ b/openspec/changes/archive/2026-03-11-bolt-barrage/specs/projectile-system/spec.md
@@ -1,0 +1,40 @@
+# Specification
+
+## Purpose
+プロジェクタイルシステムの複数弾同時生成対応（既存仕様への差分）
+
+## MODIFIED Requirements
+
+### Requirement: プロジェクタイル状態の定義
+プロジェクタイルは以下の読み取り専用フィールドを持つ `ProjectileState` インターフェースで表現しなければならない（SHALL）。`id: string`、`ownerId: string`（発射者ID）、`targetId: string`（追尾対象ID）、`position: Position`（現在位置）、`damage: number`、`speed: number`（px/sec）、`radius: number`（描画・衝突判定用半径）。すべてのフィールドは `readonly` でなければならない（SHALL）。
+
+`ProjectileEffectParams` に以下のオプショナルフィールドを追加しなければならない（SHALL）：`projectileCount: number`（生成するプロジェクタイルの数、デフォルト1）、`spreadAngle: number`（扇状の全角度、ラジアン単位）。
+
+#### Scenario: ProjectileState の生成
+- **WHEN** `createProjectile` に ownerId, targetId, 発射位置, damage, speed, radius を渡す
+- **THEN** 指定されたパラメータを持つ新しい `ProjectileState` が返される
+
+#### Scenario: イミュータブルな状態
+- **WHEN** `ProjectileState` を更新する
+- **THEN** 元のオブジェクトは変更されず、新しいオブジェクトが返される
+
+#### Scenario: 複数弾生成パラメータ
+- **WHEN** projectileCount=5, spreadAngle=0.436 の ProjectileEffectParams でスキルを発動する
+- **THEN** 5つのプロジェクタイルが生成され、各プロジェクタイルは spreadAngle の範囲内に均等に分布した方向ベクトルを持つ
+
+## ADDED Requirements
+
+### Requirement: 複数プロジェクタイル生成ロジック
+`projectileEffectHandler` は `projectileCount > 1` の場合、指定方向を中心に `spreadAngle` 幅の扇状に均等分布した複数のプロジェクタイルを生成しなければならない（SHALL）。`projectileCount` が 1 または未指定の場合、既存の単発生成ロジックを維持しなければならない（SHALL）。
+
+#### Scenario: projectileCount=1 の場合は単発
+- **WHEN** projectileCount=1 または未指定のスキルが発動される
+- **THEN** 既存の単発プロジェクタイル生成と同一の動作をする
+
+#### Scenario: projectileCount=5 の場合はファン状に生成
+- **WHEN** projectileCount=5, spreadAngle=0.436 で direction=(1,0) のスキルが発動される
+- **THEN** 5つのプロジェクタイルが角度 [-0.218, -0.109, 0, +0.109, +0.218] の方向に生成される
+
+#### Scenario: 各プロジェクタイルは独立
+- **WHEN** 複数のプロジェクタイルが生成される
+- **THEN** 各プロジェクタイルは独立した id、hitSet、distanceTraveled を持ち、個別に移動・衝突・除去される

--- a/openspec/changes/archive/2026-03-11-bolt-barrage/tasks.md
+++ b/openspec/changes/archive/2026-03-11-bolt-barrage/tasks.md
@@ -1,0 +1,12 @@
+# Tasks — bolt-barrage
+
+## Backend
+
+- [x] Add `projectileCount` and `spreadAngle` optional fields to `ProjectileEffectParams` in `shared/skills/skillDefinitions.ts`
+- [x] Add `bolt-barrage` skill definition to `SKILL_DEFINITIONS` registry
+- [x] Extend `projectileEffectHandler` to spawn multiple projectiles with angular spread when `projectileCount > 1`
+- [x] Write unit tests for bolt-barrage (skill definition, multi-projectile spawn, cooldown, dash rejection, spread angles)
+
+## Frontend
+
+- [x] Add barrage projectile visual entry to `shared/projectile/projectileVisuals.ts` (already exists — uses 'circle')

--- a/openspec/specs/bolt-barrage/spec.md
+++ b/openspec/specs/bolt-barrage/spec.md
@@ -1,0 +1,42 @@
+# Specification
+
+## Purpose
+BOLT の火力ビルドパス用バースト連射スキル。複数の弾をファン状に同時発射する。
+
+## Requirements
+
+### Requirement: bolt-barrage スキル定義
+`SKILL_DEFINITIONS` に `bolt-barrage` エントリを追加しなければならない（SHALL）。targeting は `direction`、effectType は `projectile`、cooldown は 10 秒とする。
+
+#### Scenario: スキル定義の取得
+- **WHEN** `getSkillDefinition('bolt-barrage')` を呼び出す
+- **THEN** id='bolt-barrage', targeting='direction', cooldown=10 のスキル定義が返される
+
+#### Scenario: エフェクトパラメータ
+- **WHEN** bolt-barrage の effect を参照する
+- **THEN** effectType='projectile', damage=25, speed=700, range=450, radius=4, pierceCount=0, projectileCount=5, spreadAngle=0.436 が含まれる
+
+### Requirement: 複数プロジェクタイル生成
+bolt-barrage の発動時、`projectileCount` 個のプロジェクタイルを `spreadAngle` の扇状に分散して同時生成しなければならない（SHALL）。各プロジェクタイルはカーソル方向を中心に均等に配置される。
+
+#### Scenario: 5発のプロジェクタイルが扇状に生成される
+- **WHEN** BOLT が右方向（dirX=1, dirY=0）に bolt-barrage を発動する
+- **THEN** 5つのプロジェクタイルが -12.5° から +12.5° の範囲に 6.25° 間隔で生成される
+
+#### Scenario: 各プロジェクタイルが独立したダメージを持つ
+- **WHEN** bolt-barrage で生成された5つのプロジェクタイルのうち2つが敵に命中する
+- **THEN** 敵は 25×2 = 50 のダメージを受ける
+
+### Requirement: ダッシュ中の発動拒否
+ダッシュ中（dashTimer > 0）は bolt-barrage を発動できない（SHALL）。
+
+#### Scenario: ダッシュ中に発動を試みる
+- **WHEN** dashTimer > 0 の BOLT が bolt-barrage を発動しようとする
+- **THEN** スキルは発動されず、クールダウンは消費されない
+
+### Requirement: クールダウン設定
+bolt-barrage 発動後、10秒のクールダウンが設定されなければならない（SHALL）。
+
+#### Scenario: クールダウンの適用
+- **WHEN** BOLT が bolt-barrage を発動する
+- **THEN** 使用したスキルスロットのクールダウンが 10 に設定される

--- a/openspec/specs/projectile-system/spec.md
+++ b/openspec/specs/projectile-system/spec.md
@@ -8,6 +8,8 @@
 ### Requirement: プロジェクタイル状態の定義
 プロジェクタイルは以下の読み取り専用フィールドを持つ `ProjectileState` インターフェースで表現しなければならない（SHALL）。`id: string`、`ownerId: string`（発射者ID）、`targetId: string`（追尾対象ID）、`position: Position`（現在位置）、`damage: number`、`speed: number`（px/sec）、`radius: number`（描画・衝突判定用半径）。すべてのフィールドは `readonly` でなければならない（SHALL）。
 
+`ProjectileEffectParams` に以下のオプショナルフィールドを追加しなければならない（SHALL）：`projectileCount: number`（生成するプロジェクタイルの数、デフォルト1）、`spreadAngle: number`（扇状の全角度、ラジアン単位）。
+
 #### Scenario: ProjectileState の生成
 - **WHEN** `createProjectile` に ownerId, targetId, 発射位置, damage, speed, radius を渡す
 - **THEN** 指定されたパラメータを持つ新しい `ProjectileState` が返される
@@ -15,6 +17,10 @@
 #### Scenario: イミュータブルな状態
 - **WHEN** `ProjectileState` を更新する
 - **THEN** 元のオブジェクトは変更されず、新しいオブジェクトが返される
+
+#### Scenario: 複数弾生成パラメータ
+- **WHEN** projectileCount=5, spreadAngle=0.436 の ProjectileEffectParams でスキルを発動する
+- **THEN** 5つのプロジェクタイルが生成され、各プロジェクタイルは spreadAngle の範囲内に均等に分布した方向ベクトルを持つ
 
 ### Requirement: プロジェクタイルの追尾移動
 プロジェクタイルは毎フレーム、ターゲットの現在位置に向かって `speed * deltaTime` 分だけ移動しなければならない（SHALL）。移動は純粋関数 `updateProjectile` で行い、ターゲットの現在位置を引数として受け取らなければならない（SHALL）。
@@ -136,3 +142,18 @@ GameScene の update ループにプロジェクタイルの更新・描画を�
 #### Scenario: 経路上の敵すべてに判定される
 - **WHEN** linear プロジェクタイルが飛行中に、経路上に敵ヒーロー2体と味方ヒーロー1体がいる
 - **THEN** 敵ヒーロー2体に対して衝突判定が行われ、味方ヒーローはスキップされる
+
+### Requirement: 複数プロジェクタイル生成ロジック
+`projectileEffectHandler` は `projectileCount > 1` の場合、指定方向を中心に `spreadAngle` 幅の扇状に均等分布した複数のプロジェクタイルを生成しなければならない（SHALL）。`projectileCount` が 1 または未指定の場合、既存の単発生成ロジックを維持しなければならない（SHALL）。
+
+#### Scenario: projectileCount=1 の場合は単発
+- **WHEN** projectileCount=1 または未指定のスキルが発動される
+- **THEN** 既存の単発プロジェクタイル生成と同一の動作をする
+
+#### Scenario: projectileCount=5 の場合はファン状に生成
+- **WHEN** projectileCount=5, spreadAngle=0.436 で direction=(1,0) のスキルが発動される
+- **THEN** 5つのプロジェクタイルが角度 [-0.218, -0.109, 0, +0.109, +0.218] の方向に生成される
+
+#### Scenario: 各プロジェクタイルは独立
+- **WHEN** 複数のプロジェクタイルが生成される
+- **THEN** 各プロジェクタイルは独立した id、hitSet、distanceTraveled を持ち、個別に移動・衝突・除去される

--- a/server/src/__tests__/boltBarrage.test.ts
+++ b/server/src/__tests__/boltBarrage.test.ts
@@ -7,6 +7,7 @@ import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
 import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
 import { getSkillDefinition } from '@shared/skills/skillDefinitions'
 import { ProjectileTracker } from '../game/ProjectileTracker.js'
+import { projectileEffectHandler } from '../game/skills/handlers/projectileEffectHandler.js'
 
 let tracker: ProjectileTracker
 
@@ -160,6 +161,53 @@ describe('executeSkill — bolt-barrage', () => {
     const ids = [...projectiles.values()].map(p => p.id)
     const uniqueIds = new Set(ids)
     expect(uniqueIds.size).toBe(5)
+  })
+})
+
+// ── Edge cases ──
+
+describe('projectileEffectHandler — edge cases', () => {
+  it('should spawn overlapping projectiles when spreadAngle is 0 with count > 1', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    // Use handler directly with spreadAngle=0
+    const ctx = {
+      hero: caster,
+      casterId: 'caster-1',
+      skillId: 'test-zero-spread',
+      direction: { x: 1, y: 0 },
+      targetPosition: { x: 500, y: 300 },
+      projectiles,
+      heroes,
+      zones,
+      projectileTracker: tracker,
+    }
+    const params = {
+      effectType: 'projectile' as const,
+      damage: 10,
+      speed: 500,
+      range: 300,
+      radius: 4,
+      pierceCount: 0,
+      homing: false,
+      visualType: 'circle',
+      projectileCount: 3,
+      spreadAngle: 0,
+    }
+
+    projectileEffectHandler.execute(ctx, params)
+
+    expect(projectiles.size).toBe(3)
+    const projs = [...projectiles.values()]
+    // All projectiles should fire in the same direction
+    for (const p of projs) {
+      expect(p.dirX).toBeCloseTo(1, 5)
+      expect(p.dirY).toBeCloseTo(0, 5)
+    }
   })
 })
 

--- a/server/src/__tests__/boltBarrage.test.ts
+++ b/server/src/__tests__/boltBarrage.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { ZoneSchema } from '../schema/ZoneSchema.js'
+import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
+import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+
+let tracker: ProjectileTracker
+
+function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 500
+  hero.maxHp = 500
+  hero.dead = false
+  hero.team = 'blue'
+  hero.x = 400
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'BOLT'
+  hero.skillSlotQ = 'bolt-barrage'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+beforeEach(() => {
+  registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
+})
+
+// ── Skill definition ──
+
+describe('getSkillDefinition — bolt-barrage', () => {
+  it('should return bolt-barrage definition with correct params', () => {
+    const def = getSkillDefinition('bolt-barrage')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('bolt-barrage')
+    expect(def!.targeting).toBe('direction')
+    expect(def!.cooldown).toBe(10)
+    expect(def!.effect.effectType).toBe('projectile')
+    if (def!.effect.effectType === 'projectile') {
+      expect(def!.effect.damage).toBe(25)
+      expect(def!.effect.speed).toBe(700)
+      expect(def!.effect.range).toBe(450)
+      expect(def!.effect.radius).toBe(4)
+      expect(def!.effect.pierceCount).toBe(0)
+      expect(def!.effect.projectileCount).toBe(5)
+      expect(def!.effect.spreadAngle).toBeCloseTo(0.436, 2)
+    }
+  })
+})
+
+// ── Skill execution ──
+
+describe('executeSkill — bolt-barrage', () => {
+  it('should create 5 projectiles', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('bolt-barrage')
+    expect(projectiles.size).toBe(5)
+  })
+
+  it('should set cooldown to 10 seconds', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    expect(caster.cooldownQ).toBe(10)
+  })
+
+  it('should reject activation while dashing', () => {
+    const caster = createHero({ dashTimer: 0.2 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    expect(event).toBeNull()
+    expect(projectiles.size).toBe(0)
+  })
+
+  it('should distribute projectiles in a fan spread', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    // Fire to the right (direction x=1, y=0)
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    const projs = [...projectiles.values()]
+    expect(projs).toHaveLength(5)
+
+    // All should have same origin, speed, damage
+    for (const p of projs) {
+      expect(p.x).toBe(400)
+      expect(p.y).toBe(300)
+      expect(p.speed).toBe(700)
+      expect(p.damage).toBe(25)
+      expect(p.mode).toBe('linear')
+      expect(p.maxRange).toBe(450)
+      expect(p.pierceRemaining).toBe(0)
+    }
+
+    // Check that directions span the spread angle
+    const angles = projs.map(p => Math.atan2(p.dirY, p.dirX))
+    angles.sort((a, b) => a - b)
+
+    // Total spread should be ~0.436 radians
+    const actualSpread = angles[angles.length - 1] - angles[0]
+    expect(actualSpread).toBeCloseTo(0.436, 2)
+
+    // Middle projectile should be closest to base angle (0 = right)
+    expect(angles[2]).toBeCloseTo(0, 2)
+  })
+
+  it('should fire in the aimed direction when aiming diagonally', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    // Aim down-right (45 degrees)
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 400 }, projectiles, heroes, tracker, zones)
+
+    const projs = [...projectiles.values()]
+    const angles = projs.map(p => Math.atan2(p.dirY, p.dirX))
+    const avgAngle = angles.reduce((a, b) => a + b, 0) / angles.length
+
+    // Average angle should be ~45 degrees (π/4 ≈ 0.785)
+    expect(avgAngle).toBeCloseTo(Math.PI / 4, 1)
+  })
+
+  it('should give each projectile a unique id', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    const ids = [...projectiles.values()].map(p => p.id)
+    const uniqueIds = new Set(ids)
+    expect(uniqueIds.size).toBe(5)
+  })
+})
+
+// ── Single-projectile backward compatibility ──
+
+describe('projectileEffectHandler — single projectile', () => {
+  it('should still create 1 projectile for pierce-shot (no projectileCount)', () => {
+    const caster = createHero({ skillSlotQ: 'bolt-pierce-shot' })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    expect(projectiles.size).toBe(1)
+    const proj = [...projectiles.values()][0]
+    expect(proj.damage).toBe(60)
+    expect(proj.pierceRemaining).toBe(3)
+  })
+})

--- a/server/src/game/skills/handlers/projectileEffectHandler.ts
+++ b/server/src/game/skills/handlers/projectileEffectHandler.ts
@@ -48,6 +48,9 @@ export const projectileEffectHandler: SkillEffectHandler<ProjectileEffectParams>
 
     // Multi-projectile: fan spread centered on cursor direction
     const totalSpread = params.spreadAngle ?? 0
+    if (totalSpread === 0) {
+      console.warn(`[projectileEffectHandler] projectileCount=${count} but spreadAngle is 0 — all projectiles will overlap`)
+    }
     const baseAngle = Math.atan2(ctx.direction.y, ctx.direction.x)
 
     for (let i = 0; i < count; i++) {

--- a/server/src/game/skills/handlers/projectileEffectHandler.ts
+++ b/server/src/game/skills/handlers/projectileEffectHandler.ts
@@ -2,33 +2,61 @@ import { ProjectileSchema } from '../../../schema/ProjectileSchema.js'
 import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
 import type { ProjectileEffectParams } from '@shared/skills/skillDefinitions'
 
+function createProjectile(
+  ctx: SkillExecutionContext,
+  params: ProjectileEffectParams,
+  dirX: number,
+  dirY: number,
+): void {
+  const { hero, casterId, projectiles, projectileTracker } = ctx
+
+  const proj = new ProjectileSchema()
+  proj.id = projectileTracker.nextSkillProjectileId()
+  proj.x = hero.x
+  proj.y = hero.y
+  proj.speed = params.speed
+  proj.damage = params.damage
+  proj.ownerId = casterId
+  proj.team = hero.team
+
+  if (params.homing) {
+    throw new Error('Homing skill projectiles are not yet implemented — targetId resolution is required')
+  } else {
+    proj.mode = 'linear'
+    proj.dirX = dirX
+    proj.dirY = dirY
+  }
+
+  proj.radius = params.radius
+  proj.maxRange = params.range
+  proj.pierceRemaining = params.pierceCount
+  proj.visualType = params.visualType
+
+  projectiles.set(proj.id, proj)
+}
+
 export const projectileEffectHandler: SkillEffectHandler<ProjectileEffectParams> = {
   effectType: 'projectile',
   execute(ctx: SkillExecutionContext, params: ProjectileEffectParams): void {
-    const { hero, casterId, direction, projectiles, projectileTracker } = ctx
+    const count = params.projectileCount ?? 1
+    if (count <= 0) return
 
-    const proj = new ProjectileSchema()
-    proj.id = projectileTracker.nextSkillProjectileId()
-    proj.x = hero.x
-    proj.y = hero.y
-    proj.speed = params.speed
-    proj.damage = params.damage
-    proj.ownerId = casterId
-    proj.team = hero.team
-
-    if (params.homing) {
-      throw new Error('Homing skill projectiles are not yet implemented — targetId resolution is required')
-    } else {
-      proj.mode = 'linear'
-      proj.dirX = direction.x
-      proj.dirY = direction.y
+    if (count === 1) {
+      createProjectile(ctx, params, ctx.direction.x, ctx.direction.y)
+      return
     }
 
-    proj.radius = params.radius
-    proj.maxRange = params.range
-    proj.pierceRemaining = params.pierceCount
-    proj.visualType = params.visualType
+    // Multi-projectile: fan spread centered on cursor direction
+    const totalSpread = params.spreadAngle ?? 0
+    const baseAngle = Math.atan2(ctx.direction.y, ctx.direction.x)
 
-    projectiles.set(proj.id, proj)
+    for (let i = 0; i < count; i++) {
+      // Distribute evenly across spreadAngle: -half to +half
+      const offset = -totalSpread / 2 + (totalSpread / (count - 1)) * i
+      const angle = baseAngle + offset
+      const dirX = Math.cos(angle)
+      const dirY = Math.sin(angle)
+      createProjectile(ctx, params, dirX, dirY)
+    }
   },
 }

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -17,6 +17,8 @@ export interface ProjectileEffectParams {
   readonly pierceCount: number      // max enemies to pierce (0 = single hit)
   readonly homing: boolean          // true = track target, false = straight line
   readonly visualType: string       // key into PROJECTILE_VISUALS (e.g. 'circle', 'diamond')
+  readonly projectileCount?: number // number of projectiles to spawn (default 1)
+  readonly spreadAngle?: number     // total fan spread angle in radians (used when projectileCount > 1)
 }
 
 export interface HealEffectParams {
@@ -266,6 +268,23 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
         isDebuff: false,
         target: 'ally',
       },
+    },
+  },
+  'bolt-barrage': {
+    id: 'bolt-barrage',
+    targeting: 'direction',
+    cooldown: 10,
+    effect: {
+      effectType: 'projectile',
+      damage: 25,
+      speed: 700,
+      range: 450,
+      radius: 4,
+      pierceCount: 0,
+      homing: false,
+      visualType: 'circle',
+      projectileCount: 5,
+      spreadAngle: 0.436, // ~25 degrees in radians
     },
   },
   'blade-block': {


### PR DESCRIPTION
## Summary
- Add BOLT Barrage skill — fires 5 projectiles in a 25° fan spread (direction-targeting, CD 10s)
- Extend `ProjectileEffectParams` with optional `projectileCount` and `spreadAngle` fields
- Refactor `projectileEffectHandler` to support multi-projectile spawn with angular distribution
- Backward-compatible: existing single-projectile skills (Pierce Shot) unaffected

## Parameters
| Param | Value |
|-------|-------|
| cooldown | 10s |
| projectileCount | 5 |
| damage/projectile | 25 |
| speed | 700 px/s |
| range | 450 px |
| spreadAngle | 25° |
| pierceCount | 0 |

## Test plan
- [x] Skill definition correctness (id, targeting, cooldown, effect params)
- [x] 5 projectiles created on activation
- [x] Fan spread angle verified (~0.436 rad total)
- [x] Diagonal aim direction verified
- [x] Unique IDs for each projectile
- [x] Cooldown set to 10s
- [x] Dash rejection
- [x] Backward compatibility (Pierce Shot still creates 1 projectile)
- [x] All 959 unit tests pass

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)