### PR TITLE
feat: add BOLT Ricochet & Turret skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ All game/tech specs live in `openspec/specs/`:
 - **File size** — 200-400 lines typical, 800 max. Split when larger.
 - **Feature-based organization** — Organize by feature/domain (`domain/systems/`, `scenes/effects/`), not by type (`models/`, `utils/`).
 - **No hardcoded balance values** — Game balance numbers (damage, timers, XP, growth rates, etc.) must be centralized in constant tables for easy tuning later.
+- **Interface 変更時はモック更新必須** — `GameMode`, `ServerHeroState`, `HeroState` 等の共有インターフェースにフィールドを追加・変更した場合、テストファイルのモック/ファクトリ関数も同時に更新する。`npx tsc --noEmit` で CI 前に検証。
 
 ## Git Workflow
 

--- a/openspec/changes/archive/2026-03-11-bolt-ricochet/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-11-bolt-ricochet/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-11

--- a/openspec/changes/archive/2026-03-11-bolt-ricochet/design.md
+++ b/openspec/changes/archive/2026-03-11-bolt-ricochet/design.md
@@ -1,0 +1,53 @@
+## Context
+
+既存の projectile システムは `homing`（追尾）と `linear`（直線 + 貫通）の2モードをサポート。Ricochet は `linear` モードの拡張で、ヒット時に最近接敵にリダイレクトするバウンス動作を追加する。
+
+既存の仕組み:
+- `ProjectileTracker` が hitSet（既ヒット敵ID集合）と distanceTraveled を管理
+- `processLinearProjectile` がフレームごとに移動 → 衝突判定 → pierce 処理
+- `collectEnemyEntities` で敵候補を収集済み
+
+## Goals / Non-Goals
+
+**Goals:**
+- `linear` モードのプロジェクタイルにバウンス動作を追加
+- ヒット時に `bounceRemaining > 0` なら最近接の未ヒット敵にリダイレクト
+- `ProjectileEffectParams` / `ProjectileSchema` にバウンスパラメータ追加
+
+**Non-Goals:**
+- バウンスプロジェクタイル専用の新モード追加（`linear` モードの拡張で対応）
+- タワー/ミニオンへのバウンス（ヒーローのみ。将来拡張可能）
+- バウンス時のダメージ減衰（バランス調整フェーズで検討）
+
+## Decisions
+
+### 1. `linear` モードの拡張として実装
+バウンスは `linear` モードの on-hit behavior の分岐として実装する。`bounceRemaining > 0` のときは pierce の代わりにリダイレクトする。
+
+代替案: 新しい `bounce` モードを追加 → processProjectiles のモード分岐が増える。バウンスの移動は直線と同じなので、拡張のほうが DRY。
+
+### 2. バウンスと pierce は排他
+同一プロジェクタイルが pierce と bounce を同時に持つことはない。`bounceRemaining > 0` の場合、ヒット時は pierce ではなくバウンスを実行する。
+
+### 3. バウンスターゲットはヒーローのみ
+`collectEnemyEntities` からヒーロー以外をフィルタするのではなく、バウンス先の検索時にヒーローのみを対象にする専用関数を追加。
+
+### 4. パラメータ設定
+| パラメータ | 値 | 根拠 |
+|-----------|-----|------|
+| cooldown | 8s | pierce-shot(5s) と barrage(10s) の間 |
+| damage | 50 | バウンスで複数ヒットを前提にやや控えめ |
+| speed | 700 | barrage と同等 |
+| range | 500 | 初弾の最大飛距離 |
+| radius | 5 | pierce-shot と同じ |
+| bounceCount | 3 | 初弾 + 3バウンド = 最大4ヒット |
+| bounceRange | 300 | バウンド先の探索範囲 |
+
+### 5. バウンス時の距離リセット
+バウンドのたびに distanceTraveled をリセットし、maxRange をバウンド先までの距離を元に再計算。これにより各バウンドで range 制限が適用される。
+
+## Risks / Trade-offs
+
+- **[密集戦で強すぎる]** → 4ヒット × 50 = 200 total。Barrage (5 × 25 = 125) より高いが、敵が4体密集するのは稀。バランス調整フェーズで数値チューニング。
+- **[バウンス先が見つからない場合]** → 弾丸は消滅。最後のヒット時にダメージは入るので問題なし。
+- **[distanceTraveled リセットの複雑さ]** → バウンス時にリセットするだけ。1行の変更。

