### PR TITLE
fix: small consistency fixes across codebase

### DIFF
--- a/server/src/__tests__/ServerMinionSystem.test.ts
+++ b/server/src/__tests__/ServerMinionSystem.test.ts
@@ -505,8 +505,8 @@ describe('processMinionDeaths', () => {
     // First call: detect death, start timer
     processMinionDeaths(ctx, minions, heroes, 0)
 
-    // Tick enough time to expire the timer (MINION_DEATH_CLEANUP_DELAY is in ms, deltaTime in seconds)
-    processMinionDeaths(ctx, minions, heroes, MINION_DEATH_CLEANUP_DELAY / 1000 + 0.01)
+    // Tick enough time to expire the timer (both in seconds now)
+    processMinionDeaths(ctx, minions, heroes, MINION_DEATH_CLEANUP_DELAY + 0.01)
 
     expect(minions.has('m1')).toBe(false)
     expect(ctx.deathTimers.has('m1')).toBe(false)

--- a/server/src/game/ServerMatchSystem.ts
+++ b/server/src/game/ServerMatchSystem.ts
@@ -10,9 +10,12 @@ export function checkTowerDestroyed(
   towers: MapSchema<TowerSchema>,
   endMatch: (winnerTeam: string) => void,
 ): void {
+  let found = false
   towers.forEach((tower) => {
+    if (found) return
     // Skip summoned turrets — only permanent map towers trigger match end
     if (tower.dead && tower.ownerId === '') {
+      found = true
       const winner = tower.team === 'blue' ? 'red' : 'blue'
       endMatch(winner)
     }

--- a/server/src/game/ServerMinionSystem.ts
+++ b/server/src/game/ServerMinionSystem.ts
@@ -483,7 +483,7 @@ export function processMinionDeaths(
 
   // Tick death timers and cleanup
   for (const [id, remaining] of ctx.deathTimers) {
-    const newRemaining = remaining - deltaTime * 1000
+    const newRemaining = remaining - deltaTime
     if (newRemaining <= 0) {
       minions.delete(id)
       ctx.deathTimers.delete(id)

--- a/server/src/game/ServerZoneSystem.ts
+++ b/server/src/game/ServerZoneSystem.ts
@@ -76,7 +76,7 @@ export function tickZones(
 
       // Tick heal (sustained heal zones like Sanctuary)
       if (tickFiredThisTick && zone.tickHeal > 0) {
-        hero.hp = Math.min(hero.hp + zone.tickHeal, hero.maxHp)
+        hero.applyHeal(zone.tickHeal)
       }
 
       // Apply or refresh status effect (skip for expired zones)

--- a/server/src/game/skills/handlers/projectileEffectHandler.ts
+++ b/server/src/game/skills/handlers/projectileEffectHandler.ts
@@ -1,6 +1,9 @@
 import { ProjectileSchema } from '../../../schema/ProjectileSchema.js'
 import type { SkillEffectHandler, SkillExecutionContext } from '../SkillEffectHandler.js'
 import type { ProjectileEffectParams } from '@shared/skills/skillDefinitions'
+import { createServerLogger } from '@shared/logging'
+
+const logger = createServerLogger('projectile')
 
 function createProjectile(
   ctx: SkillExecutionContext,
@@ -34,7 +37,7 @@ function createProjectile(
   proj.bounceRemaining = params.bounceCount ?? 0
   proj.bounceRange = params.bounceRange ?? 0
   if (proj.bounceRemaining > 0 && proj.bounceRange <= 0) {
-    console.warn(`[projectileEffectHandler] bounceCount=${params.bounceCount} but bounceRange is 0 or missing — projectile will never bounce`)
+    logger.warn('bounceCount set but bounceRange is 0 or missing — projectile will never bounce', { bounceCount: params.bounceCount })
   }
 
   projectiles.set(proj.id, proj)
@@ -54,7 +57,7 @@ export const projectileEffectHandler: SkillEffectHandler<ProjectileEffectParams>
     // Multi-projectile: fan spread centered on cursor direction
     const totalSpread = params.spreadAngle ?? 0
     if (totalSpread === 0) {
-      console.warn(`[projectileEffectHandler] projectileCount=${count} but spreadAngle is 0 — all projectiles will overlap`)
+      logger.warn('projectileCount > 1 but spreadAngle is 0 — all projectiles will overlap', { projectileCount: count })
     }
     const baseAngle = Math.atan2(ctx.direction.y, ctx.direction.x)
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -77,7 +77,7 @@ export const HERO_KILL_XP_REWARD = 150 // XP granted to killer on hero kill
 export const MINION_WAVE_INTERVAL = 30 // seconds between waves
 export const MINION_XP_REWARD = 20 // total XP per minion kill
 export const XP_GRANT_RANGE = 500 // px radius for proximity XP
-export const MINION_DEATH_CLEANUP_DELAY = 200 // ms before removing dead minion
+export const MINION_DEATH_CLEANUP_DELAY = 0.2 // seconds before removing dead minion
 export const MINION_DETECTION_RANGE = 200 // px — range to detect enemies and start chasing
 export const MINION_SEPARATION_MIN_DIST = 2 // px — minimum distance between edges
 

--- a/src/scenes/ui/GameHud.ts
+++ b/src/scenes/ui/GameHud.ts
@@ -31,11 +31,6 @@ export interface GameHudOptions {
   readonly onMaxLevelClick?: () => void
 }
 
-/**
- * Base design dimensions for HUD layout.
- * computeHudLayout returns positions in this 1280x720 coordinate space.
- * The container follows the camera worldView so it appears screen-fixed.
- */
 /** Build a SkillSlotConfig from hero state for a given slot. */
 function slotConfigFromHero(hero: HeroState, key: 'Q' | 'E' | 'R'): SkillSlotConfig {
   const slotMap = { Q: hero.skillSlotQ, E: hero.skillSlotE, R: hero.skillSlotR }

--- a/src/scenes/ui/GameHud.ts
+++ b/src/scenes/ui/GameHud.ts
@@ -9,6 +9,7 @@ import { SkillSlotRenderer } from './SkillSlotRenderer'
 import { LevelBadge } from './LevelBadge'
 import { HudHpBar } from './HudHpBar'
 import { drawHexPath } from './drawHexPath'
+import { DESIGN_WIDTH, DESIGN_HEIGHT } from './uiConstants'
 
 const HUD_DEPTH = 1100
 const PANEL_BG_COLOR = 0x1a1a2e
@@ -35,9 +36,6 @@ export interface GameHudOptions {
  * computeHudLayout returns positions in this 1280x720 coordinate space.
  * The container follows the camera worldView so it appears screen-fixed.
  */
-const DESIGN_WIDTH = 1280
-const DESIGN_HEIGHT = 720
-
 /** Build a SkillSlotConfig from hero state for a given slot. */
 function slotConfigFromHero(hero: HeroState, key: 'Q' | 'E' | 'R'): SkillSlotConfig {
   const slotMap = { Q: hero.skillSlotQ, E: hero.skillSlotE, R: hero.skillSlotR }


### PR DESCRIPTION
## Summary
5 small fixes for code consistency:
- `console.warn` → `createServerLogger` in projectileEffectHandler (2 occurrences)
- `checkTowerDestroyed` early return to prevent double-callback when multiple towers die same tick
- `hero.hp = Math.min(...)` → `hero.applyHeal()` in ServerZoneSystem (respects dead guard)
- `DESIGN_WIDTH/HEIGHT` imported from `uiConstants` in GameHud (remove local redeclaration)
- `MINION_DEATH_CLEANUP_DELAY` changed from 200ms to 0.2s (consistent with all other timer units)

Closes #262

## Test plan
- [x] `npm run test:unit` — 1003 tests pass
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] Minion death test updated for new seconds-based constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)