### PR TITLE
feat: add BOLT Turret skill with auto-attacking summoned turret

### DIFF
--- a/openspec/changes/archive/2026-03-16-bolt-turret/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-16-bolt-turret/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-14

--- a/openspec/changes/archive/2026-03-16-bolt-turret/design.md
+++ b/openspec/changes/archive/2026-03-16-bolt-turret/design.md
@@ -1,0 +1,77 @@
+## Context
+
+BOLT's talent tree has a Turret skill at Depth 6 that summons an auto-attacking turret. The codebase already has tower auto-attack AI (`ServerTowerSystem.processTowerCombat`) and `TowerSchema` with full combat fields. Turrets are mechanically identical to towers — they auto-target, fire projectiles, have HP, and can be destroyed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Summon a turret at a target point that auto-attacks enemies
+- Reuse existing tower combat infrastructure (no duplicate AI)
+- Turret has limited lifetime and can be destroyed
+- Balance: sustained DPS comparable to other Depth 6 skills
+
+**Non-Goals:**
+- Turret limit per player (Phase 1 — no cap, cooldown is the natural limiter)
+- Client-side turret visual distinction from towers (future: add `towerType` rendering)
+- Turret aggro/priority system beyond existing tower targeting
+
+## Decisions
+
+### §1 Reuse TowerSchema for turrets
+
+Turrets share all mechanics with towers (HP, attack, targeting, projectiles). Rather than creating a separate `TurretSchema`, extend `TowerSchema` with:
+- `remainingDuration` (float32, default 0) — 0 = permanent map tower, >0 = summoned turret
+- `ownerId` (string, default '') — who summoned it
+
+This lets `processTowerCombat` handle turret AI with zero changes.
+
+### §2 New `turret` effectType
+
+Add `TurretEffectParams` to the skill effect union:
+```typescript
+interface TurretEffectParams {
+  effectType: 'turret'
+  hp: number
+  duration: number        // seconds
+  attackDamage: number
+  attackSpeed: number     // attacks per second
+  attackRange: number     // px
+  radius: number          // collision/render radius
+  projectileSpeed: number // px/sec
+}
+```
+
+### §3 SkillExecutionContext expansion
+
+Add `towers: MapSchema<TowerSchema>` to `SkillExecutionContext`. The turret handler needs to add entities to the towers collection.
+
+### §4 Turret lifetime management
+
+In `GameRoom.update()`, iterate towers where `remainingDuration > 0`, decrement by deltaTime, mark dead and remove when expired. Extract this to a pure function `processTurretLifetime()` for testability.
+
+### §5 Balance parameters
+
+| Param | Value | Rationale |
+|-------|-------|-----------|
+| cooldown | 20s | Long CD for a sustained damage summon |
+| duration | 10s | Meaningful uptime but not permanent |
+| HP | 200 | Killable — about 3-4 hero attacks |
+| attackDamage | 25 | Per-hit; DPS = 25 × 1.5 = 37.5/s |
+| attackSpeed | 1.5 | Moderate fire rate |
+| attackRange | 250px | Shorter than hero attack range |
+| radius | 18 | Smaller than towers (24) |
+| projectileSpeed | 600 | Homing projectile speed |
+| placement range | 400px | point-targeting range |
+| Talent | Depth 6, Cost 2 | prereq: bolt-minefield |
+
+Total potential damage over 10s: 375 (comparable to bolt-ricochet's 200 instant burst).
+
+### §6 Talent tree placement
+
+`bolt-turret` node at Depth 6, Cost 2, prerequisite `bolt-minefield` (Depth 5, trap/zone branch). Thematically consistent with zone-control.
+
+## Risks / Trade-offs
+
+- **SkillExecutionContext change is breaking** — All callers of `executeSkill` must pass `towers`. Contained to `GameRoom` and tests.
+- **Client rendering** — Turrets will look identical to map towers initially. Acceptable for Phase 1; can add `towerType` distinction later.
+- **Tower cleanup** — Must ensure turret removal cleans up projectiles in flight. Existing tower death handling + `processTowerCombat` dead check covers this.

--- a/openspec/changes/archive/2026-03-16-bolt-turret/proposal.md
+++ b/openspec/changes/archive/2026-03-16-bolt-turret/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+BOLT's talent tree includes a "Turret" zone-control skill at Depth 6 (Issue #210). This adds a unique summoned-entity mechanic — placing an auto-attacking turret that provides area denial and sustained damage. It enriches BOLT's kit beyond direct-fire skills and leverages existing tower combat infrastructure.
+
+## What Changes
+
+- Add new `turret` effectType to `SkillEffectParams` with HP, duration, attack stats
+- Add `remainingDuration` and `ownerId` fields to `TowerSchema` (reuse tower for turret — same combat AI)
+- Add `towers` to `SkillExecutionContext` so handlers can spawn tower entities
+- Create `turretEffectHandler` that spawns a TowerSchema with a limited lifetime
+- Add turret lifetime expiry logic to `GameRoom` update tick
+- Register `bolt-turret` skill definition and talent node
+
+## Capabilities
+
+### New Capabilities
+- `bolt-turret`: Turret skill definition, summoning behavior, and auto-attack integration
+
+### Modified Capabilities
+- `skill-execution`: Add `towers` to SkillExecutionContext for turret spawning
+- `tower-entity`: Add `remainingDuration` (float32, default 0 = permanent) and `ownerId` (string) fields for summoned turrets
+
+## Impact
+
+- **Server schema**: TowerSchema gets 2 new fields (backward-compatible, defaults to 0/empty)
+- **Skill system**: SkillExecutionContext interface change — all callers must pass `towers`
+- **GameRoom**: Small addition to update tick for turret lifetime
+- **Client**: Existing tower rendering handles turrets automatically (same TowerSchema)

--- a/openspec/changes/archive/2026-03-16-bolt-turret/specs/bolt-turret/spec.md
+++ b/openspec/changes/archive/2026-03-16-bolt-turret/specs/bolt-turret/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Bolt Turret skill definition
+The system SHALL register a `bolt-turret` skill in `SKILL_DEFINITIONS` with targeting `point`, range 400, cooldown 20, and `turret` effectType.
+
+The turret SHALL have: hp 200, duration 10, attackDamage 25, attackSpeed 1.5, attackRange 250, radius 18, projectileSpeed 600.
+
+#### Scenario: Skill definition exists with correct parameters
+- **WHEN** `getSkillDefinition('bolt-turret')` is called
+- **THEN** it SHALL return a definition with id `bolt-turret`, targeting `point`, cooldown 20, range 400, and turret effect with hp 200, duration 10, attackDamage 25
+
+### Requirement: Turret spawns at target position
+The `turretEffectHandler` SHALL create a TowerSchema entity at `targetPosition` with the turret's combat parameters and add it to the towers collection.
+
+#### Scenario: Turret is created with correct fields
+- **WHEN** a turret skill is executed with targetPosition (500, 300)
+- **THEN** a TowerSchema SHALL be created at (500, 300) with hp 200, attackDamage 25, attackSpeed 1.5, attackRange 250, remainingDuration 10, and ownerId set to the caster's id
+
+#### Scenario: Turret inherits caster's team
+- **WHEN** a blue team hero uses bolt-turret
+- **THEN** the spawned turret SHALL have team `blue`
+
+### Requirement: Turret auto-attacks enemies
+Turrets SHALL use the existing tower combat system (`processTowerCombat`) for auto-attack behavior, targeting enemies within attackRange.
+
+#### Scenario: Turret fires at nearest enemy
+- **WHEN** an enemy hero is within the turret's attackRange
+- **THEN** the turret SHALL fire homing projectiles at the enemy using the tower combat system
+
+### Requirement: Turret lifetime expires
+Turrets with `remainingDuration > 0` SHALL have their duration decremented each tick. When duration reaches 0, the turret SHALL be marked dead and removed.
+
+#### Scenario: Turret expires after duration
+- **WHEN** a turret with remainingDuration 10 has 10 seconds of game time pass
+- **THEN** the turret SHALL be marked dead and removed from the towers collection
+
+#### Scenario: Turret can be destroyed before expiry
+- **WHEN** a turret's HP reaches 0 from enemy damage
+- **THEN** the turret SHALL be marked dead (same as any tower)
+
+### Requirement: Bolt Turret talent node
+The BOLT talent tree SHALL have a `bolt-turret` node at Depth 6, Cost 2, with prerequisite `bolt-minefield` and effect `grant_skill: bolt-turret`.
+
+#### Scenario: Talent node exists with correct properties
+- **WHEN** the BOLT talent tree is queried for `bolt-turret`
+- **THEN** it SHALL have cost 2, prerequisite `bolt-minefield`, and grant_skill effect

--- a/openspec/changes/archive/2026-03-16-bolt-turret/specs/skill-execution/spec.md
+++ b/openspec/changes/archive/2026-03-16-bolt-turret/specs/skill-execution/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: SkillExecutionContext includes towers
+`SkillExecutionContext` SHALL include a `towers` field of type `MapSchema<TowerSchema>` to allow skill handlers to spawn tower-type entities (turrets).
+
+#### Scenario: Turret handler accesses towers from context
+- **WHEN** a turret effect handler is executed
+- **THEN** it SHALL access `ctx.towers` to add the spawned turret entity
+
+#### Scenario: Existing handlers unaffected
+- **WHEN** a non-turret skill handler is executed
+- **THEN** the `towers` field SHALL be available but not used

--- a/openspec/changes/archive/2026-03-16-bolt-turret/specs/tower-entity/spec.md
+++ b/openspec/changes/archive/2026-03-16-bolt-turret/specs/tower-entity/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: TowerSchema supports summoned turrets
+`TowerSchema` SHALL include `remainingDuration` (float32, default 0) and `ownerId` (string, default '').
+
+When `remainingDuration` is 0, the tower is permanent (map tower). When > 0, it is a summoned turret with a limited lifetime.
+
+#### Scenario: Map towers have default values
+- **WHEN** a TowerSchema is created for a map tower
+- **THEN** `remainingDuration` SHALL be 0 and `ownerId` SHALL be ''
+
+#### Scenario: Summoned turrets have duration and owner
+- **WHEN** a TowerSchema is created for a summoned turret
+- **THEN** `remainingDuration` SHALL be set to the turret's duration and `ownerId` to the caster's id

--- a/openspec/changes/archive/2026-03-16-bolt-turret/tasks.md
+++ b/openspec/changes/archive/2026-03-16-bolt-turret/tasks.md
@@ -1,0 +1,28 @@
+## Tasks
+
+### Backend — Schema & Definition
+- [x] `server/src/schema/TowerSchema.ts` に `remainingDuration` (float32, default 0) と `ownerId` (string, default '') を追加
+- [x] `shared/skills/skillDefinitions.ts` に `TurretEffectParams` インターフェースを追加し、`SkillEffectParams` union に含める
+- [x] `shared/skills/skillDefinitions.ts` に `bolt-turret` スキル定義を追加
+- [x] `shared/talents/boltTalents.ts` に `bolt-turret` タレントノードを追加（Depth 6, Cost 2, prereq: bolt-minefield）
+
+### Backend — Skill Execution Context
+- [x] `server/src/game/skills/SkillEffectHandler.ts` の `SkillExecutionContext` に `towers: MapSchema<TowerSchema>` を追加
+- [x] `server/src/game/ServerSkillExecutionSystem.ts` の `executeSkill` に `towers` パラメータを追加
+- [x] `server/src/rooms/GameRoom.ts` の `executeSkill` 呼び出しに `this.state.towers` を渡す
+
+### Backend — Turret Handler
+- [x] `server/src/game/skills/handlers/turretEffectHandler.ts` を作成（TowerSchema を生成し towers に追加）
+- [x] `server/src/game/skills/handlers/index.ts` に turretEffectHandler を登録
+
+### Backend — Turret Lifetime
+- [x] `server/src/game/ServerTurretLifetime.ts` を作成（`processTurretLifetime` 純粋関数 — duration > 0 のタワーを減衰・除去）
+- [x] `server/src/rooms/GameRoom.ts` の update ループに `processTurretLifetime` を組み込む
+
+### Tests
+- [x] `server/src/__tests__/boltTurret.test.ts` テスト作成（定義検証、スポーン検証、ライフタイム期限切れ、破壊可能、チーム継承、タレントノード）
+- [x] 既存テストの `executeSkill` 呼び出しに `towers` パラメータを追加して型エラーを修正
+
+### Verification
+- [x] `npm run test:unit` 全パス確認
+- [x] `npm run lint` パス確認

--- a/openspec/specs/bolt-turret/spec.md
+++ b/openspec/specs/bolt-turret/spec.md
@@ -1,0 +1,52 @@
+# Specification
+
+## Purpose
+
+Bolt Turret skill — BOLTヒーローが設置型タレットを召喚するスキル。タレットは指定地点に出現し、一定時間の間、射程内の敵に自動攻撃を行う。破壊可能で、持続時間経過後に消滅する。
+
+## Requirements
+
+### Requirement: Bolt Turret skill definition
+The system SHALL register a `bolt-turret` skill in `SKILL_DEFINITIONS` with targeting `point`, range 400, cooldown 20, and `turret` effectType.
+
+The turret SHALL have: hp 200, duration 10, attackDamage 25, attackSpeed 1.5, attackRange 250, radius 18, projectileSpeed 600.
+
+#### Scenario: Skill definition exists with correct parameters
+- **WHEN** `getSkillDefinition('bolt-turret')` is called
+- **THEN** it SHALL return a definition with id `bolt-turret`, targeting `point`, cooldown 20, range 400, and turret effect with hp 200, duration 10, attackDamage 25
+
+### Requirement: Turret spawns at target position
+The `turretEffectHandler` SHALL create a TowerSchema entity at `targetPosition` with the turret's combat parameters and add it to the towers collection.
+
+#### Scenario: Turret is created with correct fields
+- **WHEN** a turret skill is executed with targetPosition (500, 300)
+- **THEN** a TowerSchema SHALL be created at (500, 300) with hp 200, attackDamage 25, attackSpeed 1.5, attackRange 250, remainingDuration 10, and ownerId set to the caster's id
+
+#### Scenario: Turret inherits caster's team
+- **WHEN** a blue team hero uses bolt-turret
+- **THEN** the spawned turret SHALL have team `blue`
+
+### Requirement: Turret auto-attacks enemies
+Turrets SHALL use the existing tower combat system (`processTowerCombat`) for auto-attack behavior, targeting enemies within attackRange.
+
+#### Scenario: Turret fires at nearest enemy
+- **WHEN** an enemy hero is within the turret's attackRange
+- **THEN** the turret SHALL fire homing projectiles at the enemy using the tower combat system
+
+### Requirement: Turret lifetime expires
+Turrets with `remainingDuration > 0` SHALL have their duration decremented each tick. When duration reaches 0, the turret SHALL be marked dead and removed.
+
+#### Scenario: Turret expires after duration
+- **WHEN** a turret with remainingDuration 10 has 10 seconds of game time pass
+- **THEN** the turret SHALL be marked dead and removed from the towers collection
+
+#### Scenario: Turret can be destroyed before expiry
+- **WHEN** a turret's HP reaches 0 from enemy damage
+- **THEN** the turret SHALL be marked dead (same as any tower)
+
+### Requirement: Bolt Turret talent node
+The BOLT talent tree SHALL have a `bolt-turret` node at Depth 6, Cost 2, with prerequisite `bolt-minefield` and effect `grant_skill: bolt-turret`.
+
+#### Scenario: Talent node exists with correct properties
+- **WHEN** the BOLT talent tree is queried for `bolt-turret`
+- **THEN** it SHALL have cost 2, prerequisite `bolt-minefield`, and grant_skill effect

--- a/openspec/specs/skill-execution/spec.md
+++ b/openspec/specs/skill-execution/spec.md
@@ -122,6 +122,17 @@ GameHud のスキルスロット表示にクールダウン残り時間を表示
 - **WHEN** ally ターゲティングで `aura-haste`（range: 400）のターゲット解決を行う
 - **THEN** `def.range` から 400 が取得される
 
+### Requirement: SkillExecutionContext includes towers
+`SkillExecutionContext` SHALL include a `towers` field of type `MapSchema<TowerSchema>` to allow skill handlers to spawn tower-type entities (turrets).
+
+#### Scenario: Turret handler accesses towers from context
+- **WHEN** a turret effect handler is executed
+- **THEN** it SHALL access `ctx.towers` to add the spawned turret entity
+
+#### Scenario: Existing handlers unaffected
+- **WHEN** a non-turret skill handler is executed
+- **THEN** the `towers` field SHALL be available but not used
+
 ### Requirement: resolveEnemyTarget
 `executeSkill` 内で `targeting: 'enemy'` のスキルの場合、クリック座標から最寄りの **敵チーム** 生存ヒーローを `range` 以内で検索しなければならない（SHALL）。射程内に敵がいない場合は `null` を返さなければならない（SHALL）。`resolveEnemyTarget` で解決された敵ヒーローは `SkillExecutionContext.targetHero` として渡されなければならない（SHALL）。`targetHero` が `null`（射程外）の場合、`executeSkill` は `null` を返し、クールダウンは消費されない（SHALL NOT）。
 

--- a/openspec/specs/tower-entity/spec.md
+++ b/openspec/specs/tower-entity/spec.md
@@ -15,3 +15,16 @@
 #### Scenario: タワーが生存中は試合継続
 - **WHEN** 両チームのタワーがともに `dead === false` である
 - **THEN** `matchPhase` は `'playing'` のまま変化しない
+
+### Requirement: TowerSchema supports summoned turrets
+`TowerSchema` SHALL include `remainingDuration` (float32, default 0) and `ownerId` (string, default '').
+
+When `remainingDuration` is 0, the tower is permanent (map tower). When > 0, it is a summoned turret with a limited lifetime.
+
+#### Scenario: Map towers have default values
+- **WHEN** a TowerSchema is created for a map tower
+- **THEN** `remainingDuration` SHALL be 0 and `ownerId` SHALL be ''
+
+#### Scenario: Summoned turrets have duration and owner
+- **WHEN** a TowerSchema is created for a summoned turret
+- **THEN** `remainingDuration` SHALL be set to the turret's duration and `ownerId` to the caster's id

--- a/server/src/__tests__/boltRicochet.test.ts
+++ b/server/src/__tests__/boltRicochet.test.ts
@@ -287,7 +287,7 @@ describe('processProjectiles — bounce', () => {
     expect(proj.dirX).toBeCloseTo(dx / dist, 1)
   })
 
-  it('should remove projectile when bounceRemaining reaches 0', () => {
+  it('should remove projectile immediately when bounceRemaining is 0 (no bounce configured)', () => {
     const heroes = new MapSchema<HeroSchema>()
     const towers = new MapSchema<TowerSchema>()
     const projectiles = new MapSchema<ProjectileSchema>()
@@ -309,7 +309,7 @@ describe('processProjectiles — bounce', () => {
     proj.team = 'blue'
     proj.mode = 'linear'
     proj.maxRange = 500
-    proj.bounceRemaining = 0 // no bounces left
+    proj.bounceRemaining = 0 // no bounces configured
     proj.bounceRange = 300
     proj.pierceRemaining = 0
     proj.radius = 5
@@ -319,6 +319,55 @@ describe('processProjectiles — bounce', () => {
 
     expect(events).toHaveLength(1)
     expect(projectiles.size).toBe(0) // removed — bounceRemaining was 0
+  })
+
+  it('should deal damage and remove after final bounce target is hit', () => {
+    const heroes = new MapSchema<HeroSchema>()
+    const towers = new MapSchema<TowerSchema>()
+    const projectiles = new MapSchema<ProjectileSchema>()
+
+    // Two enemies close together
+    const enemy1 = createEnemy('enemy-1', 200, 100)
+    const enemy2 = createEnemy('enemy-2', 250, 100)
+    heroes.set('enemy-1', enemy1)
+    heroes.set('enemy-2', enemy2)
+
+    const proj = new ProjectileSchema()
+    proj.id = 'last-bounce'
+    proj.x = 170
+    proj.y = 100
+    proj.dirX = 1
+    proj.dirY = 0
+    proj.speed = 1000
+    proj.damage = 50
+    proj.ownerId = 'caster'
+    proj.team = 'blue'
+    proj.mode = 'linear'
+    proj.maxRange = 500
+    proj.bounceRemaining = 1 // only 1 bounce
+    proj.bounceRange = 300
+    proj.pierceRemaining = 0
+    proj.radius = 5
+    projectiles.set(proj.id, proj)
+
+    // Tick 1: hit enemy1, bounce to enemy2 (bounceRemaining → 0)
+    const events1 = processProjectiles(projectiles, heroes, towers, 0.05, tracker)
+    expect(events1).toHaveLength(1)
+    expect(events1[0].event.targetId).toBe('enemy-1')
+    expect(proj.bounceRemaining).toBe(0)
+    expect(projectiles.size).toBe(1) // still alive, heading to enemy2
+
+    // Tick 2+: move toward enemy2 and hit it
+    // Multiple small ticks to reach enemy2
+    let events2: ReturnType<typeof processProjectiles> = []
+    for (let i = 0; i < 20; i++) {
+      events2 = processProjectiles(projectiles, heroes, towers, 0.01, tracker)
+      if (events2.length > 0) break
+    }
+
+    expect(events2).toHaveLength(1)
+    expect(events2[0].event.targetId).toBe('enemy-2')
+    expect(projectiles.size).toBe(0) // removed after hitting final target
   })
 
   it('should remove projectile when bounce target is out of bounceRange', () => {

--- a/server/src/__tests__/boltTurret.test.ts
+++ b/server/src/__tests__/boltTurret.test.ts
@@ -215,7 +215,7 @@ describe('checkTowerDestroyed — turret safety', () => {
     turret.dead = true
     turret.remainingDuration = 5
     turret.ownerId = 'caster-1'
-    towers.set('zone-1', turret)
+    towers.set('turret-1', turret)
 
     let matchEnded = false
     checkTowerDestroyed(towers, () => { matchEnded = true })

--- a/server/src/__tests__/boltTurret.test.ts
+++ b/server/src/__tests__/boltTurret.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MapSchema } from '@colyseus/schema'
+import { HeroSchema } from '../schema/HeroSchema.js'
+import { ProjectileSchema } from '../schema/ProjectileSchema.js'
+import { TowerSchema } from '../schema/TowerSchema.js'
+import { ZoneSchema } from '../schema/ZoneSchema.js'
+import { executeSkill } from '../game/ServerSkillExecutionSystem.js'
+import { registerAllEffectHandlers } from '../game/skills/handlers/index.js'
+import { getSkillDefinition } from '@shared/skills/skillDefinitions'
+import { ProjectileTracker } from '../game/ProjectileTracker.js'
+import { processTurretLifetime } from '../game/ServerTurretLifetime.js'
+import { BOLT_TALENT_TREE } from '@shared/talents/boltTalents'
+import { checkTowerDestroyed } from '../game/ServerMatchSystem.js'
+
+let tracker: ProjectileTracker
+
+function createHero(overrides: Partial<Record<string, unknown>> = {}): HeroSchema {
+  const hero = new HeroSchema()
+  hero.hp = 500
+  hero.maxHp = 500
+  hero.dead = false
+  hero.team = 'blue'
+  hero.x = 400
+  hero.y = 300
+  hero.radius = 22
+  hero.heroType = 'BOLT'
+  hero.skillSlotQ = 'bolt-turret'
+  Object.assign(hero, overrides)
+  return hero
+}
+
+beforeEach(() => {
+  registerAllEffectHandlers()
+  tracker = new ProjectileTracker()
+})
+
+// ── Skill definition ──
+
+describe('getSkillDefinition — bolt-turret', () => {
+  it('should return bolt-turret definition with correct params', () => {
+    const def = getSkillDefinition('bolt-turret')
+    expect(def).toBeDefined()
+    expect(def!.id).toBe('bolt-turret')
+    expect(def!.targeting).toBe('point')
+    expect(def!.cooldown).toBe(20)
+    expect(def!.range).toBe(400)
+    expect(def!.effect.effectType).toBe('turret')
+    if (def!.effect.effectType === 'turret') {
+      expect(def!.effect.hp).toBe(200)
+      expect(def!.effect.duration).toBe(10)
+      expect(def!.effect.attackDamage).toBe(25)
+      expect(def!.effect.attackSpeed).toBe(1.5)
+      expect(def!.effect.attackRange).toBe(250)
+      expect(def!.effect.radius).toBe(18)
+      expect(def!.effect.projectileSpeed).toBe(600)
+    }
+  })
+})
+
+// ── Turret spawning ──
+
+describe('executeSkill — bolt-turret', () => {
+  it('should spawn a turret at target position', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const projectiles = new MapSchema<ProjectileSchema>()
+    const zones = new MapSchema<ZoneSchema>()
+    const towers = new MapSchema<TowerSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 350 }, projectiles, heroes, tracker, zones, towers)
+
+    expect(event).not.toBeNull()
+    expect(event!.skillId).toBe('bolt-turret')
+    expect(towers.size).toBe(1)
+
+    const turret = [...towers.values()][0]
+    expect(turret.x).toBe(500)
+    expect(turret.y).toBe(350)
+    expect(turret.hp).toBe(200)
+    expect(turret.maxHp).toBe(200)
+    expect(turret.attackDamage).toBe(25)
+    expect(turret.attackSpeed).toBe(1.5)
+    expect(turret.attackRange).toBe(250)
+    expect(turret.radius).toBe(18)
+    expect(turret.projectileSpeed).toBe(600)
+    expect(turret.remainingDuration).toBe(10)
+    expect(turret.ownerId).toBe('caster-1')
+  })
+
+  it('should inherit caster team', () => {
+    const caster = createHero({ team: 'red' })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const towers = new MapSchema<TowerSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 350 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>(), towers)
+
+    const turret = [...towers.values()][0]
+    expect(turret.team).toBe('red')
+  })
+
+  it('should set cooldown to 20 seconds', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const towers = new MapSchema<TowerSchema>()
+
+    executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 350 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>(), towers)
+
+    expect(caster.cooldownQ).toBe(20)
+  })
+
+  it('should reject activation while dashing', () => {
+    const caster = createHero({ dashTimer: 0.2 })
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const towers = new MapSchema<TowerSchema>()
+
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 500, y: 350 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>(), towers)
+
+    expect(event).toBeNull()
+    expect(towers.size).toBe(0)
+  })
+
+  it('should reject activation when target is out of range', () => {
+    const caster = createHero()
+    const heroes = new MapSchema<HeroSchema>()
+    heroes.set('caster-1', caster)
+    const towers = new MapSchema<TowerSchema>()
+
+    // Target at 900, 300 — 500px away, range is 400
+    const event = executeSkill(caster, 'caster-1', 'Q', { x: 900, y: 300 }, new MapSchema<ProjectileSchema>(), heroes, tracker, new MapSchema<ZoneSchema>(), towers)
+
+    expect(event).toBeNull()
+    expect(towers.size).toBe(0)
+  })
+})
+
+// ── Turret lifetime ──
+
+describe('processTurretLifetime', () => {
+  it('should decrement remainingDuration each tick', () => {
+    const towers = new MapSchema<TowerSchema>()
+    const turret = new TowerSchema()
+    turret.remainingDuration = 10
+    turret.ownerId = 'caster-1'
+    towers.set('turret-1', turret)
+
+    processTurretLifetime(towers, 1)
+
+    expect(turret.remainingDuration).toBeCloseTo(9, 1)
+    expect(towers.size).toBe(1) // still alive
+  })
+
+  it('should remove turret when duration expires', () => {
+    const towers = new MapSchema<TowerSchema>()
+    const turret = new TowerSchema()
+    turret.remainingDuration = 0.5
+    turret.ownerId = 'caster-1'
+    towers.set('turret-1', turret)
+
+    processTurretLifetime(towers, 1)
+
+    expect(turret.dead).toBe(true)
+    expect(towers.size).toBe(0) // removed
+  })
+
+  it('should not affect permanent map towers', () => {
+    const towers = new MapSchema<TowerSchema>()
+    const mapTower = new TowerSchema()
+    mapTower.remainingDuration = 0 // permanent
+    mapTower.hp = 1000
+    towers.set('tower-1', mapTower)
+
+    processTurretLifetime(towers, 100)
+
+    expect(mapTower.dead).toBe(false)
+    expect(towers.size).toBe(1) // still alive
+  })
+
+  it('should clean up damage-killed turrets', () => {
+    const towers = new MapSchema<TowerSchema>()
+    const turret = new TowerSchema()
+    turret.hp = 0
+    turret.maxHp = 200
+    turret.dead = true
+    turret.remainingDuration = 8
+    turret.ownerId = 'caster-1'
+    towers.set('turret-1', turret)
+
+    processTurretLifetime(towers, 0.016)
+
+    expect(towers.size).toBe(0) // removed because dead
+  })
+})
+
+// ── Match system integration ──
+
+describe('checkTowerDestroyed — turret safety', () => {
+  it('should NOT end match when a summoned turret dies', () => {
+    const towers = new MapSchema<TowerSchema>()
+
+    // Permanent map tower (alive)
+    const mapTower = new TowerSchema()
+    mapTower.team = 'blue'
+    mapTower.hp = 1000
+    mapTower.maxHp = 1000
+    towers.set('tower-blue', mapTower)
+
+    // Dead summoned turret
+    const turret = new TowerSchema()
+    turret.team = 'blue'
+    turret.hp = 0
+    turret.dead = true
+    turret.remainingDuration = 5
+    turret.ownerId = 'caster-1'
+    towers.set('zone-1', turret)
+
+    let matchEnded = false
+    checkTowerDestroyed(towers, () => { matchEnded = true })
+    expect(matchEnded).toBe(false)
+  })
+})
+
+// ── Talent node ──
+
+describe('BOLT talent tree — bolt-turret node', () => {
+  it('should have bolt-turret node with correct properties', () => {
+    const node = BOLT_TALENT_TREE.nodes.find(n => n.id === 'bolt-turret')
+    expect(node).toBeDefined()
+    expect(node!.cost).toBe(2)
+    expect(node!.prerequisites).toEqual(['bolt-minefield'])
+    expect(node!.effects).toEqual([{ type: 'grant_skill', skillId: 'bolt-turret' }])
+  })
+})

--- a/server/src/game/ProjectileTracker.ts
+++ b/server/src/game/ProjectileTracker.ts
@@ -8,6 +8,7 @@ export class ProjectileTracker {
   private skillCounter = 0
   private towerCounter = 0
   private zoneCounter = 0
+  private turretCounter = 0
 
   private readonly distanceTraveled = new Map<string, number>()
   private readonly hitEntityIds = new Map<string, Set<string>>()
@@ -26,6 +27,10 @@ export class ProjectileTracker {
 
   nextZoneId(): string {
     return `zone-${++this.zoneCounter}`
+  }
+
+  nextTurretId(): string {
+    return `turret-${++this.turretCounter}`
   }
 
   getDistanceTraveled(projId: string): number {

--- a/server/src/game/ServerMatchSystem.ts
+++ b/server/src/game/ServerMatchSystem.ts
@@ -11,7 +11,8 @@ export function checkTowerDestroyed(
   endMatch: (winnerTeam: string) => void,
 ): void {
   towers.forEach((tower) => {
-    if (tower.dead) {
+    // Skip summoned turrets — only permanent map towers trigger match end
+    if (tower.dead && tower.ownerId === '') {
       const winner = tower.team === 'blue' ? 'red' : 'blue'
       endMatch(winner)
     }

--- a/server/src/game/ServerSkillExecutionSystem.ts
+++ b/server/src/game/ServerSkillExecutionSystem.ts
@@ -2,6 +2,7 @@ import { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../schema/HeroSchema.js'
 import type { ProjectileSchema } from '../schema/ProjectileSchema.js'
 import type { ZoneSchema } from '../schema/ZoneSchema.js'
+import type { TowerSchema } from '../schema/TowerSchema.js'
 import type { SkillEvent } from '@shared/messages'
 import { getSkillDefinition } from '@shared/skills/skillDefinitions'
 import { getEffectHandler } from './skills/skillEffectRegistry.js'
@@ -91,6 +92,7 @@ export function executeSkill(
   heroes: MapSchema<HeroSchema>,
   tracker: ProjectileTracker,
   zones: MapSchema<ZoneSchema> = new MapSchema<ZoneSchema>(),
+  towers: MapSchema<TowerSchema> = new MapSchema<TowerSchema>(),
 ): SkillEvent | null {
   // Validation: hero must be alive
   if (hero.dead) return null
@@ -148,6 +150,7 @@ export function executeSkill(
       projectiles,
       heroes,
       zones,
+      towers,
       projectileTracker: tracker,
       targetHero,
     },

--- a/server/src/game/ServerTurretLifetime.ts
+++ b/server/src/game/ServerTurretLifetime.ts
@@ -1,0 +1,31 @@
+import type { MapSchema } from '@colyseus/schema'
+import type { TowerSchema } from '../schema/TowerSchema.js'
+
+/**
+ * Tick down summoned turret lifetimes and remove expired ones.
+ * Towers with remainingDuration === 0 are permanent map towers and are skipped.
+ */
+export function processTurretLifetime(
+  towers: MapSchema<TowerSchema>,
+  deltaTime: number,
+): void {
+  const toRemove: string[] = []
+
+  towers.forEach((tower, towerId) => {
+    if (tower.remainingDuration <= 0) return // permanent map tower
+    if (tower.dead) {
+      toRemove.push(towerId) // killed by damage
+      return
+    }
+    tower.remainingDuration = tower.remainingDuration - deltaTime
+    if (tower.remainingDuration <= 0) {
+      tower.remainingDuration = 0
+      tower.dead = true
+      toRemove.push(towerId)
+    }
+  })
+
+  for (const id of toRemove) {
+    towers.delete(id)
+  }
+}

--- a/server/src/game/skills/SkillEffectHandler.ts
+++ b/server/src/game/skills/SkillEffectHandler.ts
@@ -2,6 +2,7 @@ import type { MapSchema } from '@colyseus/schema'
 import type { HeroSchema } from '../../schema/HeroSchema.js'
 import type { ProjectileSchema } from '../../schema/ProjectileSchema.js'
 import type { ZoneSchema } from '../../schema/ZoneSchema.js'
+import type { TowerSchema } from '../../schema/TowerSchema.js'
 import type { SkillEffectParams } from '@shared/skills/skillDefinitions'
 import type { ProjectileTracker } from '../../game/ProjectileTracker.js'
 
@@ -15,6 +16,7 @@ export interface SkillExecutionContext {
   readonly projectiles: MapSchema<ProjectileSchema>
   readonly heroes: MapSchema<HeroSchema>
   readonly zones: MapSchema<ZoneSchema>
+  readonly towers: MapSchema<TowerSchema>
   readonly projectileTracker: ProjectileTracker
   /** Resolved target for ally/enemy-targeting skills. */
   readonly targetHero?: HeroSchema

--- a/server/src/game/skills/handlers/index.ts
+++ b/server/src/game/skills/handlers/index.ts
@@ -6,6 +6,7 @@ import { buffEffectHandler } from './buffEffectHandler.js'
 import { aoeEffectHandler } from './aoeEffectHandler.js'
 import { zoneEffectHandler } from './zoneEffectHandler.js'
 import { strikeEffectHandler } from './strikeEffectHandler.js'
+import { turretEffectHandler } from './turretEffectHandler.js'
 
 let registered = false
 
@@ -20,6 +21,7 @@ export function registerAllEffectHandlers(): void {
   registerEffectHandler(aoeEffectHandler)
   registerEffectHandler(zoneEffectHandler)
   registerEffectHandler(strikeEffectHandler)
+  registerEffectHandler(turretEffectHandler)
 }
 
 /** Reset registration state and clear registry. For testing only. */

--- a/server/src/game/skills/handlers/projectileEffectHandler.ts
+++ b/server/src/game/skills/handlers/projectileEffectHandler.ts
@@ -33,6 +33,9 @@ function createProjectile(
   proj.visualType = params.visualType
   proj.bounceRemaining = params.bounceCount ?? 0
   proj.bounceRange = params.bounceRange ?? 0
+  if (proj.bounceRemaining > 0 && proj.bounceRange <= 0) {
+    console.warn(`[projectileEffectHandler] bounceCount=${params.bounceCount} but bounceRange is 0 or missing — projectile will never bounce`)
+  }
 
   projectiles.set(proj.id, proj)
 }

--- a/server/src/game/skills/handlers/turretEffectHandler.ts
+++ b/server/src/game/skills/handlers/turretEffectHandler.ts
@@ -1,0 +1,27 @@
+import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
+import type { TurretEffectParams } from '@shared/skills/skillDefinitions'
+import { TowerSchema } from '../../../schema/TowerSchema.js'
+
+export const turretEffectHandler: SkillEffectHandler<TurretEffectParams> = {
+  effectType: 'turret',
+
+  execute(ctx: SkillExecutionContext, params: TurretEffectParams): void {
+    const turret = new TowerSchema()
+    turret.id = ctx.projectileTracker.nextTurretId()
+    turret.x = ctx.targetPosition.x
+    turret.y = ctx.targetPosition.y
+    turret.hp = params.hp
+    turret.maxHp = params.hp
+    turret.team = ctx.hero.team
+    turret.radius = params.radius
+    turret.attackDamage = params.attackDamage
+    turret.attackSpeed = params.attackSpeed
+    turret.attackRange = params.attackRange
+    turret.projectileSpeed = params.projectileSpeed
+    turret.projectileRadius = 4
+    turret.remainingDuration = params.duration
+    turret.ownerId = ctx.casterId
+
+    ctx.towers.set(turret.id, turret)
+  },
+}

--- a/server/src/game/skills/handlers/turretEffectHandler.ts
+++ b/server/src/game/skills/handlers/turretEffectHandler.ts
@@ -18,7 +18,7 @@ export const turretEffectHandler: SkillEffectHandler<TurretEffectParams> = {
     turret.attackSpeed = params.attackSpeed
     turret.attackRange = params.attackRange
     turret.projectileSpeed = params.projectileSpeed
-    turret.projectileRadius = 4
+    turret.projectileRadius = params.projectileRadius
     turret.remainingDuration = params.duration
     turret.ownerId = ctx.casterId
 

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -12,6 +12,7 @@ import { processMovement } from '../game/ServerMovementSystem.js'
 import { processHeroCombat } from '../game/ServerCombatManager.js'
 import { processProjectiles } from '../game/ServerProjectileSystem.js'
 import { processTowerCombat } from '../game/ServerTowerSystem.js'
+import { processTurretLifetime } from '../game/ServerTurretLifetime.js'
 import { ProjectileTracker } from '../game/ProjectileTracker.js'
 import { processDeathAndRespawn } from '../game/ServerDeathSystem.js'
 import { isHeroInBase, processBaseRegen } from '../game/ServerBaseRegenSystem.js'
@@ -191,7 +192,7 @@ export class GameRoom extends Room<GameRoomState> {
       if (!isValidUseSkillMessage(message)) return
       const hero = this.state.heroes.get(client.sessionId)
       if (!hero) return
-      const event = executeSkill(hero, client.sessionId, message.slot, message.target, this.state.projectiles, this.state.heroes, this.projectileTracker, this.state.zones)
+      const event = executeSkill(hero, client.sessionId, message.slot, message.target, this.state.projectiles, this.state.heroes, this.projectileTracker, this.state.zones, this.state.towers)
       if (event) {
         this.broadcast('skill', event)
       }
@@ -453,6 +454,9 @@ export class GameRoom extends Room<GameRoomState> {
       )
       events.push(...towerEvents)
     })
+
+    // 3b. Process turret lifetime
+    processTurretLifetime(towers, deltaTime)
 
     // 4. Process projectiles
     const projectileEvents = processProjectiles(projectiles, heroes, towers, deltaTime, this.projectileTracker, minions)

--- a/server/src/schema/TowerSchema.ts
+++ b/server/src/schema/TowerSchema.ts
@@ -13,4 +13,10 @@ export class TowerSchema extends CombatEntitySchema {
   @type('float32') attackSpeed: number = 0
   @type('float32') projectileSpeed: number = 0
   @type('float32') projectileRadius: number = 0
+
+  // ── Summoned turret fields ────────────────────────────
+  /** Remaining lifetime in seconds (0 = permanent map tower) */
+  @type('float32') remainingDuration: number = 0
+  /** Session ID of the hero that summoned this turret ('' = map tower) */
+  @type('string') ownerId: string = ''
 }

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -74,7 +74,18 @@ export interface StrikeEffectParams {
   readonly executeBonusDamage?: number  // additional damage when target HP% ≤ threshold
 }
 
-export type SkillEffectParams = DashEffectParams | ProjectileEffectParams | HealEffectParams | BuffEffectParams | AoEEffectParams | ZoneEffectParams | StrikeEffectParams
+export interface TurretEffectParams {
+  readonly effectType: 'turret'
+  readonly hp: number                // turret max HP
+  readonly duration: number          // lifetime in seconds
+  readonly attackDamage: number      // damage per hit
+  readonly attackSpeed: number       // attacks per second
+  readonly attackRange: number       // targeting range (px)
+  readonly radius: number            // collision/render radius (px)
+  readonly projectileSpeed: number   // homing projectile speed (px/sec)
+}
+
+export type SkillEffectParams = DashEffectParams | ProjectileEffectParams | HealEffectParams | BuffEffectParams | AoEEffectParams | ZoneEffectParams | StrikeEffectParams | TurretEffectParams
 
 // ── Common fields shared by ALL skills ────────────────────────
 
@@ -363,6 +374,22 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       visualType: 'diamond',
       bounceCount: 3,
       bounceRange: 300,
+    },
+  },
+  'bolt-turret': {
+    id: 'bolt-turret',
+    targeting: 'point',
+    cooldown: 20,
+    range: 400,
+    effect: {
+      effectType: 'turret',
+      hp: 200,
+      duration: 10,
+      attackDamage: 25,
+      attackSpeed: 1.5,
+      attackRange: 250,
+      radius: 18,
+      projectileSpeed: 600,
     },
   },
   'bolt-snipe': {

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -83,6 +83,7 @@ export interface TurretEffectParams {
   readonly attackRange: number       // targeting range (px)
   readonly radius: number            // collision/render radius (px)
   readonly projectileSpeed: number   // homing projectile speed (px/sec)
+  readonly projectileRadius: number  // projectile collision radius (px)
 }
 
 export type SkillEffectParams = DashEffectParams | ProjectileEffectParams | HealEffectParams | BuffEffectParams | AoEEffectParams | ZoneEffectParams | StrikeEffectParams | TurretEffectParams
@@ -390,6 +391,7 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       attackRange: 250,
       radius: 18,
       projectileSpeed: 600,
+      projectileRadius: 4,
     },
   },
   'bolt-snipe': {

--- a/shared/talents/boltTalents.ts
+++ b/shared/talents/boltTalents.ts
@@ -373,6 +373,14 @@ export const BOLT_TALENT_TREE: TalentTreeDefinition = {
       prerequisites: ['bolt-minefield'],
       effects: [{ type: 'modify_basic_attack', property: 'trapSlowDuration', value: 50 }],
     },
+    {
+      id: 'bolt-turret',
+      name: 'Turret',
+      description: 'Unlock Turret skill — deploy auto-attacking turret',
+      cost: 2,
+      prerequisites: ['bolt-minefield'],
+      effects: [{ type: 'grant_skill', skillId: 'bolt-turret' }],
+    },
     // Marksman
     {
       id: 'bolt-overwatch',


### PR DESCRIPTION
## Summary
- Add `bolt-turret` skill: point-targeted summoned turret (10s duration, 200 HP, destroyable)
- New `turret` effectType reusing TowerSchema with `remainingDuration` + `ownerId` fields
- `turretEffectHandler` spawns TowerSchema at target position, existing tower AI handles auto-attack
- `processTurretLifetime` manages duration expiry and damage-killed turret cleanup
- `checkTowerDestroyed` skips summoned turrets (dead turret doesn't end match)
- Add `towers` to `SkillExecutionContext` (backward-compatible default)
- Add `bolt-turret` talent node (Depth 6, Cost 2, prereq: bolt-minefield)

## Test plan
- [x] `npm run test:unit` — 1003 tests pass
- [x] `npm run lint` — 0 errors
- [x] Turret spawns at target position with correct stats and team
- [x] Turret expires after duration, removed from towers
- [x] Damage-killed turrets cleaned up by lifetime system
- [x] Dead turret does NOT trigger match end (integration test)
- [x] Permanent map towers unaffected by lifetime system
- [x] Skill rejected when out of range or dashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)