### PR TITLE
feat: BOLT Snipe skill (self-buff stance)

### DIFF
--- a/openspec/changes/archive/2026-03-11-bolt-snipe/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-bolt-snipe/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-11-bolt-snipe/design.md
+++ b/openspec/changes/archive/2026-03-11-bolt-snipe/design.md
@@ -1,0 +1,43 @@
+## Context
+
+BOLT の火力ビルドに Snipe（狙撃態勢）スキルを追加する。移動速度を犠牲にして通常攻撃を強化するセルフバフスキル。既存の `buff` エフェクトハンドラが `additionalBuffs` をサポートしており、新しいハンドラは不要。
+
+既存の類似スキル:
+- `blade-fury`: self targeting, buff effectType, attackDamage +25 / attackSpeed +0.5, duration 5s, cooldown 18s
+- `aura-haste`: ally targeting, buff effectType, speed +80, duration 3s
+
+## Goals / Non-Goals
+
+**Goals:**
+- `bolt-snipe` スキル定義を追加（buff effectType + additionalBuffs）
+- `boltTalents.ts` に Depth 5 タレントノードを追加
+- サーバーテストで全バフ適用を検証
+
+**Non-Goals:**
+- 新しいエフェクトハンドラの作成（既存 buff ハンドラで十分）
+- クライアント側のカスタム UI / エフェクト（既存 StatusEffect 表示で対応）
+- Snipe 中の通常攻撃アニメーション変更
+
+## Decisions
+
+### 1. buff effectType + additionalBuffs パターンを使用
+`blade-fury` と同じパターンで、primary buff に attackDamage、additionalBuffs に attackSpeed と speed（負値）を設定する。
+
+代替案: 新しい `stance` effectType を作る → 過剰設計。既存の buff で同等の動作が実現可能。
+
+### 2. パラメータ設定
+| パラメータ | 値 | 根拠 |
+|-----------|-----|------|
+| cooldown | 16s | blade-fury(18s) より短め。レンジャーのため頻度高め |
+| duration | 5s | blade-fury と同じ。十分な戦闘ウィンドウ |
+| attackDamage | +20 | BOLT の基礎攻撃力が BLADE より低いため控えめ |
+| attackSpeed | +0.4 (40%) | 火力倍率の主軸 |
+| speed | -60 | aura-haste の +80 と対照的。カイト困難なリスク |
+
+### 3. タレントノード配置
+Depth 5 の marksman ブランチ（`bolt-dead-eye` の隣）に配置。前提条件は `bolt-eagle-eye`（Depth 4, 射程系パッシブ）。火力特化ビルドの自然な延長。
+
+## Risks / Trade-offs
+
+- **[移動速度-60 が強すぎる/弱すぎる]** → バランス調整フェーズで数値チューニング。定数テーブルで一元管理済み。
+- **[additionalBuffs の isDebuff フラグが parent から継承される]** → speed の負値は機能的に正しく動作する。isDebuff フラグは将来の dispel ロジック用メタデータのみ。現時点では問題なし。

--- a/openspec/changes/archive/2026-03-11-bolt-snipe/proposal.md
+++ b/openspec/changes/archive/2026-03-11-bolt-snipe/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+BOLT の火力ビルドパスに Depth 5 のアクティブスキルが不足している。Snipe（狙撃態勢）は移動速度を犠牲にして通常攻撃を大幅強化するモード切替スキルで、ポジショニングのリスク・リターンを生むゲームプレイを追加する。Issue #209。
+
+## What Changes
+
+- `shared/skills/skillDefinitions.ts` に `bolt-snipe` スキル定義を追加（`buff` effectType、self targeting）
+- `shared/talents/boltTalents.ts` に `bolt-snipe` タレントノードを追加（Depth 5, Cost 2）
+- サーバー側テスト追加（スキル定義・バフ適用・移動速度低下の検証）
+- 既存の `buff` エフェクトハンドラの `additionalBuffs` 機能をそのまま活用（新ハンドラ不要）
+
+## Capabilities
+
+### New Capabilities
+- `bolt-snipe`: BOLT の Snipe スキル定義、パラメータ、タレントノード配置
+
+### Modified Capabilities
+
+（なし — 既存の buff システムをそのまま利用）
+
+## Impact
+
+- `shared/skills/skillDefinitions.ts` — スキル定義追加
+- `shared/talents/boltTalents.ts` — タレントノード追加
+- `server/src/__tests__/` — テストファイル追加
+- クライアント側の変更なし（バフは既存の StatusEffect レンダリングで表示される）

