### PR TITLE
fix: resolve CI type errors in test files

### DIFF
--- a/shared/zone/zoneVisuals.test.ts
+++ b/shared/zone/zoneVisuals.test.ts
@@ -9,24 +9,24 @@ describe('ZONE_VISUALS registry', () => {
   it('should have an entry for aura-slow-field', () => {
     const visual = ZONE_VISUALS['aura-slow-field']
     expect(visual).toBeDefined()
-    expect(visual.color).toBe(0x9b59b6)
-    expect(visual.alpha).toBeGreaterThan(0)
-    expect(visual.alpha).toBeLessThanOrEqual(1)
-    expect(visual.borderWidth).toBeGreaterThan(0)
+    expect(visual!.color).toBe(0x9b59b6)
+    expect(visual!.alpha).toBeGreaterThan(0)
+    expect(visual!.alpha).toBeLessThanOrEqual(1)
+    expect(visual!.borderWidth).toBeGreaterThan(0)
   })
 
   it('should have an entry for bolt-trap with allyOnly', () => {
     const visual = ZONE_VISUALS['bolt-trap']
     expect(visual).toBeDefined()
-    expect(visual.color).toBe(0xf1c40f)
-    expect(visual.alpha).toBeGreaterThan(0)
-    expect(visual.alpha).toBeLessThanOrEqual(1)
-    expect(visual.allyOnly).toBe(true)
+    expect(visual!.color).toBe(0xf1c40f)
+    expect(visual!.alpha).toBeGreaterThan(0)
+    expect(visual!.alpha).toBeLessThanOrEqual(1)
+    expect(visual!.allyOnly).toBe(true)
   })
 
   it('should not have allyOnly on aura-slow-field', () => {
     const visual = ZONE_VISUALS['aura-slow-field']
-    expect(visual.allyOnly).toBeUndefined()
+    expect(visual!.allyOnly).toBeUndefined()
   })
 
   it('should have valid alpha values for all entries', () => {

--- a/src/domain/systems/__tests__/updateAttackState.test.ts
+++ b/src/domain/systems/__tests__/updateAttackState.test.ts
@@ -33,6 +33,10 @@ function makeHero(overrides: Partial<HeroState> = {}): HeroState {
     skillSlotQ: '',
     skillSlotE: '',
     skillSlotR: '',
+    cooldownQ: 0,
+    cooldownE: 0,
+    cooldownR: 0,
+    dashTimer: 0,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Add missing cooldownQ/E/R and dashTimer fields to makeHero in updateAttackState test
- Add non-null assertions for ZONE_VISUALS index access in zoneVisuals test

## Test plan
- [x] npm run test:unit — 978 tests pass
- [x] npm run lint — no errors
- [x] npx tsc --noEmit — no errors in affected files