### PR TITLE
feat: BLADE Execute melee finisher (#203)

### DIFF
--- a/openspec/changes/archive/2026-03-11-blade-execute/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-blade-execute/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-11-blade-execute/design.md
+++ b/openspec/changes/archive/2026-03-11-blade-execute/design.md
@@ -1,0 +1,48 @@
+## Context
+
+BLADE has Whirlwind (AoE DPS) and Fury (self-buff) in the fire-power path, but no finisher. Execute fills this role as a high-risk, high-reward melee skill that punishes low-HP targets.
+
+## Goals / Non-Goals
+
+**Goals:**
+- New `strike` effect type for instant melee single-target damage
+- Execute threshold mechanic: bonus damage when target HP% is below threshold
+- Reuse existing `enemy` targeting with melee range
+
+**Non-Goals:**
+- Direction-based melee targeting (would need cone detection logic — not needed for prototype)
+- Kill reset mechanic (cooldown resets on kill — too strong for 2v2, defer)
+
+## Decisions
+
+### 1. New `StrikeEffectParams` effect type
+
+A `strike` is an instant melee damage skill targeting a single enemy. Fields:
+- `damage`: base damage
+- `executeThreshold`: HP ratio (0-1) below which bonus damage applies
+- `executeBonusDamage`: additional damage when target is below threshold
+
+**Why not reuse `projectile`?** Strike is instant melee — no projectile entity, no travel time, no collision. Fundamentally different from projectile mechanics.
+
+### 2. Use `enemy` targeting with melee range
+
+The skill uses `targeting: 'enemy'` with `range: 150` (melee). The existing `resolveHeroTarget` already handles nearest-enemy selection within range. If no enemy is in range, the skill fails without consuming cooldown (existing behavior).
+
+### 3. Parameter values
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| cooldown | 20s | Depth 7, Cost 3 — ultimate tier finisher |
+| damage | 100 | Base damage (BLADE base attack = 60) |
+| range | 150 | Melee range |
+| executeThreshold | 0.3 | 30% HP — forces commitment to finish |
+| executeBonusDamage | 150 | Total 250 on low HP target = nearly lethal |
+
+### 4. Damage application
+
+Uses `hero.applyDamage()` which runs through the existing damage pipeline (damageReduction → blockAmount → clamp). The handler also sets `lastAttackerSessionId` for kill credit.
+
+## Risks / Trade-offs
+
+- **250 total damage on low HP is very high** → Intentional: 20s cooldown is the balancing factor. Can tune later.
+- **`enemy` targeting requires clicking near enemy** → Acceptable UX for melee; BLADE is already close-range.

--- a/openspec/changes/archive/2026-03-11-blade-execute/proposal.md
+++ b/openspec/changes/archive/2026-03-11-blade-execute/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+BLADE's fire-power build path needs a finisher skill to reward aggressive play. Execute (Depth 7, Cost 3) is the capstone — a high-cooldown melee strike that deals massive bonus damage to low-HP enemies. This completes BLADE's "火力" branch alongside Whirlwind and Fury.
+
+## What Changes
+
+- Add new `strike` effect type for melee single-target damage with conditional bonus
+- Add `blade-execute` skill definition (enemy targeting, melee range)
+- Register `strikeEffectHandler` in the handler index
+
+## Non-goals
+
+- Animation/cast-time system — Execute is instant (no wind-up)
+- Direction-based target selection — uses existing `enemy` targeting for simplicity
+- Kill confirmation VFX — deferred to visual polish pass
+
+## Capabilities
+
+### New Capabilities
+- `blade-execute`: BLADE melee finisher with execute threshold bonus damage
+
+### Modified Capabilities
+
+## Impact
+
+- `shared/skills/skillDefinitions.ts` — New `StrikeEffectParams` interface, `blade-execute` entry
+- `server/src/game/skills/handlers/` — New `strikeEffectHandler.ts`
+- `server/src/game/skills/handlers/index.ts` — Register new handler

--- a/openspec/changes/archive/2026-03-11-blade-execute/specs/blade-execute/spec.md
+++ b/openspec/changes/archive/2026-03-11-blade-execute/specs/blade-execute/spec.md
@@ -1,0 +1,69 @@
+# Specification
+
+## Purpose
+BLADE の火力ビルドパス最終スキル。低HP の敵に追加ダメージを与える近接フィニッシャー。
+
+## Requirements
+
+## ADDED Requirements
+
+### Requirement: blade-execute スキル定義
+`SKILL_DEFINITIONS` に `blade-execute` エントリを追加しなければならない（SHALL）。targeting は `enemy`、effectType は `strike`、cooldown は 20 秒、range は 150 とする。
+
+#### Scenario: スキル定義の取得
+- **WHEN** `getSkillDefinition('blade-execute')` を呼び出す
+- **THEN** id='blade-execute', targeting='enemy', cooldown=20, range=150 のスキル定義が返される
+
+#### Scenario: エフェクトパラメータ
+- **WHEN** blade-execute の effect を参照する
+- **THEN** effectType='strike', damage=100, executeThreshold=0.3, executeBonusDamage=150 が含まれる
+
+### Requirement: StrikeEffectParams の定義
+`SkillEffectParams` ユニオンに `StrikeEffectParams` を追加しなければならない（SHALL）。フィールド: `damage`, `executeThreshold`, `executeBonusDamage`。
+
+#### Scenario: StrikeEffectParams の型定義
+- **WHEN** effectType='strike' のスキルを定義する
+- **THEN** damage, executeThreshold, executeBonusDamage の各フィールドが使用可能である
+
+### Requirement: 基本ダメージの適用
+blade-execute はターゲットの敵ヒーローに `damage` 分のダメージを適用しなければならない（SHALL）。ダメージは既存のダメージパイプライン（damageReduction → blockAmount）を通す。
+
+#### Scenario: 基本ダメージ
+- **WHEN** HP 100% の敵に blade-execute を使用する
+- **THEN** 敵は 100 のダメージを受ける（DR/Block なしの場合）
+
+### Requirement: 低HP 追加ダメージ（Execute）
+ターゲットの現在HPが maxHP の `executeThreshold` 以下の場合、`executeBonusDamage` を追加で適用しなければならない（SHALL）。閾値チェックはダメージ適用前に行う。
+
+#### Scenario: 低HP ターゲットへの追加ダメージ
+- **WHEN** HP が maxHP の 30% 以下の敵に blade-execute を使用する
+- **THEN** 敵は 100 + 150 = 250 のダメージを受ける
+
+#### Scenario: HP が閾値を超えるターゲット
+- **WHEN** HP が maxHP の 31% 以上の敵に blade-execute を使用する
+- **THEN** 敵は 100 のダメージのみを受ける
+
+#### Scenario: 閾値ちょうどのターゲット
+- **WHEN** HP が maxHP のちょうど 30% の敵に blade-execute を使用する
+- **THEN** 追加ダメージが適用され、合計 250 のダメージを受ける
+
+### Requirement: キルクレジットの設定
+blade-execute でダメージを与えた場合、ターゲットの `lastAttackerSessionId` をキャスターに設定しなければならない（SHALL）。
+
+#### Scenario: キルクレジット
+- **WHEN** blade-execute で敵にダメージを与える
+- **THEN** 敵の lastAttackerSessionId がキャスターのセッションIDに設定される
+
+### Requirement: ダッシュ中の発動拒否
+ダッシュ中（dashTimer > 0）は blade-execute を発動できない（SHALL）。
+
+#### Scenario: ダッシュ中に発動を試みる
+- **WHEN** dashTimer > 0 の BLADE が blade-execute を発動しようとする
+- **THEN** スキルは発動されず、クールダウンは消費されない
+
+### Requirement: 範囲外の敵への発動拒否
+range 内に敵がいない場合、blade-execute は発動されず、クールダウンは消費されない（SHALL）。
+
+#### Scenario: 範囲外の敵
+- **WHEN** 150px 以内に敵がいない状態で blade-execute を発動しようとする
+- **THEN** スキルは発動されず、クールダウンは消費されない

--- a/openspec/changes/archive/2026-03-11-blade-execute/tasks.md
+++ b/openspec/changes/archive/2026-03-11-blade-execute/tasks.md
@@ -1,0 +1,9 @@
+# Tasks — blade-execute
+
+## Backend
+
+- [x] Add `StrikeEffectParams` interface to `shared/skills/skillDefinitions.ts` and extend `SkillEffectParams` union
+- [x] Add `blade-execute` skill definition to `SKILL_DEFINITIONS` registry
+- [x] Create `strikeEffectHandler.ts` with execute threshold logic
+- [x] Register `strikeEffectHandler` in handler index
+- [x] Write unit tests for blade-execute (definition, base damage, execute bonus, threshold edge cases, dash rejection, out-of-range rejection, kill credit)

--- a/openspec/specs/blade-execute/spec.md
+++ b/openspec/specs/blade-execute/spec.md
@@ -1,0 +1,67 @@
+# Specification
+
+## Purpose
+BLADE の火力ビルドパス最終スキル。低HP の敵に追加ダメージを与える近接フィニッシャー。
+
+## Requirements
+
+### Requirement: blade-execute スキル定義
+`SKILL_DEFINITIONS` に `blade-execute` エントリを追加しなければならない（SHALL）。targeting は `enemy`、effectType は `strike`、cooldown は 20 秒、range は 150 とする。
+
+#### Scenario: スキル定義の取得
+- **WHEN** `getSkillDefinition('blade-execute')` を呼び出す
+- **THEN** id='blade-execute', targeting='enemy', cooldown=20, range=150 のスキル定義が返される
+
+#### Scenario: エフェクトパラメータ
+- **WHEN** blade-execute の effect を参照する
+- **THEN** effectType='strike', damage=100, executeThreshold=0.3, executeBonusDamage=150 が含まれる
+
+### Requirement: StrikeEffectParams の定義
+`SkillEffectParams` ユニオンに `StrikeEffectParams` を追加しなければならない（SHALL）。フィールド: `damage`, `executeThreshold`, `executeBonusDamage`。
+
+#### Scenario: StrikeEffectParams の型定義
+- **WHEN** effectType='strike' のスキルを定義する
+- **THEN** damage, executeThreshold, executeBonusDamage の各フィールドが使用可能である
+
+### Requirement: 基本ダメージの適用
+blade-execute はターゲットの敵ヒーローに `damage` 分のダメージを適用しなければならない（SHALL）。ダメージは既存のダメージパイプライン（damageReduction → blockAmount）を通す。
+
+#### Scenario: 基本ダメージ
+- **WHEN** HP 100% の敵に blade-execute を使用する
+- **THEN** 敵は 100 のダメージを受ける（DR/Block なしの場合）
+
+### Requirement: 低HP 追加ダメージ（Execute）
+ターゲットの現在HPが maxHP の `executeThreshold` 以下の場合、`executeBonusDamage` を追加で適用しなければならない（SHALL）。閾値チェックはダメージ適用前に行う。
+
+#### Scenario: 低HP ターゲットへの追加ダメージ
+- **WHEN** HP が maxHP の 30% 以下の敵に blade-execute を使用する
+- **THEN** 敵は 100 + 150 = 250 のダメージを受ける
+
+#### Scenario: HP が閾値を超えるターゲット
+- **WHEN** HP が maxHP の 31% 以上の敵に blade-execute を使用する
+- **THEN** 敵は 100 のダメージのみを受ける
+
+#### Scenario: 閾値ちょうどのターゲット
+- **WHEN** HP が maxHP のちょうど 30% の敵に blade-execute を使用する
+- **THEN** 追加ダメージが適用され、合計 250 のダメージを受ける
+
+### Requirement: キルクレジットの設定
+blade-execute でダメージを与えた場合、ターゲットの `lastAttackerSessionId` をキャスターに設定しなければならない（SHALL）。
+
+#### Scenario: キルクレジット
+- **WHEN** blade-execute で敵にダメージを与える
+- **THEN** 敵の lastAttackerSessionId がキャスターのセッションIDに設定される
+
+### Requirement: ダッシュ中の発動拒否
+ダッシュ中（dashTimer > 0）は blade-execute を発動できない（SHALL）。
+
+#### Scenario: ダッシュ中に発動を試みる
+- **WHEN** dashTimer > 0 の BLADE が blade-execute を発動しようとする
+- **THEN** スキルは発動されず、クールダウンは消費されない
+
+### Requirement: 範囲外の敵への発動拒否
+range 内に敵がいない場合、blade-execute は発動されず、クールダウンは消費されない（SHALL）。
+
+#### Scenario: 範囲外の敵
+- **WHEN** 150px 以内に敵がいない状態で blade-execute を発動しようとする
+- **THEN** スキルは発動されず、クールダウンは消費されない

--- a/server/src/__tests__/bladeExecute.test.ts
+++ b/server/src/__tests__/bladeExecute.test.ts
@@ -168,6 +168,20 @@ describe('executeSkill — blade-execute', () => {
     expect(enemy.hp).toBe(650) // no damage
   })
 
+  it('should not deal damage to already dead enemy', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 450, y: 300, dead: true })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    // enemy targeting filters out dead enemies, so skill should fail
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(event).toBeNull()
+    expect(enemy.hp).toBe(650) // untouched
+  })
+
   it('should clamp damage so HP does not go below 0', () => {
     const caster = createHero()
     const enemy = createEnemy({ x: 450, y: 300, hp: 50 }) // 50/650 = 7.7% < 30%

--- a/server/src/__tests__/bladeExecute.test.ts
+++ b/server/src/__tests__/bladeExecute.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { ZoneSchema } from '../schema/ZoneSchema.js'
+import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
+import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+
+let tracker: ProjectileTracker
+
+function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 650
+  hero.maxHp = 650
+  hero.dead = false
+  hero.team = 'blue'
+  hero.x = 400
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'BLADE'
+  hero.skillSlotQ = 'blade-execute'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+function createEnemy(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 650
+  hero.maxHp = 650
+  hero.dead = false
+  hero.team = 'red'
+  hero.x = 450
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'BOLT'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+beforeEach(() => {
+  registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
+})
+
+// ── Skill definition ──
+
+describe('getSkillDefinition — blade-execute', () => {
+  it('should return blade-execute definition with correct params', () => {
+    const def = getSkillDefinition('blade-execute')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('blade-execute')
+    expect(def!.targeting).toBe('enemy')
+    expect(def!.cooldown).toBe(20)
+    expect(def!.range).toBe(150)
+    expect(def!.effect.effectType).toBe('strike')
+    if (def!.effect.effectType === 'strike') {
+      expect(def!.effect.damage).toBe(100)
+      expect(def!.effect.executeThreshold).toBe(0.3)
+      expect(def!.effect.executeBonusDamage).toBe(150)
+    }
+  })
+})
+
+// ── Skill execution ──
+
+describe('executeSkill — blade-execute', () => {
+  it('should deal base damage to full-HP enemy', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 450, y: 300 }) // within 150px range
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('blade-execute')
+    expect(enemy.hp).toBe(650 - 100) // base damage only
+  })
+
+  it('should deal base + bonus damage to low-HP enemy (below threshold)', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 450, y: 300, hp: 180 }) // 180/650 = 27.7% < 30%
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(enemy.hp).toBe(0) // base 100 + bonus 150 = 250, clamped to 0 by applyDamage
+  })
+
+  it('should deal base damage only when enemy is above threshold', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 450, y: 300, hp: 250 }) // 250/650 = 38.5% > 30%
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(enemy.hp).toBe(250 - 100) // base damage only
+  })
+
+  it('should apply bonus damage at exactly 30% HP threshold', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 450, y: 300, hp: 195 }) // 195/650 = 30.0% exactly
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(enemy.hp).toBe(0) // 195 - 250 = clamped to 0 by applyDamage
+  })
+
+  it('should set cooldown to 20 seconds', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 450, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(caster.cooldownQ).toBe(20)
+  })
+
+  it('should set lastAttackerSessionId for kill credit', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 450, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(enemy.lastAttackerSessionId).toBe('caster-1')
+  })
+
+  it('should reject activation while dashing', () => {
+    const caster = createHero({ dashTimer: 0.2 })
+    const enemy = createEnemy({ x: 450, y: 300 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(event).toBeNull()
+    expect(enemy.hp).toBe(650) // no damage
+  })
+
+  it('should reject when no enemy in range', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 800, y: 300 }) // 400px away from hero
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    // Click near the hero — enemy is 400px from click, exceeds 150px range
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(event).toBeNull()
+    expect(caster.cooldownQ).toBe(0) // no CD consumed
+    expect(enemy.hp).toBe(650) // no damage
+  })
+
+  it('should clamp damage so HP does not go below 0', () => {
+    const caster = createHero()
+    const enemy = createEnemy({ x: 450, y: 300, hp: 50 }) // 50/650 = 7.7% < 30%
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    heroes.set('enemy-1', enemy)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 450, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(enemy.hp).toBe(0) // 50 - 250 = clamped to 0
+  })
+})