--- a/openspec/changes/archive/2026-03-11-bolt-snipe/specs/bolt-snipe/spec.md
+++ b/openspec/changes/archive/2026-03-11-bolt-snipe/specs/bolt-snipe/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Bolt Snipe skill definition
+The system SHALL register a `bolt-snipe` skill in `SKILL_DEFINITIONS` with targeting `self`, cooldown 16s, and `buff` effectType.
+
+The primary buff SHALL be `attackDamage` with value +20, duration 5s, `isDebuff: false`.
+
+The skill SHALL include `additionalBuffs`:
+- `attackSpeed` with value +0.4 (40%)
+- `speed` with value -60
+
+#### Scenario: Skill definition exists with correct parameters
+- **WHEN** `getSkillDefinition('bolt-snipe')` is called
+- **THEN** it SHALL return a definition with id `bolt-snipe`, targeting `self`, cooldown 16, and buff effect with attackDamage +20, duration 5
+
+#### Scenario: Additional buffs include attack speed and speed penalty
+- **WHEN** the skill definition's `additionalBuffs` is inspected
+- **THEN** it SHALL contain exactly 2 entries: attackSpeed +0.4 and speed -60
+
+### Requirement: Snipe applies all three status effects on activation
+The system SHALL apply three status effects to the caster when `bolt-snipe` is activated:
+1. `attackDamage` buff (+20) for 5 seconds
+2. `attackSpeed` buff (+0.4) for 5 seconds
+3. `speed` debuff (-60) for 5 seconds
+
+All three effects SHALL share the same duration and be removed simultaneously.
+
+#### Scenario: Full HP caster activates Snipe
+- **WHEN** a BOLT hero with 0 cooldown activates bolt-snipe
+- **THEN** the hero SHALL receive 3 status effects (attackDamage, attackSpeed, speed) with correct values and 5s duration
+
+#### Scenario: Cooldown is set after activation
+- **WHEN** bolt-snipe is activated successfully
+- **THEN** the caster's cooldown for the skill slot SHALL be set to 16 seconds
+
+#### Scenario: Activation rejected during dash
+- **WHEN** a hero with active dashTimer attempts to activate bolt-snipe
+- **THEN** the activation SHALL be rejected and no status effects SHALL be applied
+
+### Requirement: Bolt Snipe talent node placement
+The system SHALL include a `bolt-snipe` talent node in the BOLT talent tree at Depth 5 with cost 2, granting the `bolt-snipe` skill.
+
+The node SHALL require `bolt-eagle-eye` as a prerequisite.
+
+#### Scenario: Talent node exists in BOLT tree
+- **WHEN** the BOLT talent tree is inspected
+- **THEN** it SHALL contain a node with id `bolt-snipe`, cost 2, prerequisite `bolt-eagle-eye`, and effect `grant_skill` with skillId `bolt-snipe`

--- a/openspec/changes/archive/2026-03-11-bolt-snipe/tasks.md
+++ b/openspec/changes/archive/2026-03-11-bolt-snipe/tasks.md
@@ -1,0 +1,10 @@
+## Tasks
+
+### Backend
+- [x] `shared/skills/skillDefinitions.ts` に `bolt-snipe` スキル定義を追加（buff effectType, attackDamage +20, additionalBuffs: attackSpeed +0.4, speed -60, duration 5s, cooldown 16s）
+- [x] `shared/talents/boltTalents.ts` に `bolt-snipe` タレントノードを追加（Depth 5, Cost 2, prerequisite: bolt-eagle-eye, grant_skill: bolt-snipe）
+- [x] `server/src/__tests__/boltSnipe.test.ts` テスト作成（定義検証、バフ3種適用、クールダウン、ダッシュ中拒否）
+
+### Verification
+- [x] `npm run test:unit` 全パス確認
+- [x] `npm run lint` パス確認