--- a/openspec/changes/archive/2026-03-11-bolt-ricochet/proposal.md
+++ b/openspec/changes/archive/2026-03-11-bolt-ricochet/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+BOLT の火力ビルドに中距離の集団戦向けスキルが不足している。Ricochet（跳弾）は敵間を跳ね回る弾丸で、密集した敵チームに対して効率的にダメージを与えるスキル。Issue #208。
+
+## What Changes
+
+- `ProjectileEffectParams` に `bounceCount` / `bounceRange` フィールドを追加
+- `ProjectileSchema` に `bounceRemaining` / `bounceRange` フィールドを追加
+- `ServerProjectileSystem.ts` の `processLinearProjectile` にバウンスロジックを追加（ヒット時に最近接敵にリターゲット）
+- `shared/skills/skillDefinitions.ts` に `bolt-ricochet` スキル定義を追加
+- サーバーテスト追加（バウンド動作、範囲外停止、既ヒット除外）
+
+## Capabilities
+
+### New Capabilities
+- `bolt-ricochet`: Ricochet スキル定義とバウンスプロジェクタイルシステム
+
+### Modified Capabilities
+- `projectile-system`: プロジェクタイルにバウンス動作を追加（`bounceCount`/`bounceRange`）
+
+## Impact
+
+- `shared/skills/skillDefinitions.ts` — `ProjectileEffectParams` 拡張 + スキル定義追加
+- `server/src/schema/ProjectileSchema.ts` — `bounceRemaining`, `bounceRange` フィールド追加
+- `server/src/game/ServerProjectileSystem.ts` — バウンスロジック追加
+- `server/src/game/skills/handlers/projectileEffectHandler.ts` — バウンスフィールド設定
+- `shared/talents/boltTalents.ts` — 既に `bolt-ricochet` ノード存在（変更不要）

--- a/openspec/changes/archive/2026-03-11-bolt-ricochet/specs/bolt-ricochet/spec.md
+++ b/openspec/changes/archive/2026-03-11-bolt-ricochet/specs/bolt-ricochet/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Bolt Ricochet skill definition
+The system SHALL register a `bolt-ricochet` skill in `SKILL_DEFINITIONS` with targeting `direction`, cooldown 8s, and `projectile` effectType.
+
+The projectile SHALL have: damage 50, speed 700, range 500, radius 5, pierceCount 0, homing false, visualType `diamond`, bounceCount 3, bounceRange 300.
+
+#### Scenario: Skill definition exists with correct parameters
+- **WHEN** `getSkillDefinition('bolt-ricochet')` is called
+- **THEN** it SHALL return a definition with id `bolt-ricochet`, targeting `direction`, cooldown 8, and projectile effect with damage 50, bounceCount 3, bounceRange 300
+
+### Requirement: Ricochet projectile bounces between enemies
+The system SHALL redirect the projectile toward the nearest unhit enemy hero within `bounceRange` after each hit, decrementing `bounceRemaining`.
+
+#### Scenario: Projectile bounces to nearest enemy after hitting first target
+- **WHEN** a ricochet projectile hits an enemy hero and bounceRemaining > 0
+- **THEN** the projectile SHALL redirect toward the nearest unhit enemy hero within bounceRange and decrement bounceRemaining by 1
+
+#### Scenario: Projectile is removed when no bounce target is available
+- **WHEN** a ricochet projectile hits an enemy hero and bounceRemaining > 0 but no unhit enemy is within bounceRange
+- **THEN** the projectile SHALL be removed after dealing damage to the current target
+
+#### Scenario: Projectile is removed when bounceRemaining reaches 0
+- **WHEN** a ricochet projectile hits an enemy hero and bounceRemaining is 0
+- **THEN** the projectile SHALL be removed after dealing damage
+
+### Requirement: Ricochet does not hit the same enemy twice
+The system SHALL track which enemies have been hit and exclude them from bounce target selection.
+
+#### Scenario: Previously hit enemy is excluded from bounce targets
+- **WHEN** a ricochet projectile looks for the next bounce target
+- **THEN** it SHALL NOT select an enemy that was already hit by this projectile

