### PR TITLE
fix: Canvas サイズがモバイル画面に正しくフィットしない #275

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>simoba - 2v2 Micro Arena</title>
     <style>
       * {
@@ -11,19 +11,23 @@
         box-sizing: border-box;
       }
 
-      body {
-        background-color: #1a1a1a;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        min-height: 100vh;
+      html, body {
+        width: 100%;
+        height: 100vh;
+        height: 100dvh;
         overflow: hidden;
+        background-color: #1a1a1a;
       }
 
       #game-container {
-        display: flex;
-        justify-content: center;
-        align-items: center;
+        width: 100%;
+        height: 100vh;
+        height: 100dvh;
+      }
+
+      #game-container canvas {
+        display: block;
+        touch-action: none;
       }
     </style>
   </head>

--- a/openspec/specs/tech-architecture.md
+++ b/openspec/specs/tech-architecture.md
@@ -5,7 +5,7 @@
 - **エンジン:** Phaser.js 3.x
 - **ビルドツール:** Vite 6.x（開発サーバー + バンドラー）
 - **レンダリング:** 2D トップダウン（Canvas / WebGL）
-- **解像度:** 1280x720（Scale.FIT + CENTER_BOTH）
+- **解像度:** 2560x1440（Scale.FIT + CENTER_BOTH）
 - **物理演算:** Arcade Physics（gravity: 0、トップダウン）
 - **ホスティング:** S3 + CloudFront（静的ファイル）
 - **言語:** TypeScript（strict mode）


### PR DESCRIPTION
## Summary
- `#game-container` に明示的な `width: 100%; height: 100dvh` を設定（`100vh` フォールバック付き）
- body の不要な flex レイアウトを削除（Phaser の `CENTER_BOTH` との干渉を解消）
- `viewport-fit=cover` でノッチ付きデバイスに対応
- canvas に `touch-action: none` を追加しブラウザデフォルトのズーム/スクロールを無効化

## Test plan
- [ ] デスクトップブラウザで表示が変わらないことを確認
- [ ] モバイルブラウザ（iOS Safari, Chrome）で Canvas が画面にフィットすることを確認
- [ ] ブラウザのリサイズ・デバイス回転時に追従することを確認
- [x] 既存ユニットテスト全 PASS
- [x] lint PASS

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)