--- a/openspec/specs/bolt-snipe/spec.md
+++ b/openspec/specs/bolt-snipe/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Bolt Snipe skill definition
+The system SHALL register a `bolt-snipe` skill in `SKILL_DEFINITIONS` with targeting `self`, cooldown 16s, and `buff` effectType.
+
+The primary buff SHALL be `attackDamage` with value +20, duration 5s, `isDebuff: false`.
+
+The skill SHALL include `additionalBuffs`:
+- `attackSpeed` with value +0.4 (40%)
+- `speed` with value -60
+
+#### Scenario: Skill definition exists with correct parameters
+- **WHEN** `getSkillDefinition('bolt-snipe')` is called
+- **THEN** it SHALL return a definition with id `bolt-snipe`, targeting `self`, cooldown 16, and buff effect with attackDamage +20, duration 5
+
+#### Scenario: Additional buffs include attack speed and speed penalty
+- **WHEN** the skill definition's `additionalBuffs` is inspected
+- **THEN** it SHALL contain exactly 2 entries: attackSpeed +0.4 and speed -60
+
+### Requirement: Snipe applies all three status effects on activation
+The system SHALL apply three status effects to the caster when `bolt-snipe` is activated:
+1. `attackDamage` buff (+20) for 5 seconds
+2. `attackSpeed` buff (+0.4) for 5 seconds
+3. `speed` debuff (-60) for 5 seconds
+
+All three effects SHALL share the same duration and be removed simultaneously.
+
+#### Scenario: Full HP caster activates Snipe
+- **WHEN** a BOLT hero with 0 cooldown activates bolt-snipe
+- **THEN** the hero SHALL receive 3 status effects (attackDamage, attackSpeed, speed) with correct values and 5s duration
+
+#### Scenario: Cooldown is set after activation
+- **WHEN** bolt-snipe is activated successfully
+- **THEN** the caster's cooldown for the skill slot SHALL be set to 16 seconds
+
+#### Scenario: Activation rejected during dash
+- **WHEN** a hero with active dashTimer attempts to activate bolt-snipe
+- **THEN** the activation SHALL be rejected and no status effects SHALL be applied
+
+### Requirement: Bolt Snipe talent node placement
+The system SHALL include a `bolt-snipe` talent node in the BOLT talent tree at Depth 5 with cost 2, granting the `bolt-snipe` skill.
+
+The node SHALL require `bolt-eagle-eye` as a prerequisite.
+
+#### Scenario: Talent node exists in BOLT tree
+- **WHEN** the BOLT talent tree is inspected
+- **THEN** it SHALL contain a node with id `bolt-snipe`, cost 2, prerequisite `bolt-eagle-eye`, and effect `grant_skill` with skillId `bolt-snipe`

--- a/server/src/__tests__/boltSnipe.test.ts
+++ b/server/src/__tests__/boltSnipe.test.ts
@@ -56,7 +56,7 @@ describe('getSkillDefinition — bolt-snipe', () => {
       expect(extras).toBeDefined()
       expect(extras).toHaveLength(2)
       expect(extras![0]).toEqual({ buffType: 'attackSpeed', value: 0.4 })
-      expect(extras![1]).toEqual({ buffType: 'speed', value: -60 })
+      expect(extras![1]).toEqual({ buffType: 'speed', value: -60, isDebuff: true })
     }
   })
 })
@@ -88,12 +88,13 @@ describe('executeSkill — bolt-snipe', () => {
     expect(asBuff!.value).toBe(0.4)
     expect(asBuff!.remainingDuration).toBe(5)
 
-    // Additional: speed (negative = penalty)
+    // Additional: speed (negative = penalty, isDebuff = true)
     const speedBuff = caster.statusEffects.get('bolt-snipe:speed')
     expect(speedBuff).toBeDefined()
     expect(speedBuff!.buffType).toBe('speed')
     expect(speedBuff!.value).toBe(-60)
     expect(speedBuff!.remainingDuration).toBe(5)
+    expect(speedBuff!.isDebuff).toBe(true)
   })
 
   it('should set cooldown to 16 seconds', () => {
@@ -135,8 +136,10 @@ describe('executeSkill — bolt-snipe', () => {
     // Second activation
     executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
 
-    // Duration should be refreshed to full
+    // Duration should be refreshed to full for all three buffs
     expect(caster.statusEffects.get('bolt-snipe')!.remainingDuration).toBe(5)
+    expect(caster.statusEffects.get('bolt-snipe:attackSpeed')!.remainingDuration).toBe(5)
+    expect(caster.statusEffects.get('bolt-snipe:speed')!.remainingDuration).toBe(5)
   })
 })
 