--- a/openspec/changes/archive/2026-03-11-bolt-ricochet/specs/projectile-system/spec.md
+++ b/openspec/changes/archive/2026-03-11-bolt-ricochet/specs/projectile-system/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Linear projectile bounce behavior
+The linear projectile processing system SHALL support bounce behavior when `bounceRemaining > 0`. On hit, instead of pierce behavior, the projectile SHALL:
+1. Deal damage to the hit target
+2. Add the target to the hitSet
+3. Find the nearest unhit enemy hero within `bounceRange`
+4. If found: redirect the projectile's direction toward that enemy, decrement `bounceRemaining`, reset `distanceTraveled`
+5. If not found: remove the projectile
+
+Bounce and pierce SHALL be mutually exclusive. When `bounceRemaining > 0`, pierce logic SHALL NOT apply.
+
+#### Scenario: Bounce takes priority over pierce
+- **WHEN** a projectile has both `bounceRemaining > 0` and `pierceRemaining > 0`
+- **THEN** the system SHALL execute bounce logic, not pierce logic
+
+#### Scenario: Distance traveled resets on bounce
+- **WHEN** a projectile bounces to a new target
+- **THEN** `distanceTraveled` SHALL be reset to 0 so the projectile can travel `maxRange` toward the new target
+
+## ADDED Requirements
+
+### Requirement: ProjectileSchema bounce fields
+`ProjectileSchema` SHALL include `bounceRemaining` (int16, default 0) and `bounceRange` (float32, default 0) fields.
+
+#### Scenario: New projectile has default bounce values
+- **WHEN** a new ProjectileSchema is created
+- **THEN** `bounceRemaining` SHALL be 0 and `bounceRange` SHALL be 0
+
+### Requirement: ProjectileEffectParams bounce fields
+`ProjectileEffectParams` SHALL include optional `bounceCount` (number) and `bounceRange` (number) fields. The `projectileEffectHandler` SHALL set `bounceRemaining` and `bounceRange` on the schema from these params.
+
+#### Scenario: Handler sets bounce fields from params
+- **WHEN** a projectile effect with `bounceCount: 3` and `bounceRange: 300` is executed
+- **THEN** the created ProjectileSchema SHALL have `bounceRemaining: 3` and `bounceRange: 300`

--- a/openspec/changes/archive/2026-03-11-bolt-ricochet/tasks.md
+++ b/openspec/changes/archive/2026-03-11-bolt-ricochet/tasks.md
@@ -1,0 +1,17 @@
+## Tasks
+
+### Backend — Schema & Definition
+- [x] `server/src/schema/ProjectileSchema.ts` に `bounceRemaining` (int16) と `bounceRange` (float32) フィールドを追加
+- [x] `shared/skills/skillDefinitions.ts` の `ProjectileEffectParams` に optional `bounceCount` と `bounceRange` を追加
+- [x] `shared/skills/skillDefinitions.ts` に `bolt-ricochet` スキル定義を追加
+- [x] `server/src/game/skills/handlers/projectileEffectHandler.ts` で bounceRemaining / bounceRange を設定
+
+### Backend — Bounce Logic
+- [x] `server/src/game/ServerProjectileSystem.ts` の `processLinearProjectile` にバウンスロジックを追加（ヒット時に最近接ヒーローへリダイレクト、distanceTraveled リセット）
+
+### Tests
+- [x] `server/src/__tests__/boltRicochet.test.ts` テスト作成（定義検証、バウンド動作、範囲外停止、同一敵除外、バウンス切れ、ダッシュ中拒否）
+
+### Verification
+- [x] `npm run test:unit` 全パス確認
+- [x] `npm run lint` パス確認

--- a/openspec/specs/bolt-ricochet/spec.md
+++ b/openspec/specs/bolt-ricochet/spec.md
@@ -1,0 +1,37 @@
+# Specification
+
+## Purpose
+Bolt Ricochet skill: a bouncing projectile that chains between enemy heroes.
+
+## Requirements
+
+### Requirement: Bolt Ricochet skill definition
+The system SHALL register a `bolt-ricochet` skill in `SKILL_DEFINITIONS` with targeting `direction`, cooldown 8s, and `projectile` effectType.
+
+The projectile SHALL have: damage 50, speed 700, range 500, radius 5, pierceCount 0, homing false, visualType `diamond`, bounceCount 3, bounceRange 300.
+
+#### Scenario: Skill definition exists with correct parameters
+- **WHEN** `getSkillDefinition('bolt-ricochet')` is called
+- **THEN** it SHALL return a definition with id `bolt-ricochet`, targeting `direction`, cooldown 8, and projectile effect with damage 50, bounceCount 3, bounceRange 300
+
+### Requirement: Ricochet projectile bounces between enemies
+The system SHALL redirect the projectile toward the nearest unhit enemy hero within `bounceRange` after each hit, decrementing `bounceRemaining`.
+
+#### Scenario: Projectile bounces to nearest enemy after hitting first target
+- **WHEN** a ricochet projectile hits an enemy hero and bounceRemaining > 0
+- **THEN** the projectile SHALL redirect toward the nearest unhit enemy hero within bounceRange and decrement bounceRemaining by 1
+
+#### Scenario: Projectile is removed when no bounce target is available
+- **WHEN** a ricochet projectile hits an enemy hero and bounceRemaining > 0 but no unhit enemy is within bounceRange
+- **THEN** the projectile SHALL be removed after dealing damage to the current target
+
+#### Scenario: Projectile is removed when bounceRemaining reaches 0
+- **WHEN** a ricochet projectile hits an enemy hero and bounceRemaining is 0
+- **THEN** the projectile SHALL be removed after dealing damage
+
+### Requirement: Ricochet does not hit the same enemy twice
+The system SHALL track which enemies have been hit and exclude them from bounce target selection.
+
+#### Scenario: Previously hit enemy is excluded from bounce targets
+- **WHEN** a ricochet projectile looks for the next bounce target
+- **THEN** it SHALL NOT select an enemy that was already hit by this projectile

