### PR TITLE
refactor: decouple zone self-debuff with explicit selfEffect param

### DIFF
--- a/server/src/game/skills/handlers/zoneEffectHandler.ts
+++ b/server/src/game/skills/handlers/zoneEffectHandler.ts
@@ -39,18 +39,18 @@ export const zoneEffectHandler: SkillEffectHandler<ZoneEffectParams> = {
     const id = ctx.projectileTracker.nextZoneId()
     ctx.zones.set(id, zone)
 
-    // Apply self speed debuff for follow zones (e.g. Whirlwind slows the caster)
-    if (params.followCaster && params.zoneEffect.isDebuff) {
+    // Apply self-debuff to caster (e.g. Whirlwind slows the caster)
+    if (params.selfEffect) {
       const effectKey = ctx.skillId
       const existing = ctx.hero.statusEffects.get(effectKey)
       if (existing) {
-        existing.remainingDuration = params.zoneDuration
+        existing.remainingDuration = params.selfEffect.duration
       } else {
         const effect = new StatusEffectSchema()
         effect.id = effectKey
-        effect.buffType = params.zoneEffect.buffType
-        effect.value = params.zoneEffect.value
-        effect.remainingDuration = params.zoneDuration
+        effect.buffType = params.selfEffect.buffType
+        effect.value = params.selfEffect.value
+        effect.remainingDuration = params.selfEffect.duration
         effect.isDebuff = true
         ctx.hero.statusEffects.set(effectKey, effect)
       }

--- a/shared/skills/skillDefinitions.ts
+++ b/shared/skills/skillDefinitions.ts
@@ -58,6 +58,11 @@ export interface ZoneEffectParams {
   readonly tickHeal?: number       // healing per tick to allies (0 = no tick heal)
   readonly tickInterval?: number   // seconds between tick damage/heal applications
   readonly followCaster?: boolean  // true = zone follows caster position each tick
+  readonly selfEffect?: {          // optional debuff applied to caster when followCaster is true
+    readonly buffType: string
+    readonly value: number
+    readonly duration: number      // seconds
+  }
   readonly zoneEffect: {
     readonly buffType: string       // effect category ('speed', etc.)
     readonly value: number          // effect amount (negative = debuff)
@@ -265,6 +270,11 @@ export const SKILL_DEFINITIONS: Record<string, SkillDefinition> = {
       tickDamage: 30,
       tickInterval: 0.5,
       followCaster: true,
+      selfEffect: {
+        buffType: 'speed',
+        value: -40,
+        duration: 3,
+      },
       zoneEffect: {
         buffType: 'speed',
         value: -40,


### PR DESCRIPTION
## Summary
- Add optional `selfEffect` param to `ZoneEffectParams` for explicit caster self-debuff
- Update `blade-whirlwind` to use `selfEffect` instead of implicit `zoneEffect.isDebuff` coupling
- Update `zoneEffectHandler` to read from `params.selfEffect` instead of `params.zoneEffect`
- Future follow zones with enemy debuffs won't unintentionally slow the caster

Closes #241

## Test plan
- [x] `npm run test:unit` — 1003 tests pass
- [x] `npm run lint` — 0 errors
- [x] Whirlwind self-debuff behavior unchanged (same buffType, value, duration)
- [x] Sanctuary (followCaster + no debuff) unaffected — no selfEffect param

🤖 Generated with [Claude Code](https://claude.com/claude-code)