--- a/server/src/game/skills/handlers/index.ts
+++ b/server/src/game/skills/handlers/index.ts
@@ -5,6 +5,7 @@ import { healEffectHandler } from './healEffectHandler.js'
 import { buffEffectHandler } from './buffEffectHandler.js'
 import { aoeEffectHandler } from './aoeEffectHandler.js'
 import { zoneEffectHandler } from './zoneEffectHandler.js'
+import { strikeEffectHandler } from './strikeEffectHandler.js'
 
 let registered = false
 
@@ -18,6 +19,7 @@ export function registerAllEffectHandlers(): void {
   registerEffectHandler(buffEffectHandler)
   registerEffectHandler(aoeEffectHandler)
   registerEffectHandler(zoneEffectHandler)
+  registerEffectHandler(strikeEffectHandler)
 }
 
 /** Reset registration state and clear registry. For testing only. */

--- a/server/src/game/skills/handlers/strikeEffectHandler.ts
+++ b/server/src/game/skills/handlers/strikeEffectHandler.ts
@@ -1,0 +1,23 @@
+import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
+import type { StrikeEffectParams } from '@shared/skills/skillDefinitions'
+
+export const strikeEffectHandler: SkillEffectHandler<StrikeEffectParams> = {
+  effectType: 'strike',
+
+  execute(ctx: SkillExecutionContext, params: StrikeEffectParams): void {
+    const target = ctx.targetHero
+    if (!target || target.dead) return
+
+    // Execute threshold check uses pre-damage HP ratio (standard MOBA pattern)
+    const hpRatio = target.maxHp > 0 ? target.hp / target.maxHp : 1
+    const isExecute = params.executeThreshold != null
+      && hpRatio <= params.executeThreshold
+
+    const totalDamage = isExecute
+      ? params.damage + (params.executeBonusDamage ?? 0)
+      : params.damage
+
+    target.applyDamage(totalDamage)
+    target.lastAttackerSessionId = ctx.casterId
+  },
+}

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -62,7 +62,14 @@ export interface ZoneEffectParams {
   }
 }
 