--- a/openspec/specs/projectile-system/spec.md
+++ b/openspec/specs/projectile-system/spec.md
@@ -114,6 +114,38 @@ GameScene の update ループにプロジェクタイルの更新・描画を�
 - **WHEN** 通常攻撃でプロジェクタイルが生成される
 - **THEN** mode='homing', dirX=0, dirY=0, maxRange=0, pierceRemaining=0 のデフォルト値を持つ
 
+### Requirement: ProjectileSchema bounce fields
+`ProjectileSchema` SHALL include `bounceRemaining` (int16, default 0) and `bounceRange` (float32, default 0) fields.
+
+#### Scenario: New projectile has default bounce values
+- **WHEN** a new ProjectileSchema is created
+- **THEN** `bounceRemaining` SHALL be 0 and `bounceRange` SHALL be 0
+
+### Requirement: ProjectileEffectParams bounce fields
+`ProjectileEffectParams` SHALL include optional `bounceCount` (number) and `bounceRange` (number) fields. The `projectileEffectHandler` SHALL set `bounceRemaining` and `bounceRange` on the schema from these params.
+
+#### Scenario: Handler sets bounce fields from params
+- **WHEN** a projectile effect with `bounceCount: 3` and `bounceRange: 300` is executed
+- **THEN** the created ProjectileSchema SHALL have `bounceRemaining: 3` and `bounceRange: 300`
+
+### Requirement: Linear projectile bounce behavior
+The linear projectile processing system SHALL support bounce behavior when `bounceRemaining > 0`. On hit, instead of pierce behavior, the projectile SHALL:
+1. Deal damage to the hit target
+2. Add the target to the hitSet
+3. Find the nearest unhit enemy hero within `bounceRange`
+4. If found: redirect the projectile's direction toward that enemy, decrement `bounceRemaining`, reset `distanceTraveled`
+5. If not found: remove the projectile
+
+Bounce and pierce SHALL be mutually exclusive. When `bounceRemaining > 0`, pierce logic SHALL NOT apply.
+
+#### Scenario: Bounce takes priority over pierce
+- **WHEN** a projectile has both `bounceRemaining > 0` and `pierceRemaining > 0`
+- **THEN** the system SHALL execute bounce logic, not pierce logic
+
+#### Scenario: Distance traveled resets on bounce
+- **WHEN** a projectile bounces to a new target
+- **THEN** `distanceTraveled` SHALL be reset to 0 so the projectile can travel `maxRange` toward the new target
+
 ### Requirement: 射程による自動除去
 `mode: 'linear'` のプロジェクタイルは累計移動距離を追跡し、`maxRange` を超えた時点で除去しなければならない（SHALL）。累計移動距離はサーバーサイドで管理し、Schema には含めない。
 