--- a/server/src/__tests__/boltSnipe.test.ts
+++ b/server/src/__tests__/boltSnipe.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { ZoneSchema } from '../schema/ZoneSchema.js'
+import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
+import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+import { BOLT_TALENT_TREE } from '@shared/talents/boltTalents'
+
+let tracker: ProjectileTracker
+
+function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 500
+  hero.maxHp = 500
+  hero.dead = false
+  hero.team = 'blue'
+  hero.x = 400
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'BOLT'
+  hero.skillSlotQ = 'bolt-snipe'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+beforeEach(() => {
+  registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
+})
+
+// ── Skill definition ──
+
+describe('getSkillDefinition — bolt-snipe', () => {
+  it('should return bolt-snipe definition with correct params', () => {
+    const def = getSkillDefinition('bolt-snipe')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('bolt-snipe')
+    expect(def!.targeting).toBe('self')
+    expect(def!.cooldown).toBe(16)
+    if (def!.effect.effectType === 'buff') {
+      expect(def!.effect.buffType).toBe('attackDamage')
+      expect(def!.effect.value).toBe(20)
+      expect(def!.effect.duration).toBe(5)
+      expect(def!.effect.isDebuff).toBe(false)
+    }
+  })
+
+  it('should have additionalBuffs with attackSpeed and speed', () => {
+    const def = getSkillDefinition('bolt-snipe')
+    expect(def).toBeDefined()
+    if (def!.effect.effectType === 'buff') {
+      const extras = def!.effect.additionalBuffs
+      expect(extras).toBeDefined()
+      expect(extras).toHaveLength(2)
+      expect(extras![0]).toEqual({ buffType: 'attackSpeed', value: 0.4 })
+      expect(extras![1]).toEqual({ buffType: 'speed', value: -60 })
+    }
+  })
+})
+
+// ── Skill execution ──
+
+describe('executeSkill — bolt-snipe', () => {
+  it('should apply three status effects on activation', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('bolt-snipe')
+
+    // Primary buff: attackDamage
+    const adBuff = caster.statusEffects.get('bolt-snipe')
+    expect(adBuff).toBeDefined()
+    expect(adBuff!.buffType).toBe('attackDamage')
+    expect(adBuff!.value).toBe(20)
+    expect(adBuff!.remainingDuration).toBe(5)
+
+    // Additional: attackSpeed
+    const asBuff = caster.statusEffects.get('bolt-snipe:attackSpeed')
+    expect(asBuff).toBeDefined()
+    expect(asBuff!.buffType).toBe('attackSpeed')
+    expect(asBuff!.value).toBe(0.4)
+    expect(asBuff!.remainingDuration).toBe(5)
+
+    // Additional: speed (negative = penalty)
+    const speedBuff = caster.statusEffects.get('bolt-snipe:speed')
+    expect(speedBuff).toBeDefined()
+    expect(speedBuff!.buffType).toBe('speed')
+    expect(speedBuff!.value).toBe(-60)
+    expect(speedBuff!.remainingDuration).toBe(5)
+  })
+
+  it('should set cooldown to 16 seconds', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(caster.cooldownQ).toBe(16)
+  })
+
+  it('should reject activation while dashing', () => {
+    const caster = createHero({ dashTimer: 0.2 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    expect(event).toBeNull()
+    expect(caster.statusEffects.size).toBe(0)
+  })
+
+  it('should refresh buffs when activated again (overwrite duration)', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+
+    // First activation
+    executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    // Simulate time passing — reduce remaining duration
+    const adBuff = caster.statusEffects.get('bolt-snipe')!
+    adBuff.remainingDuration = 1.0
+
+    // Reset cooldown to allow re-cast
+    caster.cooldownQ = 0
+
+    // Second activation
+    executeSkill(caster, 'caster-1', 'Q', { x: 400, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>())
+
+    // Duration should be refreshed to full
+    expect(caster.statusEffects.get('bolt-snipe')!.remainingDuration).toBe(5)
+  })
+})
+
+// ── Talent node ──
+
+describe('BOLT talent tree — bolt-snipe node', () => {
+  it('should have bolt-snipe node at Depth 5 with correct properties', () => {
+    const node = BOLT_TALENT_TREE.nodes.find(n => n.id === 'bolt-snipe')
+    expect(node).toBeDefined()
+    expect(node!.cost).toBe(2)
+    expect(node!.prerequisites).toEqual(['bolt-eagle-eye'])
+    expect(node!.effects).toEqual([{ type: 'grant_skill', skillId: 'bolt-snipe' }])
+  })
+})