-export type SkillEffectParams = DashEffectParams | ProjectileEffectParams | HealEffectParams | BuffEffectParams | AoEEffectParams | ZoneEffectParams
+export interface StrikeEffectParams {
+  readonly effectType: 'strike'
+  readonly damage: number               // base melee damage
+  readonly executeThreshold?: number    // HP ratio (0-1) below which bonus damage applies (omit for plain strikes)
+  readonly executeBonusDamage?: number  // additional damage when target HP% ≤ threshold
+}
+
+export type SkillEffectParams = DashEffectParams | ProjectileEffectParams | HealEffectParams | BuffEffectParams | AoEEffectParams | ZoneEffectParams | StrikeEffectParams
 
 // ── Common fields shared by ALL skills ────────────────────────
 
@@ -305,6 +312,18 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       additionalBuffs: [
         { buffType: 'attackSpeed', value: 0.5 },
       ],
+    },
+  },
+  'blade-execute': {
+    id: 'blade-execute',
+    targeting: 'enemy',
+    cooldown: 20,
+    range: 150,
+    effect: {
+      effectType: 'strike',
+      damage: 100,
+      executeThreshold: 0.3,
+      executeBonusDamage: 150,
     },
   },
 }


### PR DESCRIPTION
## Summary
- Add BLADE Execute skill — melee finisher with low-HP bonus damage (enemy targeting, CD 20s)
- New `strike` effect type for instant melee single-target damage
- Execute threshold: 100 base damage, +150 bonus when target HP ≤ 30%
- Optional threshold fields for future plain strike skills

## Parameters
| Param | Value |
|-------|-------|
| cooldown | 20s |
| targeting | enemy |
| range | 150 px (melee) |
| damage | 100 |
| executeThreshold | 30% HP |
| executeBonusDamage | 150 |

## Test plan
- [x] Skill definition correctness (id, targeting, cooldown, range, effect params)
- [x] Base damage to full-HP enemy (100)
- [x] Execute bonus to low-HP enemy (250 total)
- [x] Base damage only when above threshold
- [x] Bonus at exactly 30% threshold (inclusive)
- [x] HP clamped to 0 on overkill
- [x] Cooldown set to 20s
- [x] Kill credit (lastAttackerSessionId)
- [x] Dash rejection
- [x] Out-of-range rejection (no CD consumed)
- [x] All 961 unit tests pass

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)