--- a/server/src/__tests__/boltRicochet.test.ts
+++ b/server/src/__tests__/boltRicochet.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { TowerSchema } from '../schema/TowerSchema.js'
+import { ZoneSchema } from '../schema/ZoneSchema.js'
+import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
+import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+import { processProjectiles } from '../game/ServerProjectileSystem.js'
+import { BOLT_TALENT_TREE } from '@shared/talents/boltTalents'
+
+let tracker: ProjectileTracker
+
+function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 500
+  hero.maxHp = 500
+  hero.dead = false
+  hero.team = 'blue'
+  hero.x = 400
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'BOLT'
+  hero.skillSlotQ = 'bolt-ricochet'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+function createEnemy(id: string, x: number, y: number): HeroSchema {
+  const hero = new HeroSchema()
+  hero.id = id
+  hero.hp = 500
+  hero.maxHp = 500
+  hero.dead = false
+  hero.team = 'red'
+  hero.x = x
+  hero.y = y
+  hero.radius = 22
+  return hero
+}
+
+beforeEach(() => {
+  registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
+})
+
+// ── Skill definition ──
+
+describe('getSkillDefinition — bolt-ricochet', () => {
+  it('should return bolt-ricochet definition with correct params', () => {
+    const def = getSkillDefinition('bolt-ricochet')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('bolt-ricochet')
+    expect(def!.targeting).toBe('direction')
+    expect(def!.cooldown).toBe(8)
+    expect(def!.effect.effectType).toBe('projectile')
+    if (def!.effect.effectType === 'projectile') {
+      expect(def!.effect.damage).toBe(50)
+      expect(def!.effect.speed).toBe(700)
+      expect(def!.effect.range).toBe(500)
+      expect(def!.effect.radius).toBe(5)
+      expect(def!.effect.pierceCount).toBe(0)
+      expect(def!.effect.homing).toBe(false)
+      expect(def!.effect.visualType).toBe('diamond')
+      expect(def!.effect.bounceCount).toBe(3)
+      expect(def!.effect.bounceRange).toBe(300)
+    }
+  })
+})
+
+// ── Skill execution ──
+
+describe('executeSkill — bolt-ricochet', () => {
+  it('should create a projectile with bounce fields set', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('bolt-ricochet')
+    expect(projectiles.size).toBe(1)
+
+    const proj = [...projectiles.values()][0]
+    expect(proj.bounceRemaining).toBe(3)
+    expect(proj.bounceRange).toBe(300)
+    expect(proj.mode).toBe('linear')
+    expect(proj.damage).toBe(50)
+    expect(proj.speed).toBe(700)
+    expect(proj.visualType).toBe('diamond')
+  })
+
+  it('should set cooldown to 8 seconds', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    expect(caster.cooldownQ).toBe(8)
+  })
+
+  it('should reject activation while dashing', () => {
+    const caster = createHero({ dashTimer: 0.2 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 300 }, projectiles, heroes, tracker, zones)
+
+    expect(event).toBeNull()
+    expect(projectiles.size).toBe(0)
+  })
+})
+
+// ── Bounce behavior ──
+
+describe('processProjectiles — bounce', () => {
+  it('should redirect projectile toward nearest unhit enemy on hit', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const towers = new MapSchema<TowerSchema>()
+    const projectiles = new MapSchema<ProjectileSchema>()
+
+    // Enemy 1 directly ahead, Enemy 2 nearby
+    const enemy1 = createEnemy('enemy-1', 200, 100)
+    const enemy2 = createEnemy('enemy-2', 300, 100)
+    heroes.set('enemy-1', enemy1)
+    heroes.set('enemy-2', enemy2)
+
+    // Projectile heading right toward enemy1
+    const proj = new ProjectileSchema()
+    proj.id = 'bounce-proj'
+    proj.x = 170
+    proj.y = 100
+    proj.dirX = 1
+    proj.dirY = 0
+    proj.speed = 1000
+    proj.damage = 50
+    proj.ownerId = 'caster'
+    proj.team = 'blue'
+    proj.mode = 'linear'
+    proj.maxRange = 500
+    proj.bounceRemaining = 3
+    proj.bounceRange = 300
+    proj.pierceRemaining = 0
+    proj.radius = 5
+    projectiles.set(proj.id, proj)
+
+    // Tick — should hit enemy1 and redirect toward enemy2
+    const events = processProjectiles(projectiles, heroes, towers, 0.05, tracker)
+
+    expect(events).toHaveLength(1)
+    expect(events[0].event.targetId).toBe('enemy-1')
+    expect(projectiles.size).toBe(1) // still alive
+    expect(proj.bounceRemaining).toBe(2) // decremented
+
+    // Direction should now point toward enemy2
+    const dx = enemy2.x - proj.x
+    const dy = enemy2.y - proj.y
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    expect(proj.dirX).toBeCloseTo(dx / dist, 2)
+    expect(proj.dirY).toBeCloseTo(dy / dist, 2)
+  })
+
+  it('should reset distanceTraveled on bounce', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const towers = new MapSchema<TowerSchema>()
+    const projectiles = new MapSchema<ProjectileSchema>()
+
+    const enemy1 = createEnemy('enemy-1', 200, 100)
+    const enemy2 = createEnemy('enemy-2', 400, 100)
+    heroes.set('enemy-1', enemy1)
+    heroes.set('enemy-2', enemy2)
+
+    const proj = new ProjectileSchema()
+    proj.id = 'bounce-dist'
+    proj.x = 170
+    proj.y = 100
+    proj.dirX = 1
+    proj.dirY = 0
+    proj.speed = 1000
+    proj.damage = 50
+    proj.ownerId = 'caster'
+    proj.team = 'blue'
+    proj.mode = 'linear'
+    proj.maxRange = 500
+    proj.bounceRemaining = 2
+    proj.bounceRange = 500
+    proj.pierceRemaining = 0
+    proj.radius = 5
+    projectiles.set(proj.id, proj)
+
+    // Pre-set some distance traveled
+    tracker.setDistanceTraveled(proj.id, 100)
+
+    processProjectiles(projectiles, heroes, towers, 0.05, tracker)
+
+    // After bounce, distance should be reset (close to 0 + movement in this tick)
+    const traveled = tracker.getDistanceTraveled(proj.id)
+    expect(traveled).toBeLessThan(10) // was 100, now reset
+  })
+
+  it('should remove projectile when no bounce target available', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const towers = new MapSchema<TowerSchema>()
+    const projectiles = new MapSchema<ProjectileSchema>()
+
+    // Only one enemy, no one to bounce to
+    const enemy1 = createEnemy('enemy-1', 200, 100)
+    heroes.set('enemy-1', enemy1)
+
+    const proj = new ProjectileSchema()
+    proj.id = 'bounce-none'
+    proj.x = 170
+    proj.y = 100
+    proj.dirX = 1
+    proj.dirY = 0
+    proj.speed = 1000
+    proj.damage = 50
+    proj.ownerId = 'caster'
+    proj.team = 'blue'
+    proj.mode = 'linear'
+    proj.maxRange = 500
+    proj.bounceRemaining = 2
+    proj.bounceRange = 300
+    proj.pierceRemaining = 0
+    proj.radius = 5
+    projectiles.set(proj.id, proj)
+
+    const events = processProjectiles(projectiles, heroes, towers, 0.05, tracker)
+
+    expect(events).toHaveLength(1)
+    expect(events[0].event.targetId).toBe('enemy-1')
+    expect(projectiles.size).toBe(0) // removed — no bounce target
+  })
+
+  it('should exclude previously hit enemies from bounce targets', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const towers = new MapSchema<TowerSchema>()
+    const projectiles = new MapSchema<ProjectileSchema>()
+
+    // Two enemies: one already hit, one new
+    const enemy1 = createEnemy('enemy-1', 200, 100)
+    const enemy2 = createEnemy('enemy-2', 250, 100) // closer but already hit
+    const enemy3 = createEnemy('enemy-3', 350, 100) // farther but unhit
+    heroes.set('enemy-1', enemy1)
+    heroes.set('enemy-2', enemy2)
+    heroes.set('enemy-3', enemy3)
+
+    const proj = new ProjectileSchema()
+    proj.id = 'bounce-excl'
+    proj.x = 170
+    proj.y = 100
+    proj.dirX = 1
+    proj.dirY = 0
+    proj.speed = 1000
+    proj.damage = 50
+    proj.ownerId = 'caster'
+    proj.team = 'blue'
+    proj.mode = 'linear'
+    proj.maxRange = 500
+    proj.bounceRemaining = 2
+    proj.bounceRange = 500
+    proj.pierceRemaining = 0
+    proj.radius = 5
+    projectiles.set(proj.id, proj)
+
+    // Pre-mark enemy2 as already hit
+    tracker.getHitSet(proj.id).add('enemy-2')
+
+    // Hit enemy1 → should bounce to enemy3 (not enemy2)
+    processProjectiles(projectiles, heroes, towers, 0.05, tracker)
+
+    expect(projectiles.size).toBe(1)
+    // Direction should point toward enemy3, not enemy2
+    const dx = enemy3.x - proj.x
+    const dy = enemy3.y - proj.y
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    expect(proj.dirX).toBeCloseTo(dx / dist, 1)
+  })
+
+  it('should remove projectile when bounceRemaining reaches 0', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const towers = new MapSchema<TowerSchema>()
+    const projectiles = new MapSchema<ProjectileSchema>()
+
+    const enemy1 = createEnemy('enemy-1', 200, 100)
+    const enemy2 = createEnemy('enemy-2', 300, 100)
+    heroes.set('enemy-1', enemy1)
+    heroes.set('enemy-2', enemy2)
+
+    const proj = new ProjectileSchema()
+    proj.id = 'bounce-zero'
+    proj.x = 170
+    proj.y = 100
+    proj.dirX = 1
+    proj.dirY = 0
+    proj.speed = 1000
+    proj.damage = 50
+    proj.ownerId = 'caster'
+    proj.team = 'blue'
+    proj.mode = 'linear'
+    proj.maxRange = 500
+    proj.bounceRemaining = 0 // no bounces left
+    proj.bounceRange = 300
+    proj.pierceRemaining = 0
+    proj.radius = 5
+    projectiles.set(proj.id, proj)
+
+    const events = processProjectiles(projectiles, heroes, towers, 0.05, tracker)
+
+    expect(events).toHaveLength(1)
+    expect(projectiles.size).toBe(0) // removed — bounceRemaining was 0
+  })
+
+  it('should remove projectile when bounce target is out of bounceRange', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const towers = new MapSchema<TowerSchema>()
+    const projectiles = new MapSchema<ProjectileSchema>()
+
+    const enemy1 = createEnemy('enemy-1', 200, 100)
+    const enemy2 = createEnemy('enemy-2', 800, 100) // too far (600px away)
+    heroes.set('enemy-1', enemy1)
+    heroes.set('enemy-2', enemy2)
+
+    const proj = new ProjectileSchema()
+    proj.id = 'bounce-range'
+    proj.x = 170
+    proj.y = 100
+    proj.dirX = 1
+    proj.dirY = 0
+    proj.speed = 1000
+    proj.damage = 50
+    proj.ownerId = 'caster'
+    proj.team = 'blue'
+    proj.mode = 'linear'
+    proj.maxRange = 500
+    proj.bounceRemaining = 2
+    proj.bounceRange = 300 // enemy2 is 600px away, out of range
+    proj.pierceRemaining = 0
+    proj.radius = 5
+    projectiles.set(proj.id, proj)
+
+    processProjectiles(projectiles, heroes, towers, 0.05, tracker)
+
+    expect(projectiles.size).toBe(0) // removed — no target in range
+  })
+
+  it('bounce should take priority over pierce when both are set', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const towers = new MapSchema<TowerSchema>()
+    const projectiles = new MapSchema<ProjectileSchema>()
+
+    const enemy1 = createEnemy('enemy-1', 200, 100)
+    const enemy2 = createEnemy('enemy-2', 300, 100)
+    heroes.set('enemy-1', enemy1)
+    heroes.set('enemy-2', enemy2)
+
+    const proj = new ProjectileSchema()
+    proj.id = 'bounce-priority'
+    proj.x = 170
+    proj.y = 100
+    proj.dirX = 1
+    proj.dirY = 0
+    proj.speed = 1000
+    proj.damage = 50
+    proj.ownerId = 'caster'
+    proj.team = 'blue'
+    proj.mode = 'linear'
+    proj.maxRange = 500
+    proj.bounceRemaining = 2
+    proj.bounceRange = 300
+    proj.pierceRemaining = 3 // both set
+    proj.radius = 5
+    projectiles.set(proj.id, proj)
+
+    processProjectiles(projectiles, heroes, towers, 0.05, tracker)
+
+    // Bounce should have fired, not pierce
+    expect(proj.bounceRemaining).toBe(1) // decremented by bounce
+    expect(proj.pierceRemaining).toBe(3) // untouched — bounce took priority
+    expect(projectiles.size).toBe(1) // still alive after bounce
+  })
+})
+
+// ── Talent node ──
+
+describe('BOLT talent tree — bolt-ricochet node', () => {
+  it('should have bolt-ricochet node with correct properties', () => {
+    const node = BOLT_TALENT_TREE.nodes.find(n => n.id === 'bolt-ricochet')
+    expect(node).toBeDefined()
+    expect(node!.cost).toBe(2)
+    expect(node!.prerequisites).toEqual(['bolt-quickdraw'])
+    expect(node!.effects).toEqual([{ type: 'grant_skill', skillId: 'bolt-ricochet' }])
+  })
+})