--- a/server/src/game/skills/handlers/buffEffectHandler.ts
+++ b/server/src/game/skills/handlers/buffEffectHandler.ts
@@ -38,7 +38,7 @@ export const buffEffectHandler: SkillEffectHandler<BuffEffectParams> = {
     if (params.additionalBuffs) {
       for (const extra of params.additionalBuffs) {
         const key = `${ctx.skillId}:${extra.buffType}`
-        applyBuff(target, key, extra.buffType, extra.value, params.duration, params.isDebuff)
+        applyBuff(target, key, extra.buffType, extra.value, params.duration, extra.isDebuff ?? params.isDebuff)
       }
     }
   },

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -35,6 +35,7 @@ export interface BuffEffectParams {
   readonly additionalBuffs?: readonly {
     readonly buffType: string
     readonly value: number
+    readonly isDebuff?: boolean  // override parent isDebuff for this specific buff
   }[]
 }
 
@@ -357,7 +358,7 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       isDebuff: false,
       additionalBuffs: [
         { buffType: 'attackSpeed', value: 0.4 },
-        { buffType: 'speed', value: -60 },
+        { buffType: 'speed', value: -60, isDebuff: true },
       ],
     },
   },

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -345,6 +345,22 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       executeBonusDamage: 150,
     },
   },
+  'bolt-snipe': {
+    id: 'bolt-snipe',
+    targeting: 'self',
+    cooldown: 16,
+    effect: {
+      effectType: 'buff',
+      buffType: 'attackDamage',
+      value: 20,
+      duration: 5,
+      isDebuff: false,
+      additionalBuffs: [
+        { buffType: 'attackSpeed', value: 0.4 },
+        { buffType: 'speed', value: -60 },
+      ],
+    },
+  },
 }
 
 export function getSkillDefinition(skillId: string): SkillDefinition | undefined {

--- a/shared/talents/boltTalents.ts
+++ b/shared/talents/boltTalents.ts
@@ -304,6 +304,14 @@ export const BOLT_TALENT_TREE: TalentTreeDefinition = {
       effects: [{ type: 'stat_modifier', stat: 'attackDamage', value: 8, mode: 'percent' }],
     },
     {
+      id: 'bolt-snipe',
+      name: 'Snipe',
+      description: 'Unlock Snipe skill — sniper stance',
+      cost: 2,
+      prerequisites: ['bolt-eagle-eye'],
+      effects: [{ type: 'grant_skill', skillId: 'bolt-snipe' }],
+    },
+    {
       id: 'bolt-rain',
       name: 'Arrow Rain',
       description: 'Unlock Rain skill',


### PR DESCRIPTION
## Summary
- Add bolt-snipe skill: self-targeting buff that boosts attack damage (+20) and attack speed (+40%) at the cost of movement speed (-60) for 5 seconds
- Add talent node to BOLT tree (Depth 5, Cost 2, prerequisite: bolt-eagle-eye)
- Reuses existing buff effect handler with additionalBuffs pattern (same as blade-fury)
- 7 unit tests covering all scenarios

## Test plan
- [x] npm run test:unit - 978 tests pass (7 new boltSnipe tests)
- [x] npm run lint - no errors (1 pre-existing warning)
- [ ] Manual: verify buff application in-game with BOLT hero

Closes #209