--- a/server/src/game/ServerProjectileSystem.ts
+++ b/server/src/game/ServerProjectileSystem.ts
@@ -124,6 +124,30 @@ function collectEnemyEntities(
   return candidates
 }
 
+/** Find nearest enemy hero within bounce range (heroes only — design decision, see bolt-ricochet design.md §3). */
+function findNearestUnhitHero(
+  x: number,
+  y: number,
+  projTeam: string,
+  hitSet: Set<string>,
+  heroes: MapSchema<HeroSchema>,
+  bounceRange: number,
+): EntityCandidate | null {
+  let nearest: EntityCandidate | null = null
+  let nearestDistSq = bounceRange * bounceRange
+
+  heroes.forEach((h, id) => {
+    if (h.team === projTeam || h.dead || hitSet.has(id)) return
+    const dSq = distanceSq(x, y, h.x, h.y)
+    if (dSq <= nearestDistSq) {
+      nearestDistSq = dSq
+      nearest = { id, x: h.x, y: h.y, radius: h.radius, dead: h.dead, team: h.team }
+    }
+  })
+
+  return nearest
+}
+
 function processLinearProjectile(
   proj: ProjectileSchema,
   projId: string,
@@ -163,6 +187,27 @@ function processLinearProjectile(
       hitSet.add(enemy.id)
       applyDamageToTarget(enemy.id, proj.damage, heroes, towers, minions, proj.ownerId)
       events.push({ kind: 'damage', event: { targetId: enemy.id, amount: proj.damage, sourceId: proj.ownerId } })
+
+      // Bounce takes priority over pierce
+      if (proj.bounceRemaining > 0) {
+        const nextTarget = findNearestUnhitHero(proj.x, proj.y, proj.team, hitSet, heroes, proj.bounceRange)
+        if (nextTarget) {
+          const dx = nextTarget.x - proj.x
+          const dy = nextTarget.y - proj.y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          if (dist === 0) {
+            toRemove.push(projId)
+          } else {
+            proj.bounceRemaining = proj.bounceRemaining - 1
+            proj.dirX = dx / dist
+            proj.dirY = dy / dist
+            tracker.setDistanceTraveled(projId, 0)
+          }
+        } else {
+          toRemove.push(projId)
+        }
+        return
+      }
 
       // Decrement pierce
       if (proj.pierceRemaining > 0) {

--- a/server/src/game/skills/handlers/projectileEffectHandler.ts
+++ b/server/src/game/skills/handlers/projectileEffectHandler.ts
@@ -31,6 +31,8 @@ function createProjectile(
   proj.maxRange = params.range
   proj.pierceRemaining = params.pierceCount
   proj.visualType = params.visualType
+  proj.bounceRemaining = params.bounceCount ?? 0
+  proj.bounceRange = params.bounceRange ?? 0
 
   projectiles.set(proj.id, proj)
 }

--- a/server/src/schema/ProjectileSchema.ts
+++ b/server/src/schema/ProjectileSchema.ts
@@ -31,4 +31,10 @@ export class ProjectileSchema extends Schema {
   @type('float32') maxRange: number = 0
   /** Remaining pierce count (0 = remove on first hit) */
   @type('int16') pierceRemaining: number = 0
+
+  // ── Bounce fields ─────────────────────────────────────────
+  /** Remaining bounce count (0 = no bouncing) */
+  @type('int16') bounceRemaining: number = 0
+  /** Max distance to search for next bounce target (px) */
+  @type('float32') bounceRange: number = 0
 }

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -19,6 +19,8 @@ export interface ProjectileEffectParams {
   readonly visualType: string       // key into PROJECTILE_VISUALS (e.g. 'circle', 'diamond')
   readonly projectileCount?: number // number of projectiles to spawn (default 1)
   readonly spreadAngle?: number     // total fan spread angle in radians (used when projectileCount > 1)
+  readonly bounceCount?: number     // number of bounces (0 = no bounce)
+  readonly bounceRange?: number     // max distance to search for next bounce target (px)
 }
 
 export interface HealEffectParams {
@@ -344,6 +346,23 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       damage: 100,
       executeThreshold: 0.3,
       executeBonusDamage: 150,
+    },
+  },
+  'bolt-ricochet': {
+    id: 'bolt-ricochet',
+    targeting: 'direction',
+    cooldown: 8,
+    effect: {
+      effectType: 'projectile',
+      damage: 50,
+      speed: 700,
+      range: 500,
+      radius: 5,
+      pierceCount: 0,
+      homing: false,
+      visualType: 'diamond',
+      bounceCount: 3,
+      bounceRange: 300,
     },
   },
   'bolt-snipe': {


### PR DESCRIPTION
## Summary
- **Ricochet**: Linear projectile that bounces between enemy heroes (up to 3 bounces, 300px search range)
- **Turret**: Summoned auto-attacking turret at target point (10s duration, 200 HP, destroyable)
- Extend `processLinearProjectile` with bounce logic (mutually exclusive with pierce)
- Add `TurretEffectParams` effectType, reuse TowerSchema for turret entities
- Add turret lifetime management + match system safety (dead turrets don't trigger match end)
- Add `towers` to `SkillExecutionContext` for handler access

## Test plan
- [x] `npm run test:unit` — 1002 tests pass
- [x] `npm run lint` — 0 errors
- [x] Bounce: redirects to nearest unhit hero, range-gated, excludes hit enemies, priority over pierce
- [x] Turret: spawns at target, inherits team, expires after duration, cleaned up when damaged
- [x] Dead turret does NOT trigger match end (integration test)
- [x] Division-by-zero guard for bounce overlapping positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)